### PR TITLE
fix(pie-monorepo): correct existing changeset files to no longer version example apps

### DIFF
--- a/.changeset/polite-cooks-double.md
+++ b/.changeset/polite-cooks-double.md
@@ -1,9 +1,9 @@
 ---
 "pie-monorepo": minor
 "@justeattakeaway/pie-icons-react": patch
-"wc-next13": patch
-"wc-nuxt3": patch
-"wc-vue3": patch
+"pie-monorepo": patch
+"pie-monorepo": patch
+"pie-monorepo": patch
 ---
 
 [Changed] - Updated Typescript to v5 and tidied up some of the package.json entries and versions

--- a/apps/examples/wc-next10/package.json
+++ b/apps/examples/wc-next10/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wc-next10",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/examples/wc-next13/package.json
+++ b/apps/examples/wc-next13/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wc-next13",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/examples/wc-nuxt2/package.json
+++ b/apps/examples/wc-nuxt2/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wc-nuxt2",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/apps/examples/wc-nuxt3/package.json
+++ b/apps/examples/wc-nuxt3/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wc-nuxt3",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "build": "nuxt build",

--- a/apps/examples/wc-react18/package.json
+++ b/apps/examples/wc-react18/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wc-react18",
-  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@justeattakeaway/pie-button": "^0.10.1",

--- a/apps/examples/wc-vue3/package.json
+++ b/apps/examples/wc-vue3/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wc-vue3",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This PR fixes a bug where example apps were trying to be versioned

## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
