### PR TITLE
ci(pie-monorepo): pass environment variables to changeset action

### DIFF
--- a/.changeset/eighty-emus-think.md
+++ b/.changeset/eighty-emus-think.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Fixed] - Issue where tokens weren't being provided to Changeset composite action

--- a/.github/actions/changeset-release/action.yml
+++ b/.github/actions/changeset-release/action.yml
@@ -7,6 +7,7 @@ inputs:
       required: true
   github-token:
       description: 'The github token used for creating version PRs & tagging.'
+      required: true
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ concurrency:
 
 env:
   DOCS_AMPLIFY_ID: dvskdcoepjoyf
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   STORYBOOK_AMPLIFY_ID: d17ja0ul7nrdy0
   HUSKY: 0
   PERCY_TOKEN_PIE_DOCS: ${{ secrets.PERCY_TOKEN_PIE_DOCS }}
@@ -352,3 +351,6 @@ jobs:
           script-name: "build"
       - name: Changeset Release
         uses: ./.github/actions/changeset-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Fixed] - Issue where tokens weren't being provided to Changeset composite action

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
