### PR TITLE
pie-icons-vue@2.0.0-beta.1 – Fixing dist output of module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,6 @@ esm
 
 .turbo
 build/**
-dist/**
+dist/
 
 .plugin-clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.18.3
+------------------------------
+*November 24, 2022*
+
+### Fixed
+- `.gitignore` dist folder exemption causing dist output not to be published. Have modified to be the same specificity as package `files` setting.
+
+
 v1.18.2
 ------------------------------
 *November 24, 2022*

--- a/packages/tools/pie-icons-vue/CHANGELOG.md
+++ b/packages/tools/pie-icons-vue/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix example webpage
 - Run clean pre-bundle (so it cleans the icons generated locally)
 
+v2.0.0-beta.1
+------------------------------
+*November 24, 2022*
+
+### Fixed
+- Published version didn't include all dist files (due to root `.gitignore`)
+
 
 v2.0.0-beta.0
 ------------------------------

--- a/packages/tools/pie-icons-vue/package.json
+++ b/packages/tools/pie-icons-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeattakeaway/pie-icons-vue",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "tag": "beta",
   "main": "dist/pie-icons-vue.cjs.js",
   "cdn": "dist/pie-icons-vue.min.js",
@@ -33,7 +33,7 @@
     "PIE"
   ],
   "scripts": {
-    "prepublishOnly": "yarn lint && yarn build",
+    "prepublishOnly": "yarn lint:scripts && yarn build",
     "build": "yarn build:icons && yarn build:dist",
     "build:dist": "bili --input generated/index.js --format umd,es,cjs,umd-min --js buble --name pie-icons-vue",
     "build:icons": "node build && babel generated/components -d icons",


### PR DESCRIPTION
### Fixed
- `.gitignore` dist folder exemption causing dist output not to be published. Have modified to be the same specificity as package `files` setting.