### PR TITLE
pie-monorepo - Fix release CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,9 @@ jobs:
           restore-keys: |
             turborepo-dist-cache-${{ github.ref_name }}
             turborepo-dist-cache-
+      # Build Packages
+      - name: Build Microsite
+        run: yarn build --cache-dir=".turbo"
       - name: Check for pre.json file existence
         id: check_files
         uses: andstor/file-existence-action@v2.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,8 @@ jobs:
             turborepo-dist-cache-
       # Build Packages
       - name: Build Microsite
+        if: ${{ github.event_name != 'pull_request' }} &&
+          (contains(github.ref_name, 'main') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'feature'))
         run: yarn build --cache-dir=".turbo"
       - name: Check for pre.json file existence
         id: check_files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.25.1
+------------------------------
+*Febuary 3, 2022*
+
+### Fixed
+- Issue with dist's not being available to changesets release job.
+
 v1.25.0
 ------------------------------
 *January 31, 2022*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pie-monorepo",
   "description": "JustEatTakeaway",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "keywords": [],
   "author": "JustEatTakeaway - Design System Web Team",
   "license": "Apache-2.0",


### PR DESCRIPTION
v1.25.1
------------------------------
*Febuary 3, 2022*

### Fixed
- Issue with dist's not being available to changesets release job.