### PR TITLE
fix(pie-monorepo): add missing Volta settings

### DIFF
--- a/.changeset/chilly-paws-pretend.md
+++ b/.changeset/chilly-paws-pretend.md
@@ -1,0 +1,12 @@
+---
+"@justeattakeaway/pie-stylelint-config": patch
+"@justeattakeaway/pie-eslint-config": patch
+"@justeattakeaway/pie-button": patch
+"@justeattakeaway/pie-icons-react": patch
+"@justeattakeaway/pie-icons-vue": patch
+"@justeattakeaway/pie-icons": patch
+"wc-vue3": patch
+"pie-storybook": patch
+---
+
+Add missing Volta settings to package.json

--- a/apps/examples/wc-vue3/package.json
+++ b/apps/examples/wc-vue3/package.json
@@ -20,5 +20,8 @@
     "npm-run-all": "4.1.5",
     "typescript": "~4.8.4",
     "vue-tsc": "1.2.0"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/apps/pie-storybook/package.json
+++ b/apps/pie-storybook/package.json
@@ -22,5 +22,8 @@
     "react-dom": "18.2.0",
     "serve": "14.1.2",
     "storybook": "7.0.0-beta.40"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/components/pie-button/package.json
+++ b/packages/components/pie-button/package.json
@@ -11,5 +11,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "JustEatTakeaway - Design System Web Team",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "volta": {
+    "extends": "../../../package.json"
+  }
 }

--- a/packages/tools/pie-eslint-config/package.json
+++ b/packages/tools/pie-eslint-config/package.json
@@ -33,5 +33,8 @@
   "peerDependencies": {
     "eslint": "7.x || 8.x",
     "eslint-plugin-import": "^2.26.0"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/tools/pie-icons-react/package.json
+++ b/packages/tools/pie-icons-react/package.json
@@ -47,5 +47,8 @@
     "rollup-plugin-delete": "2.0.0",
     "rollup-plugin-typescript2": "0.30.0",
     "typescript": "4.8.4"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/tools/pie-icons-vue/package.json
+++ b/packages/tools/pie-icons-vue/package.json
@@ -57,5 +57,8 @@
     "marked": "1.2.5",
     "pascal-case": "3.1.2",
     "prismjs": "1.28.0"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/tools/pie-icons/package.json
+++ b/packages/tools/pie-icons/package.json
@@ -40,5 +40,8 @@
   },
   "jest": {
     "testEnvironment": "jsdom"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/tools/pie-stylelint-config/package.json
+++ b/packages/tools/pie-stylelint-config/package.json
@@ -26,5 +26,8 @@
   },
   "jest": {
     "testEnvironment": "jsdom"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Add missing Volta settings to package.json

Volta doesn't inherit the settings from the monorepo root as some might expect. `cd`ing into any directory will lead node to use whatever version is installed in the developer environment, and this can easily lead to confusion and random outcomes.

References:
- [GH issue](https://github.com/volta-cli/volta/issues/862)
- [GH issue](https://github.com/volta-cli/volta/issues/378)
- [Volta documentation](https://docs.volta.sh/advanced/workspaces)

`pie-docs` wasn't updated because it already has the necessary settings.