### PR TITLE
v1.46.0 - Fixes h2 sizes for narrow and wide devices.

### DIFF
--- a/apps/pie-microsite/CHANGELOG.md
+++ b/apps/pie-microsite/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.46.0
+------------------------------
+*January 25, 2023*
+
+### Fixed
+- H2 wide & narrow sizes to be inline with the new design sizes.
+
+
 v1.45.1
 ------------------------------
 *January 24, 2023*

--- a/apps/pie-microsite/package.json
+++ b/apps/pie-microsite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pie-microsite",
   "description": "todo",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "main": "index.js",
   "keywords": [],
   "author": "JustEatTakeaway - Vue Design System Team",

--- a/apps/pie-microsite/src/assets/styles/components/_contentPage.scss
+++ b/apps/pie-microsite/src/assets/styles/components/_contentPage.scss
@@ -68,7 +68,7 @@
     padding-bottom: f.spacing(j);
 
     > h2 {
-        @include f.font-size('heading-m');
+        @include f.font-size('heading-l');
     }
 
     > h3 {
@@ -80,7 +80,7 @@
         padding-bottom: calc(f.spacing(j) + f.spacing(d));
 
         > h2 {
-            @include f.font-size('heading-l');
+            @include f.font-size('heading-xl');
         }
 
         > h3 {


### PR DESCRIPTION

### Fixed
- H2 wide & narrow sizes to be inline with the new design sizes.