### PR TITLE
ci(pie-monorepo): Only run PR deployments against PRs

### DIFF
--- a/.changeset/tame-years-change.md
+++ b/.changeset/tame-years-change.md
@@ -2,4 +2,4 @@
 "pie-monorepo": patch
 ---
 
-[Changed] Don't run deployment status CI steps on main branch
+[Changed] Only run PR-related CI steps for pull requests

--- a/.changeset/tame-years-change.md
+++ b/.changeset/tame-years-change.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Changed] Don't run deployment status CI steps on main branch

--- a/.github/actions/amplify-deploy/action.yml
+++ b/.github/actions/amplify-deploy/action.yml
@@ -75,8 +75,7 @@ runs:
         aws amplify start-deployment \
           --app-id ${{ inputs.amplify-app-id }} \
           --branch-name ${{ inputs.branch-name }} \
-          --source-url https://${{ inputs.bucket-name }}.s3.${{ inputs.aws-region }}.amazonaws.com/${{ inputs.package-name }}-pr-${{ github.event.number }}.zip \
-          --debug
+          --source-url https://${{ inputs.bucket-name }}.s3.${{ inputs.aws-region }}.amazonaws.com/${{ inputs.package-name }}-pr-${{ github.event.number }}.zip
       env:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           package-name: 'pie-docs'
       # If successful
       - name: Update deployment status (success)
-        if: success()
+        if: ${{ github.ref != 'refs/heads/main' && success() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
           state: "success"
       # If it failed
       - name: Update deployment status (failure)
-        if: failure()
+        if: ${{ github.ref != 'refs/heads/main' && failure() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +226,7 @@ jobs:
           package-name: 'pie-storybook'
       # If successful
       - name: Update deployment status (success)
-        if: success()
+        if: ${{ github.ref != 'refs/heads/main' && success() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -235,7 +235,7 @@ jobs:
           state: "success"
       # If it failed
       - name: Update deployment status (failure)
-        if: failure()
+        if: ${{ github.ref != 'refs/heads/main' && failure() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,42 +119,42 @@ jobs:
       # Build Docs Site
       - name: Build Docs Site
         run: yarn build --filter=pie-docs
-      # Deployments
+      # Create Github Deployment
       - name: Create Docs GitHub deployment
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: chrnorm/deployment-action@v2
         id: docs-deploy
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment: "pie-docs-pr-${{github.event.number}}"
+          environment: "pie-docs-pr-${{ github.event.number }}"
       # Amplify Deploy
       - name: Amplify Deploy
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/amplify-deploy
         with:
           amplify-app-id: ${{ env.DOCS_AMPLIFY_ID }}
           aws-region: 'eu-west-1'
           aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          branch-name: 'pr${{github.event.number}}'
+          branch-name: 'pr${{ github.event.number }}'
           bucket-name: ${{ secrets.AWS_DOCS_BUCKET }}
           package-name: 'pie-docs'
       # If successful
       - name: Update deployment status (success)
-        if: ${{ github.ref != 'refs/heads/main' && success() }}
+        if: ${{ github.event_name == 'pull_request' && success() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: https://pr${{github.event.number}}.${{ env.DOCS_AMPLIFY_ID }}.amplifyapp.com
+          environment-url: https://pr${{ github.event.number }}.${{ env.DOCS_AMPLIFY_ID }}.amplifyapp.com
           deployment-id: ${{ steps.docs-deploy.outputs.deployment_id }}
           state: "success"
       # If it failed
       - name: Update deployment status (failure)
-        if: ${{ github.ref != 'refs/heads/main' && failure() }}
+        if: ${{ github.event_name == 'pull_request' && failure() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: https://pr${{github.event.number}}.${{ env.DOCS_AMPLIFY_ID }}.amplifyapp.com
+          environment-url: https://pr${{ github.event.number }}.${{ env.DOCS_AMPLIFY_ID }}.amplifyapp.com
           deployment-id: ${{ steps.docs-deploy.outputs.deployment_id }}
           state: "failure"
       # Main deployments
@@ -206,40 +206,40 @@ jobs:
         run: yarn build --filter=pie-storybook
       # Deployments
       - name: Create Storybook GitHub deployment
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: chrnorm/deployment-action@v2
         id: storybook-deploy
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment: "pie-storybook-pr-${{github.event.number}}"
+          environment: "pie-storybook-pr-${{ github.event.number }}"
       # Amplify Deploy
       - name: Amplify Deploy
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: ./.github/actions/amplify-deploy
         with:
           amplify-app-id: ${{ env.STORYBOOK_AMPLIFY_ID }}
           aws-region: 'eu-west-1'
           aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          branch-name: 'pr${{github.event.number}}'
+          branch-name: 'pr${{ github.event.number }}'
           bucket-name: '${{ secrets.AWS_STORYBOOK_BUCKET }}'
           package-name: 'pie-storybook'
       # If successful
       - name: Update deployment status (success)
-        if: ${{ github.ref != 'refs/heads/main' && success() }}
+        if: ${{ github.event_name == 'pull_request' && success() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: https://pr${{github.event.number}}.${{ env.STORYBOOK_AMPLIFY_ID }}.amplifyapp.com
+          environment-url: https://pr${{ github.event.number }}.${{ env.STORYBOOK_AMPLIFY_ID }}.amplifyapp.com
           deployment-id: ${{ steps.storybook-deploy.outputs.deployment_id }}
           state: "success"
       # If it failed
       - name: Update deployment status (failure)
-        if: ${{ github.ref != 'refs/heads/main' && failure() }}
+        if: ${{ github.event_name == 'pull_request' && failure() }}
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: https://pr${{github.event.number}}.${{ env.STORYBOOK_AMPLIFY_ID }}.amplifyapp.com
+          environment-url: https://pr${{ github.event.number }}.${{ env.STORYBOOK_AMPLIFY_ID }}.amplifyapp.com
           deployment-id: ${{ steps.storybook-deploy.outputs.deployment_id }}
           state: "failure"
       # Main deployments


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Some of the steps are running against the main branch (or merge queues) when they shouldn't be, this should fix that.

Now that we've disabled merge queues this isn't essential, but it's a good safeguard against any other potential issues in future.

e.g., https://github.com/justeattakeaway/pie/actions/runs/4676632186/jobs/8283287361


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
