### PR TITLE
pie-microsite@v1.44.0 - add support for opening markdown links in a new tab

### DIFF
--- a/apps/pie-microsite/.eleventy.js
+++ b/apps/pie-microsite/.eleventy.js
@@ -1,8 +1,9 @@
-const {
+const { 
   filters,
-  shortcodes,
-  plugins
-} = require('./src/_11ty');
+  libraries,
+   shortcodes, 
+   plugins
+   } = require('./src/_11ty');
 
 module.exports = eleventyConfig => {
   // Copy over img directory to dist directory.
@@ -13,6 +14,9 @@ module.exports = eleventyConfig => {
 
   // Filters
   filters.addAllFilters(eleventyConfig);
+
+  // Libraries to amend the used library instances
+  libraries.amendAllLibraries(eleventyConfig);
 
   // Shortcodes
   shortcodes.addAllShortCodes(eleventyConfig);

--- a/apps/pie-microsite/CHANGELOG.md
+++ b/apps/pie-microsite/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.44.0
+------------------------------
+*January 24, 2023*
+
+### Added
+- `markdown-it-attrs` to support opening markdown links in a new tab
+
+
 v1.43.1
 ------------------------------
 *January 23, 2023*

--- a/apps/pie-microsite/package.json
+++ b/apps/pie-microsite/package.json
@@ -34,7 +34,7 @@
     "eleventy-plugin-clean": "1.1.3",
     "eleventy-plugin-rev": "1.0.2",
     "eleventy-sass": "2.1.3",
-    "markdown-it-attrs": "^4.1.6"
+    "markdown-it-attrs": "4.1.6"
   },
   "dependencies": {
     "markdown-it": "13.0.1"

--- a/apps/pie-microsite/package.json
+++ b/apps/pie-microsite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pie-microsite",
   "description": "todo",
-  "version": "1.43.1",
+  "version": "1.44.0",
   "main": "index.js",
   "keywords": [],
   "author": "JustEatTakeaway - Vue Design System Team",

--- a/apps/pie-microsite/package.json
+++ b/apps/pie-microsite/package.json
@@ -33,7 +33,8 @@
     "dree": "3.4.2",
     "eleventy-plugin-clean": "1.1.3",
     "eleventy-plugin-rev": "1.0.2",
-    "eleventy-sass": "2.1.3"
+    "eleventy-sass": "2.1.3",
+    "markdown-it-attrs": "^4.1.6"
   },
   "dependencies": {
     "markdown-it": "13.0.1"

--- a/apps/pie-microsite/src/_11ty/filters/markdown.js
+++ b/apps/pie-microsite/src/_11ty/filters/markdown.js
@@ -1,9 +1,4 @@
-const MarkdownIt = require('markdown-it');
-
-const md = new MarkdownIt({
-    html: true
-});
-
+const md = require('../../utilities/markdown');
 /**
  * Converts markdown to HTML
  * @param {string} content - The content to be converted.

--- a/apps/pie-microsite/src/_11ty/index.js
+++ b/apps/pie-microsite/src/_11ty/index.js
@@ -1,5 +1,6 @@
 const collections = require('./collections');
 const filters = require('./filters');
+const libraries = require('./libraries');
 const shortcodes = require('./shortcodes');
 const plugins = require('./plugins');
 
@@ -10,6 +11,7 @@ const plugins = require('./plugins');
 module.exports = {
     collections,
     filters,
+    libraries,
     shortcodes,
     plugins
 };

--- a/apps/pie-microsite/src/_11ty/libraries/index.js
+++ b/apps/pie-microsite/src/_11ty/libraries/index.js
@@ -1,0 +1,13 @@
+const md = require('../../utilities/markdown');
+
+/**
+ * Adds all 11ty libraries
+ * @param {object} eleventyConfig
+ */
+const amendAllLibraries = eleventyConfig => {
+    eleventyConfig.setLibrary('md', md);
+};
+
+module.exports = {
+    amendAllLibraries
+};

--- a/apps/pie-microsite/src/content/pages/foundations/design-tokens/updates-and-maintenance.md
+++ b/apps/pie-microsite/src/content/pages/foundations/design-tokens/updates-and-maintenance.md
@@ -43,7 +43,7 @@ caption: "Screenshot of the cover page in our PIE 2.0 Foundations – Light Figm
 
 ### Communicate updates to designers and developers
 
-Updates carried out by PIE designers are communicated through the [Bi-weekly Component & Token Roundup](https://docs.google.com/document/d/10-_Ev2GsV18ACKHYWc49qgU-LYRYToAKrlfbHKA9cOM/edit?usp=sharing) document. The file is structured in bi-weekly releases, which show what has changed within the system and includes a description for additional context.
+Updates carried out by PIE designers are communicated through the [Bi-weekly Component & Token Roundup](https://docs.google.com/document/d/10-_Ev2GsV18ACKHYWc49qgU-LYRYToAKrlfbHKA9cOM/edit?usp=sharing){target="_blank"} document. The file is structured in bi-weekly releases, which show what has changed within the system and includes a description for additional context.
 
 {% contentPageImage {
 src:"../../../../../assets/img/foundations/design-tokens/updates-and-maintenance/component-token-roundup.svg",

--- a/apps/pie-microsite/src/utilities/markdown.js
+++ b/apps/pie-microsite/src/utilities/markdown.js
@@ -1,0 +1,8 @@
+const MarkdownIt = require('markdown-it');
+const markdownItAttrs = require('markdown-it-attrs');
+
+const md = new MarkdownIt({
+    html: true
+}).use(markdownItAttrs);
+
+module.exports = md;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11781,6 +11781,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it-attrs@npm:^4.1.6":
+  version: 4.1.6
+  resolution: "markdown-it-attrs@npm:4.1.6"
+  peerDependencies:
+    markdown-it: ">= 9.0.0"
+  checksum: 3487fab315a5955f1882edcb29b5362fcdc9a369c4cd1c38688b3d32a145254094d2d8389bdd6887c3af66f9a9a75143f167d88421dcf201e54ec587675756a0
+  languageName: node
+  linkType: hard
+
 "markdown-it@npm:13.0.1":
   version: 13.0.1
   resolution: "markdown-it@npm:13.0.1"
@@ -13324,6 +13333,7 @@ __metadata:
     eleventy-plugin-rev: 1.0.2
     eleventy-sass: 2.1.3
     markdown-it: 13.0.1
+    markdown-it-attrs: ^4.1.6
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11781,7 +11781,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it-attrs@npm:^4.1.6":
+"markdown-it-attrs@npm:4.1.6":
   version: 4.1.6
   resolution: "markdown-it-attrs@npm:4.1.6"
   peerDependencies:
@@ -13333,7 +13333,7 @@ __metadata:
     eleventy-plugin-rev: 1.0.2
     eleventy-sass: 2.1.3
     markdown-it: 13.0.1
-    markdown-it-attrs: ^4.1.6
+    markdown-it-attrs: 4.1.6
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
adds [markdown-it-attrs ](https://github.com/arve0/markdown-it-attrs) as a dev package to support opening markdown links in a new tab when needed. 

📓 currently we only need to open links in a new tab when the link requires authentication, for example, Okta to adhere to [WCAG 2.0](https://www.w3.org/TR/WCAG20-TECHS/) guidelines.

📓 to open a link in a new tab, we need to add {target="_blank"} at the end of the markdown element. such as `[google](https://www.google.com) {target="_blank"}`

📓 please check out [11ty docs](https://www.11ty.dev/docs/languages/markdown/#add-your-own-plugins) for a walkthrough of how to modify a library instance. 