### PR TITLE
root@v1.23.0 – editorconfig update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,14 @@
 root = true
 
 [*]
-end_of_line = lf
-insert_final_newline = true
-
-[*.{js,json,yml}]
 charset = utf-8
+end_of_line = lf
 indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**/*.{config,csproj,dotsettings,feature,fxcop,json,markdown,md,ncrunch*,ndepend,rb,targets,xml,xsd,yml}]
 indent_size = 2
+
+[**/*.{cs,cshtml,css,html,js,less,vue}]
+indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.23.0
+------------------------------
+*January 27, 2022*
+
+### Changed
+- `.editorconfig` updated – matches old mono-repo settings now, which matches up with our current linting rulesets
+
+
 v1.22.0
 ------------------------------
 *January 19, 2022*


### PR DESCRIPTION
### Changed
- `.editorconfig` updated – matches old mono-repo settings now, which matches up with our current linting rulesets