### PR TITLE
revert(pie-monorepo): revert changes to GHA config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
     "changelog": ["./changelog-config.js", {"repo": "justeattakeaway/pie"}],
-    "commit": true,
+    "commit": false,
     "fixed": [],
     "linked": [
       [

--- a/.changeset/wet-laws-prove.md
+++ b/.changeset/wet-laws-prove.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[ Fixed ] - Revert back to old changeset / GHA config to prevent CI not running on Release commits

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -315,14 +315,7 @@ jobs:
         # If .changeset/pre.json does not exist and we did not recently exit
         # prerelease mode.
         if: steps.check_files.outputs.files_exists == 'true' && contains(github.ref_name, 'main')
-        run: |
-          npx changeset pre exit
-      - name: commit prerelease exit changes
-        if: steps.check_files.outputs.files_exists == 'true' && contains(github.ref_name, 'main')
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore(pie-monorepo): exit prerelease mode"
-          branch: ${{ github.event.inputs.branch }}
+        run: npx changeset pre exit
       - name: Create latest release PR
         if: contains(github.ref_name, 'main')
         uses: changesets/action@v1


### PR DESCRIPTION
[ Fixed ] - Revert back to old changeset / GHA config to prevent CI not running on Release commits