### PR TITLE
docs(pie-docs): carry out link audit on the docs site

### DIFF
--- a/.changeset/calm-moles-live.md
+++ b/.changeset/calm-moles-live.md
@@ -1,0 +1,8 @@
+---
+"pie-docs": minor
+---
+
+[Added] Previously missing links on designer pages.
+[Changed] Reword some sections to make the link destinations more obvious at a glance.
+[Removed] Some links that won't be used or aren't currently used. These will be added back in later when they are ready.
+[Fixed] Some links were pointing to pages that no longer existed, e.g., `/engineers/guidelines` is now `/engineers/guidelines/overview`.

--- a/apps/pie-docs/src/designers/contributing/contributing.md
+++ b/apps/pie-docs/src/designers/contributing/contributing.md
@@ -38,11 +38,11 @@ Below you can find the process we’ll follow to implement your suggested design
 
 Before creating a new component or piece of documentation, please make sure there isn’t already a solution that would fit your needs. If you are unsure about this, please get in touch with us so we can help you figure out what the best way forward might be.
 
-We have a [process]() in place to determine whether a new component needs to be created, please make sure you read it and follow the steps outlined when proposing a new component.
+We have a [partnership process](https://www.figma.com/file/BRwqw7B4dm4mVPdvfVLSNY/Process?node-id=440%3A3052&t=bTA5tJ46naOtMqUn-0) in place to determine whether a new component needs to be created, please make sure you read it and follow the steps outlined when proposing a new component.
 
 ### Volunteer to work with us
 
-If you have a particular interest in design systems or would like to help us out with the design, development or documentation of PIE, you can [reach out to us]() at any time to become a new PIE advocate.
+If you have a particular interest in design systems or would like to help us out with the design, development or documentation of PIE, you can [reach out to us](/support/contact-us) at any time to become a new PIE advocate.
 
 We’re always happy to hear about new ideas and opinions on how to improve our system, and will welcome any feedback, suggestions or support from you.
 

--- a/apps/pie-docs/src/designers/getting-started/best-practices.md
+++ b/apps/pie-docs/src/designers/getting-started/best-practices.md
@@ -40,7 +40,7 @@ caption: "Example of a library update notification in Figma."
 
 We share updates and news through a variety of communications and Slack channels. These will keep you up to date with what’s happening in the Design System, where are we heading to and what changes or updates have been made to the system.
 
-You can find a list of the Slack channels we use in our [Support]() section.
+You can find a list of the Slack channels we use in our [Support](/support/contact-us) section.
 
 {% contentPageImage {
 src: "../../../assets/img/designers/getting-started/best-practices/monthly-slice.svg",
@@ -54,8 +54,6 @@ caption: "The image above shows one of our usual PIE communications: The PIE mon
 ## Use Auto Layout
 
 To ensure your designs adjust to the layout and are able to scale, try using Auto Layout when designing your product. This will ensure you create designs that grow to fill or shrink to fit your screens, accommodating longer text strings, maintaining alignment with our grid and ensuring the structure of your designs isn’t compromised as they evolve.
-
-If you want to learn more about using Auto Layout, you can check out our ‘[Working with Auto layout]()’ guide.
 
 {% contentPageImage {
 src: "../../../assets/img/designers/getting-started/best-practices/auto-layout.svg",

--- a/apps/pie-docs/src/designers/getting-started/overview.md
+++ b/apps/pie-docs/src/designers/getting-started/overview.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 You can access Figma through the browser, but it is recommended that you use the desktop app. If Figma’s desktop app is not installed on your computer, get in touch with your manager to request this.
 
-As a designer within the Just Eat Takeaway organisation, you’ll automatically have access to all of PIE’s libraries and files. However, if that’s not the case, please [get in touch with the PIE team]() to request access.
+As a designer within the Just Eat Takeaway organisation, you’ll automatically have access to all of PIE’s libraries and files. However, if that’s not the case, please [get in touch with the PIE team](/support/contact-us) to request access.
 
 {% notification {
 type: "information",
@@ -23,10 +23,9 @@ message: "If you’re new to Figma, check [these tutorials](https://www.figma.co
 
 ## How is PIE structured?
 
-We have divided our foundations, components and assets into multiple libraries, so they can be easily found and referenced. All of them can be found on the [PIE Team]() section in Figma.
+We have divided our foundations, components and assets into multiple libraries, so they can be easily found and referenced. All of them can be found on the [Getting started with Figma files](/designers/getting-started/figma-files) section.
 
-You’ll need to enable these libraries if you want to use the PIE design system for your products. If you don’t know how to do that, please read our [‘How to enable libraries in Figma’]() guide.
-
+You’ll need to enable these libraries if you want to use the PIE design system for your products.
 
 {% contentPageImage {
 src: "../../../assets/img/designers/getting-started/overview/libraries-wheel.svg",
@@ -56,7 +55,7 @@ These libraries contain assets which can be used in our products, such as icons 
 
 Business Area libraries were created to provide more flexibility to our teams. Components which are unique to a specific Business Area (such as Customer, Restaurant…) and would not be relevant in other ones live within these libraries.
 
-Business Area designers own these libraries, and PIE designers only help with maintaining them and making sure they are consistent with our Core Components libraries. You can learn more about how we support these libraries in our [Getting Support]() section.
+Business Area designers own these libraries, and PIE designers only help with maintaining them and making sure they are consistent with our Core Components libraries. You can learn more about how we support these libraries in our [Getting Support](/designers/how-we-support-you) section.
 
 ---
 

--- a/apps/pie-docs/src/designers/how-we-support-you.md
+++ b/apps/pie-docs/src/designers/how-we-support-you.md
@@ -19,15 +19,15 @@ Our goal is never to take ownership from designers in pillars, so we try to prov
 
 We have come up with three different support models which can help you improve the way you implement PIE within your products.
 
-If you’re unsure about which model might be best for you or your team, or would like to know more about how we can support you, please [get in touch with us]().
+If you’re unsure about which model might be best for you or your team, or would like to know more about how we can support you, please [get in touch with us](/support/contact-us).
 
 ### Mentoring
 
-With the mentoring model, the business area designer is in charge of creating the component following the [contribution process]() outlined in our [Contribution]() section.
+With the mentoring model, the business area designer is in charge of creating the component following the contribution process outlined in our [Contribution](/designers/contributing) section.
 
 During this process, a PIE designer will support the business area designer by reviewing the work, offering help and providing feedback at any stage.
 
-You can check the process closely in our [Process]() file.
+You can take a closer look at this in our [mentoring process](https://www.figma.com/file/BRwqw7B4dm4mVPdvfVLSNY/Process?node-id=440%3A1574&t=3PXkTh6rokGiG3sG-4) file.
 
 {% contentPageImage {
 src: "../../assets/img/designers/how-we-support-you/mentoring.svg",
@@ -38,11 +38,11 @@ caption: "A flow diagram which shows the steps we follow during our Mentorship s
 
 ### Cleanup
 
-With the cleanup model, the business area designer creates the component only **requesting support if/when needed**. Designers must ensure they create the new component following the [contribution process]() outlined in our [Contribution]() section.
+With the cleanup model, the business area designer creates the component only **requesting support if/when needed**. Designers must ensure they create the new component following the contribution process outlined in our [Contributing](/designers/contributing) section.
 
 Once the component is finished, a PIE designer will help the business area designer finalise and finesse the component, making sure it aligns with our design system.
 
-You can check the process closely in our [Process]() file.
+You can take a closer look at this in our [cleanup process](https://www.figma.com/file/BRwqw7B4dm4mVPdvfVLSNY/Process?node-id=440%3A1723&t=3PXkTh6rokGiG3sG-4) file.
 
 {% contentPageImage {
 src: "../../assets/img/designers/how-we-support-you/cleanup.svg",
@@ -55,7 +55,7 @@ caption: "A flow diagram which shows the steps we follow during our Cleanup supp
 
 With the partnership model, the business area designer **will work closely with a PIE designer** throughout the component creation process, from research and testing, right through component building and finalisation.
 
-You can check the process closely in our [Process]() file.
+You can take a closer look at this in our [partnership process](https://www.figma.com/file/BRwqw7B4dm4mVPdvfVLSNY/Process?node-id=440%3A3052&t=aVebo2jjEWjKMFwI-0) file.
 
 {% contentPageImage {
 src: "../../assets/img/designers/how-we-support-you/partnership.svg",

--- a/apps/pie-docs/src/engineers/getting-started/overview.md
+++ b/apps/pie-docs/src/engineers/getting-started/overview.md
@@ -23,7 +23,7 @@ If you're interested in knowing more about where we are in our engineering journ
 
 If you'd like to contribute to PIE, check out our [contributing guide](/engineers/contributing/).
 
-We also maintain guides for global front-end best practices across JET. These can be found in the [engineering guidelines section of our docs](/engineers/guidelines).
+We also maintain guides for global front-end best practices across JET. These can be found in the [engineering guidelines section of our docs](/engineers/guidelines/overview).
 
 
 <!-- N.B. for the future – we should include a components summary section here like this when we want to start advertising our components:

--- a/apps/pie-docs/src/support/faq.md
+++ b/apps/pie-docs/src/support/faq.md
@@ -29,25 +29,25 @@ We’re always committed to review our Core Components if there are changes and 
 
 Keep in mind that you can always contribute directly to PIE Business Area libraries. With our support, you’ll be able to add or amend components, while we keep an eye on the quality and consistency of the user experience.
 
-Please check our contributing guidelines for [Designers]() and [Engineers]() for more information on how you can collaborate with us.
+Please check our contributing guidelines for [Designers](/designers/contributing) and [Engineers](/engineers/contributing) for more information on how you can collaborate with us.
 
 ---
 
 ## How do I get started with PIE?
 
-We are here to help you get set up! Please check [Designers]() and [Engineers]() to get started with PIE, or reach out directly if you just want to start a conversation about how PIE can help you or your team.
+We are here to help you get set up! Please check [Designers](/designers/getting-started/overview) and [Engineers](/engineers/getting-started/overview) to get started with PIE, or reach out directly if you just want to start a conversation about how PIE can help you or your team.
 
 ---
 
 ## I found a bug. How do I report it?
 
-First, make sure the problem is reproducible. Once confirmed, send us a bug report using [this form]().
+First, make sure the problem is reproducible. Once confirmed, send us a bug report using the **Report defect** workflow in the **help-designsystem** Slack channel (JET employees only).
 
 ---
 
 ## I need a new icon. How do I add it?
 
-All new icons requests should be submitted through the [icon request form](https://docs.google.com/forms/d/16x_tEnAZS75vamcGQpOwipjCfz6Nczg2TfI0a_Ixh9U/viewform?pli=1&pli=1&edit_requested=true). Please read the [Contact Us]() page for more information on how to contact us directly with an icon request.
+All new icons requests should be submitted through the [icon request form](https://docs.google.com/forms/d/16x_tEnAZS75vamcGQpOwipjCfz6Nczg2TfI0a_Ixh9U/viewform?pli=1&pli=1&edit_requested=true). Please read the [Contact Us](/support/contact-us) page for more information on how to contact us directly with an icon request.
 
 Please keep in mind though that if there’s a similar icon already in use, we will suggest you to use that instead.
 
@@ -55,15 +55,15 @@ Please keep in mind though that if there’s a similar icon already in use, we w
 
 ## I need a new component. How do I request it?
 
-If you need a new component built, please check the processes we’ve outlined in our support guidelines for [Designers]() and [Engineers](). You can also reach out to us directly asking for help and we’ll help you choose the right support model for you or your team.
+If you need a new component built, please check the processes we’ve outlined in our support guidelines for [Designers](/designers/how-we-support-you) and [Engineers](/engineers/contributing). You can also use the **Request help** workflow in the **#help-designsystem** Slack channel (JET employees only) and we’ll help you choose the right support model for you or your team.
 
 ---
 
 ## How can I contribute?
 
-If you have new ideas for components, patterns or general UI improvements for your products, you can certainly contribute. Please check our contributing guidelines for [Designers]() and [Engineers]() for more details.
+If you have new ideas for components, patterns or general UI improvements for your products, you can certainly contribute. Please check our contributing guidelines for [Designers](/designers/contributing) and [Engineers](/engineers/contributing) for more details.
 
 ---
 
 ## I couldn’t find an answer to my question
-If you couldn’t find the answer to your question, please [contact us]() directly.
+If you couldn’t find the answer to your question, please [contact us](/support/contact-us) directly.


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- [Added] Previously missing links on designer pages.
- [Changed] Reword some sections to make the link destinations more obvious at a glance.
- [Removed] Some links that won't be used or aren't currently used. These will be added back in later when they are ready.
- [Fixed] Some links were pointing to pages that no longer existed, e.g., `/engineers/guidelines` is now `/engineers/guidelines/overview`.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
