### PR TITLE
pie-microsite@v1.16.2 - remove figcaption lists

### DIFF
--- a/apps/pie-microsite/CHANGELOG.md
+++ b/apps/pie-microsite/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.16.2
+------------------------------
+*September 22, 2022*
+
+### Changed
+- Use lists rather than captions for some colour images
+
+### Removed
+- figcaption lists (not needed)
+
+
 v1.16.1
 ------------------------------
 *September 22, 2022*

--- a/apps/pie-microsite/package.json
+++ b/apps/pie-microsite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pie-microsite",
   "description": "todo",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "main": "index.js",
   "keywords": [],
   "author": "JustEatTakeaway - Vue Design System Team",

--- a/apps/pie-microsite/src/_11ty/shortcodes/contentPageImage.js
+++ b/apps/pie-microsite/src/_11ty/shortcodes/contentPageImage.js
@@ -1,25 +1,6 @@
-createCaptionList = config => {
-  return `<figcaption class="c-contentImage-caption">
-      ${config.caption}
-      <ul>
-        ${config.captionListItems.map(item => `<li>${item}</li>`).join('')}
-      </ul>
-    </figcaption>`;
-}
-
-createCaptionStandard = config => `<figcaption class="c-contentImage-caption">${config.caption}</figcaption>`;
-
-createCaption = config => {
-  if (config.caption) {
-    if (config.captionType === 'list') {
-      return createCaptionList(config);
-    }
-  
-    return createCaptionStandard(config);
-  }
-
-  return '';
-};
+createCaption = config => config.caption 
+  ? `<figcaption class="c-contentImage-caption">${config.caption}</figcaption>` 
+  : '';
 
 /**
  * Creates an image to render on a content page.

--- a/apps/pie-microsite/src/assets/styles/components/_contentPage.scss
+++ b/apps/pie-microsite/src/assets/styles/components/_contentPage.scss
@@ -18,7 +18,8 @@ $content-max-width: 80ch;
     }
 
     & p,
-    & .c-contentPage-img {
+    & .c-contentPage-img,
+    & ul {
         color: f.$color-content-subdued;
     }
 }
@@ -72,6 +73,10 @@ $content-max-width: 80ch;
         margin-top: f.spacing(f);
     }
 
+    > .c-contentPage-img + p {
+        margin-top: f.spacing(e);
+    }
+
     > p + h2 {
         margin-top: f.spacing(h);
 
@@ -82,6 +87,7 @@ $content-max-width: 80ch;
 
     > p + h3,
     > p + h4,
+    > ul + h4,
     & .c-contentPage-notification {
         margin-top: f.spacing(f);
     }

--- a/apps/pie-microsite/src/assets/styles/components/_contentPage.scss
+++ b/apps/pie-microsite/src/assets/styles/components/_contentPage.scss
@@ -60,7 +60,8 @@ $content-max-width: 80ch;
 
     > h2 + h3,
     > h3 + h4,
-    > p + .c-contentPage-img {
+    > p + .c-contentPage-img,
+    > .c-contentPage-img + p {
         margin-top: f.spacing(e);
     }
 
@@ -71,10 +72,6 @@ $content-max-width: 80ch;
     > .c-contentPage-img + h3,
     > .c-contentPage-img + h4 {
         margin-top: f.spacing(f);
-    }
-
-    > .c-contentPage-img + p {
-        margin-top: f.spacing(e);
     }
 
     > p + h2 {

--- a/apps/pie-microsite/src/content/pages/foundations/colour/overview.md
+++ b/apps/pie-microsite/src/content/pages/foundations/colour/overview.md
@@ -57,18 +57,27 @@ Here are some guidelines which outline when to use Brand orange and Product oran
 
 {% contentPageImage {
 src:"../../../../../assets/img/foundations/colour/brand-orange.svg",
-width: "243px",
-captionType: 'list',
-caption: "You should use Brand orange for:",
-captionListItems: ["Non-interactive elements", "Logos", "Illustrations", "Splash screens", "Navigation bars", "Marketing panels’ backgrounds"]
+width: "243px"
 } %}
+
+You should use Brand orange for:
+- Non-interactive elements
+- Logos
+- Illustrations
+- Splash screens
+- Navigation bars
+- Marketing panels’ backgrounds
 
 #### Product orange
 
 {% contentPageImage {
 src:"../../../../../assets/img/foundations/colour/product-orange.svg",
-width: "243px",
-captionType: 'list',
-caption: "You should use Product orange for:",
-captionListItems: ["Interactive elements", "Buttons", "Icons", "Interactive text", "Headings"]
+width: "243px"
 } %}
+
+You should use Product orange for:
+- Interactive elements
+- Buttons
+- Icons
+- Interactive text
+- Headings


### PR DESCRIPTION
v1.16.2
------------------------------
*September 22, 2022*

### Changed
- Use lists rather than captions for some colour images

### Removed
- figcaption lists (not needed)

## Before
<img width="1507" alt="Screenshot 2022-09-22 at 16 20 39" src="https://user-images.githubusercontent.com/16766185/191787053-486dd180-e969-4bbc-b50a-08e5f5b94d67.png">


## After
<img width="1062" alt="Screenshot 2022-09-22 at 16 20 14" src="https://user-images.githubusercontent.com/16766185/191786952-3cd6e99a-df08-4769-8555-fcf16b46f55f.png">
