### PR TITLE
pie-microsite: change support icon

### DIFF
--- a/.changeset/famous-chairs-perform.md
+++ b/.changeset/famous-chairs-perform.md
@@ -1,0 +1,5 @@
+---
+"pie-microsite": minor
+---
+
+[Changed] use `help-circle` icon for `Support` section of nav

--- a/apps/pie-microsite/src/_includes/nav.njk
+++ b/apps/pie-microsite/src/_includes/nav.njk
@@ -4,7 +4,7 @@
     'All about PIE': 'pie',
     'Designers': 'bulb-lightning',
     Foundations: 'foundations',
-    Support: 'hand-heart'
+    Support: 'help-circle'
 } %}
 
 {% set chevronFill = { tokenName: 'interactive-primary', tokenPath: ['alias', 'default'] } | pieDesignTokenColours %}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@justeat/fozzie": "10.9.0",
-    "@justeattakeaway/pie-icons": "2.0.0-beta.3",
+    "@justeattakeaway/pie-icons": "2.0.0-beta.4",
     "lit": "2.6.1"
   },
   "volta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,7 +2612,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-vue@workspace:packages/tools/pie-icons-vue"
   dependencies:
-    "@justeattakeaway/pie-icons": 2.0.0-beta.3
+    "@justeattakeaway/pie-icons": 2.0.0-beta.4
     "@vue/babel-helper-vue-jsx-merge-props": 1.4.0
     "@vue/babel-preset-jsx": 1.4.0
     bili: 3.4.2
@@ -2624,7 +2624,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons@2.0.0-beta.3, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
+"@justeattakeaway/pie-icons@2.0.0-beta.4, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons@workspace:packages/tools/pie-icons"
   dependencies:
@@ -16669,7 +16669,7 @@ __metadata:
     "@justeat/fozzie": 10.9.0
     "@justeat/pie-design-tokens": 4.0.0-beta.0
     "@justeat/stylelint-config-fozzie": 3.x
-    "@justeattakeaway/pie-icons": 2.0.0-beta.3
+    "@justeattakeaway/pie-icons": 2.0.0-beta.4
     "@percy/cli": 1.16.0
     "@percy/webdriverio": 2.0.2
     "@wdio/allure-reporter": 7.26.0


### PR DESCRIPTION
[Changed] use `help-circle` icon for `Support` section of nav
