### PR TITLE
fix(pie-docs): sticky nav on wider viewports now sticky again

### DIFF
--- a/.changeset/great-pants-rule.md
+++ b/.changeset/great-pants-rule.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Fixed] Sticky nav on wider viewports now sticky again

--- a/apps/pie-docs/src/assets/styles/components/_nav.scss
+++ b/apps/pie-docs/src/assets/styles/components/_nav.scss
@@ -40,6 +40,7 @@ $nav-item-left-margin: calc($nav-category-gap + $nav-category-icon-width);
 
     .c-nav-inner {
         position: sticky;
+        top: 0;
         height: 100%; // 100% of the parent .c-nav container
         overflow-y: auto;
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] Sticky nav on wider viewports now sticky again


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them
