### PR TITLE
pie-styleint-config - npm badge in readme

### DIFF
--- a/packages/tools/pie-stylelint-config/README.md
+++ b/packages/tools/pie-stylelint-config/README.md
@@ -1,8 +1,6 @@
 # pie-stylelint-config
 
-TODO - add npm version
-
-TODO - add build status
+[![npm version](https://badge.fury.io/js/@justeattakeaway%2Fpie-stylelint-config.svg)](https://badge.fury.io/js/@justeattakeaway%2Fpie-stylelint-config)
 
 > PIE shareable stylelint config.
 


### PR DESCRIPTION
adds the npm badge to the readme - I don't think this warrants a version change nor changeset