### PR TITLE
cosmetic(pie-docs): update footer styles based on designers feedback

### DIFF
--- a/.changeset/big-cooks-fry.md
+++ b/.changeset/big-cooks-fry.md
@@ -1,0 +1,9 @@
+---
+"pie-docs": minor
+---
+
+[Fixed] Footer styles based on designers feedback
+[Fixed] The small divider between the two logos to be 1px wide
+[Fixed] The PIE logo to be 24px high, and centre aligned to the other logo.
+[Fixed] The space above and below the links to be 64px, not 56px.
+[Fixed] The dot between ‘Privacy policy’ and ‘Updated on…’ to be centre aligned horizontally

--- a/apps/pie-docs/src/assets/styles/components/_footer.scss
+++ b/apps/pie-docs/src/assets/styles/components/_footer.scss
@@ -19,15 +19,24 @@
         align-items: center;
         padding-bottom: f.spacing(b);
 
+        @include f.media('>=narrowMid') {
+            padding-bottom: 0;
+        }
+
+        picture {
+            display: flex;
+            align-items: start;
+        }
+
         .c-footer-logo-divider {
             display: inline-block;
-            border: 1px solid f.$color-border-strong;
+            border-left: 1px solid f.$color-border-strong;
             height: f.spacing(f);
             margin: 0 f.spacing(d);
         }
 
         svg {
-            height: 32px;
+            height: 24px;
         }
     }
 
@@ -45,7 +54,7 @@
 
     @include f.media('>=narrowMid') {
         flex-direction: row;
-        padding: f.spacing(h) 0;
+        padding: f.spacing(i) 0;
     }
 
     section {
@@ -85,5 +94,6 @@
         border-radius: f.$radius-rounded-e;
         background-color: f.$color-border-strong;
         margin: 0 f.spacing(b);
+        vertical-align: middle;
     }
 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Fixed] Footer styles based on designers feedback
[Fixed] The small divider between the two logos to be 1px wide
[Fixed] The PIE logo to be 24px high, and centre aligned to the other logo.
[Fixed] The space above and below the links to be 64px, not 56px.
[Fixed] The dot between ‘Privacy policy’ and ‘Updated on…’ to be centre aligned horizontally

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
