### PR TITLE
pie-docs - Fix issue with build:dev command not executing tasks on dependencies

### DIFF
--- a/.changeset/selfish-items-lie.md
+++ b/.changeset/selfish-items-lie.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Fixed] -  issue where `dev` command wasn't executing tasks for dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.27.1
 
 ### Fixed
 - Fixed issue where `pie-docs#build:dev` wasn't included in `turbo.json`.
+- Fixed issue where linting would fail if dependency `dist` wasn't present.
 
 
 v1.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.27.1
+------------------------------
+*Febuary 21, 2022*
+
+### Fixed
+- Fixed issue where `pie-docs#build:dev` wasn't included in `turbo.json`.
+
+
 v1.27.0
 ------------------------------
 *Febuary 16, 2022*

--- a/apps/pie-docs/package.json
+++ b/apps/pie-docs/package.json
@@ -12,7 +12,7 @@
     "build": "DEPLOYMENT_ENVIRONMENT='production' eleventy",
     "build:dev": "DEPLOYMENT_ENVIRONMENT='development' eleventy",
     "clean:dist": "run -T rimraf dist",
-    "dev": "yarn clean:dist && yarn build:dev --serve",
+    "dev": "npx @11ty/eleventy --serve",
     "lint:scripts": "run -T eslint .",
     "lint:scripts:fix": "run -T eslint . --fix",
     "lint:style": "run -T stylelint ./src/**/*.{css,scss}",

--- a/apps/pie-docs/package.json
+++ b/apps/pie-docs/package.json
@@ -12,7 +12,7 @@
     "build": "DEPLOYMENT_ENVIRONMENT='production' eleventy",
     "build:dev": "DEPLOYMENT_ENVIRONMENT='development' eleventy",
     "clean:dist": "run -T rimraf dist",
-    "dev": "npx @11ty/eleventy --serve",
+    "dev": "yarn clean:dist && npx @11ty/eleventy --serve",
     "lint:scripts": "run -T eslint .",
     "lint:scripts:fix": "run -T eslint . --fix",
     "lint:style": "run -T stylelint ./src/**/*.{css,scss}",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pie-monorepo",
   "description": "JustEatTakeaway",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "keywords": [],
   "author": "JustEatTakeaway - Design System Web Team",
   "license": "Apache-2.0",

--- a/turbo.json
+++ b/turbo.json
@@ -81,6 +81,9 @@
     },
     "lint:scripts": {
       "cache": true,
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "lint:scripts:fix": {
@@ -88,7 +91,9 @@
     },
     "lint:style": {
       "cache": true,
-      "dependsOn": []
+      "dependsOn": [
+        "^build"
+      ]
     },
     "dev": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,20 @@
         "@justeattakeaway/pie-icons#build"
       ]
     },
+    "pie-docs#build:dev": {
+      "cache": true,
+      "dependsOn": [
+        "^build",
+        "@justeattakeaway/pie-icons#build"
+      ]
+    },
+    "pie-docs#dev": {
+      "cache": false,
+      "dependsOn": [
+        "pie-docs#build:dev",
+        "^build"
+      ]
+    },
     "clean": {
       "cache": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,20 +2654,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-icons@npm:2.0.0-beta.3":
-  version: 2.0.0-beta.3
-  resolution: "@justeattakeaway/pie-icons@npm:2.0.0-beta.3"
-  dependencies:
-    cheerio: 1.0.0-rc.10
-    classnames: 2.3.1
-    html-minifier: 4.0.0
-    prettier: 2.5.1
-    rimraf: 3.0.2
-    svgo: 1.3.2
-  checksum: a78b5bf0663a64b368225f6e08301e64adc205ee4a951485b518cdfe324be1d8823ecb6e9d117d91f96abb6aac6048beb6b6394ee710876535770b5d7e2fdd87
-  languageName: node
-  linkType: hard
-
 "@justeattakeaway/pie-stylelint-config@workspace:packages/tools/pie-stylelint-config":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-stylelint-config@workspace:packages/tools/pie-stylelint-config"


### PR DESCRIPTION
**pie-monorepo**
v1.27.1
------------------------------
*Febuary 21, 2022*

### Fixed
- Fixed issue where `pie-docs#build:dev` wasn't included in `turbo.json`.
- Fixed issue where linting would fail if dependency `dist` wasn't present.