### PR TITLE
fix(pie-button): remove global declare statement

### DIFF
--- a/.changeset/clean-kids-give.md
+++ b/.changeset/clean-kids-give.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": minor
+---
+
+[Removed] Global declare statement

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -64,9 +64,3 @@ export class PieButton extends LitElement {
     // Renders a `CSSResult` generated from SCSS by Vite
     static styles = unsafeCSS(styles);
 }
-
-declare global {
-    interface HTMLElementTagNameMap {
-        'pie-button': PieButton;
-    }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,7 +3625,7 @@ __metadata:
     "@babel/node": 7.20.7
     "@babel/preset-env": 7.20.2
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-icons": 2.1.0
+    "@justeattakeaway/pie-icons": 2.2.0
     "@svgr/core": 6.4.0
     "@types/react": 18.0.31
     babel-jest: 29.5.0
@@ -3645,7 +3645,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-vue@workspace:packages/tools/pie-icons-vue"
   dependencies:
-    "@justeattakeaway/pie-icons": 2.1.0
+    "@justeattakeaway/pie-icons": 2.2.0
     "@vue/babel-helper-vue-jsx-merge-props": 1.4.0
     "@vue/babel-preset-jsx": 1.4.0
     bili: 3.4.2
@@ -3658,7 +3658,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons@2.1.0, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
+"@justeattakeaway/pie-icons@2.2.0, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons@workspace:packages/tools/pie-icons"
   dependencies:
@@ -21591,7 +21591,7 @@ __metadata:
     "@justeat/fozzie": 10.11.1
     "@justeat/pie-design-tokens": 4.2.0
     "@justeat/stylelint-config-fozzie": 3.x
-    "@justeattakeaway/pie-icons": 2.1.0
+    "@justeattakeaway/pie-icons": 2.2.0
     "@percy/cli": 1.20.3
     "@percy/playwright": 1.0.4
     "@playwright/test": 1.31.2


### PR DESCRIPTION
[Removed] Global declare statement

There seems to be a problem with using a global declare statement within the example projects (nuxt3). From what I can see this isn't necessary for LitElement based custom element to work. It looks like the declaration is mainly for TypeScript to provide strong typing with regards to the dom API. 