### PR TITLE
#trivial – Tidying up rimraf in pie-icons

### DIFF
--- a/packages/tools/pie-icons/package.json
+++ b/packages/tools/pie-icons/package.json
@@ -16,7 +16,7 @@
     "nodemon": "nodemon --config ./nodemon.json",
     "build": "node ./bin/build.js",
     "prepare": "yarn build && yarn test:coverage",
-    "clean": "rimraf -rf ./dist/*",
+    "clean": "run -T rimraf -rf ./dist/*",
     "prepublishOnly": "yarn run build",
     "lint:scripts": "run -T eslint .",
     "lint:scripts:fix": "run -T eslint . --fix",
@@ -30,13 +30,11 @@
     "classnames": "2.3.1",
     "html-minifier": "4.0.0",
     "prettier": "2.5.1",
-    "rimraf": "3.0.2",
     "svgo": "1.3.2"
   },
   "devDependencies": {
     "lint-staged": "12.3.4",
     "nodemon": "2.0.15",
-    "rimraf": "3.0.2",
     "svgo": "1.3.2",
     "webpack": "5.69.1",
     "webpack-cli": "4.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,7 +2634,6 @@ __metadata:
     lint-staged: 12.3.4
     nodemon: 2.0.15
     prettier: 2.5.1
-    rimraf: 3.0.2
     svgo: 1.3.2
     webpack: 5.69.1
     webpack-cli: 4.9.2


### PR DESCRIPTION
Super trivial update to the clean script, to make it work properly with turborepo. Also, removes the dependency at this package level, as not needed (it's in the root dependencies)