### PR TITLE
Ensure Storybook previews are removed after merge + Fix property name in GHA config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           folder: ./apps/pie-storybook/dist
           force: false
           branch: gh-pages
-          target_folder: ./storybook
+          target-folder: ./storybook
           clean-exclude: |
             pr-preview-docs
             pr-preview-storybook

--- a/.github/workflows/remove-preview-deploy.yml
+++ b/.github/workflows/remove-preview-deploy.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn add --cached
 
-  remove-preview-deploy:
+  remove-preview-deploy-microsite:
     needs: install
     runs-on: ubuntu-latest
     steps:
@@ -56,5 +56,33 @@ jobs:
         with:
           source-dir: ./apps/pie-microsite/dist
           preview-branch: gh-pages
-          umbrella-dir: pr-preview
+          umbrella-dir: pr-preview-docs
+          action: remove
+
+  remove-preview-deploy-storybook:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the Repo
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Setup Node 16
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+      # Restore node_modules - Cache should exist as one was created in previous 'install' job
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Remove PR Preview deploy
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./apps/pie-storybook/dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview-storybook
           action: remove


### PR DESCRIPTION
This PR:
- Fixes a type for the `main` storybook deploy.
- Ensures Storybook previews get deleted after merging.