### PR TITLE
pie-icons@v2.0.0-beta.2 - Updating icon classname to be camelCase

### DIFF
--- a/packages/tools/pie-icons/CHANGELOG.md
+++ b/packages/tools/pie-icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.0.0-beta.2
+------------------------------
+*October 7, 2022*
+
+### Changed
+- Updating icon classname modifier to be camelcase (i.e. `c-pieIcon--About` > `c-pieIcon--about`)
+
+
 v2.0.0-beta.1
 ------------------------------
 *October 6, 2022*

--- a/packages/tools/pie-icons/package.json
+++ b/packages/tools/pie-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeattakeaway/pie-icons",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "tag": "beta",
   "description": "Common icons for use for PIE Project",
   "main": "dist/pie-icons.js",

--- a/packages/tools/pie-icons/src/icon.js
+++ b/packages/tools/pie-icons/src/icon.js
@@ -20,7 +20,9 @@ class Icon {
    * @returns {string}
    */
     toSvg (attrs = {}, platform = 'default') {
-        const classname = classnames('c-pieIcon', `c-pieIcon--${this.name}`, this.attrs.class, attrs.class);
+        const camelCaseClassname = (this.name).substring(0, 1).toLowerCase() + (this.name).substring(1);
+
+        const classname = classnames('c-pieIcon', `c-pieIcon--${camelCaseClassname}`, this.attrs.class, attrs.class);
 
         const combinedAttrs = {
             ...this.attrs,


### PR DESCRIPTION
### Changed
- Updating icon classname modifier to be camelcase (i.e. `c-pieIcon--About` > `c-pieIcon--about`)