### PR TITLE
@v1.16.1 - Update github actions config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
       - 'LICENSE'
   push:
     branches:
-      - master
+      - main
 
 jobs:
     install:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,19 @@
 name: Build
 
 on:
-  pull_request
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths-ignore:
+      - '.husky/**'
+      - 'stories/**'
+      - '.vscode/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'LICENSE'
+  push:
+    branches:
+      - master
 
 jobs:
     install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v1.16.0
+
+v1.16.1
 ------------------------------
 *October 10, 2022*
+
+### Changed
+- add more granular config to the GitHub actions file for running on pushes to master and PRs
+
+
+v1.16.0
+------------------------------
+*October 13, 2022*
 
 ### Added
 - `pie-icons-vue` package to `/tools` (as a beta release).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.16.1
 ------------------------------
-*October 10, 2022*
+*October 13, 2022*
 
 ### Changed
 - add more granular config to the GitHub actions file for running on pushes to master and PRs
@@ -14,7 +14,7 @@ v1.16.1
 
 v1.16.0
 ------------------------------
-*October 13, 2022*
+*October 10, 2022*
 
 ### Added
 - `pie-icons-vue` package to `/tools` (as a beta release).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ v1.16.1
 *October 13, 2022*
 
 ### Changed
-- add more granular config to the GitHub actions file for running on pushes to master and PRs
+- add more granular config to the GitHub actions file for running on pushes to main and PRs
 
 
 v1.16.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pie",
   "description": "JustEatTakeaway",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "keywords": [],
   "author": "JustEatTakeaway - Vue Design System Team",
   "license": "MIT",


### PR DESCRIPTION
v1.16.1
------------------------------
*October 13, 2022*

### Changed
- add more granular config to the GitHub actions file for running on pushes to main and PRs