### PR TITLE
fix(pie-docs): ensure cookie-banner css loads before js executes

### DIFF
--- a/.changeset/curly-dots-sort.md
+++ b/.changeset/curly-dots-sort.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Changed] - Use f-cookie-banner package for cookie banner

--- a/apps/pie-docs/.eleventy.js
+++ b/apps/pie-docs/.eleventy.js
@@ -39,7 +39,8 @@ module.exports = eleventyConfig => {
     // Allow JS to pass through (can add a bundling step in future if needed)
     eleventyConfig.addPassthroughCopy("./src/assets/js");
 
-    // Any js from node_modules we want to pull in with <script> tags may need to reference the root node_modules folder
+    // This allows us to reference JS from node_modules in <script> tags.
+    // However it can work with any kind of type and any location!
     eleventyConfig.addPassthroughCopy({
         "../../node_modules/@justeat/f-cookie-banner/dist/static/en-GB.js": "assets/js/en-GB.js"
     });

--- a/apps/pie-docs/.eleventy.js
+++ b/apps/pie-docs/.eleventy.js
@@ -39,6 +39,11 @@ module.exports = eleventyConfig => {
     // Allow JS to pass through (can add a bundling step in future if needed)
     eleventyConfig.addPassthroughCopy("./src/assets/js");
 
+    // Any js from node_modules we want to pull in with <script> tags may need to reference the root node_modules folder
+    eleventyConfig.addPassthroughCopy({
+        "../../node_modules/@justeat/f-cookie-banner/dist/static/en-GB.js": "assets/js/en-GB.js"
+    });
+
     return {
         dir: {
         input: "src",

--- a/apps/pie-docs/package.json
+++ b/apps/pie-docs/package.json
@@ -39,6 +39,7 @@
     "markdown-it-attrs": "4.1.6"
   },
   "dependencies": {
+    "@justeat/f-cookie-banner": "4.7.0",
     "markdown-it": "13.0.1"
   },
   "volta": {

--- a/apps/pie-docs/src/_includes/head.njk
+++ b/apps/pie-docs/src/_includes/head.njk
@@ -32,16 +32,4 @@
     <meta property="og:description" content="{{ metadata.description }}">
     {# Common <head> content #}
     {% include "head-common.njk" %}
-    {# Static cookie banner - These are non-critical stylesheets and loading should be deferred #}
-    <link rel="preload" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-reset.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-reset.css"></noscript>
-
-    <link rel="preload" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-typography.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-typography.css"></noscript>
-
-    <link rel="preload" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-utilities.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://unpkg.com/@justeat/fozzie/dist/css/fozzie-utilities.css"></noscript>
-
-    <link rel="preload" href="https://unpkg.com/@justeat/f-cookie-banner/dist/static/en-GB.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://unpkg.com/@justeat/f-cookie-banner/dist/static/en-GB.css"></noscript>
 </head>

--- a/apps/pie-docs/src/_includes/scripts.njk
+++ b/apps/pie-docs/src/_includes/scripts.njk
@@ -1,5 +1,5 @@
 {# All JS modules to go here #}
-<script defer src="https://unpkg.com/@justeat/f-cookie-banner/dist/static/en-GB.js" type="text/javascript"></script>
+<script defer src="{{ '/assets/js/en-GB.js' | url }}" type="module"></script>
 <script defer src="{{ '/assets/js/accordions.js' | url }}" type="module"></script>
 <script defer src="{{ '/assets/js/toggled-content.js' | url }}" type="module"></script>
 <script defer src="{{ '/assets/js/prism.js' | url }}" type="module"></script>

--- a/apps/pie-docs/src/assets/styles/_dependencies.scss
+++ b/apps/pie-docs/src/assets/styles/_dependencies.scss
@@ -13,6 +13,8 @@
 @use 'base/layout';
 @use 'base/typography';
 
+@use '@justeat/f-cookie-banner/dist/static/en-GB.css';
+
 /**
  * Plugin Styles:
  * =================================

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,6 +3155,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@justeat/f-cookie-banner@npm:4.7.0":
+  version: 4.7.0
+  resolution: "@justeat/f-cookie-banner@npm:4.7.0"
+  dependencies:
+    "@justeat/f-services": 1.x
+  peerDependencies:
+    "@justeat/browserslist-config-fozzie": ">=1.1.1"
+    js-cookie: 2.2.1
+  checksum: 072fe042d0d201431c77cbe5107c1660943b7152c869942b8a93f6e3a9d958947ed349485a22ce58b90f64384b472847c3c4500326a70bbe63cc22b2006133eb
+  languageName: node
+  linkType: hard
+
+"@justeat/f-services@npm:1.x":
+  version: 1.17.0
+  resolution: "@justeat/f-services@npm:1.17.0"
+  dependencies:
+    lodash-es: 4.17.21
+    window-or-global: 1.0.1
+  peerDependencies:
+    axios: ">=0.21.1"
+  checksum: ad1b9a191c344ba73998ff825ab2814e03180cbb88b3c1af0fbedb3101c2f397f5fc36f6c83c9f542f540ff5ed64bd0ebe017435de55e743a6205f0e8e42b35a
+  languageName: node
+  linkType: hard
+
 "@justeat/fozzie@npm:10.11.0":
   version: 10.11.0
   resolution: "@justeat/fozzie@npm:10.11.0"
@@ -15951,6 +15975,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash-es@npm:4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
+  languageName: node
+  linkType: hard
+
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -18220,6 +18251,7 @@ __metadata:
   dependencies:
     "@11ty/eleventy": 1.0.2
     "@11ty/eleventy-navigation": 0.3.5
+    "@justeat/f-cookie-banner": 4.7.0
     dree: 3.4.2
     eleventy-plugin-clean: 1.1.3
     eleventy-plugin-rev: 1.0.2
@@ -25233,6 +25265,13 @@ __metadata:
   version: 2.0.0
   resolution: "wildcard@npm:2.0.0"
   checksum: 1f4fe4c03dfc492777c60f795bbba597ac78794f1b650d68f398fbee9adb765367c516ebd4220889b6a81e9626e7228bbe0d66237abb311573c2ee1f4902a5ad
+  languageName: node
+  linkType: hard
+
+"window-or-global@npm:1.0.1":
+  version: 1.0.1
+  resolution: "window-or-global@npm:1.0.1"
+  checksum: 19272a9589dedf790389376015b7a92e9b987d1c9b15457840f65a3829c5173a8cecce72111944624d98c2120799168d26b38e6b911fff77b4828a2322a8a02e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Changed] - Use f-cookie-banner package for cookie banner

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
