### PR TITLE
ci(pie-monorepo): add environment variable to changeset action

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -23,6 +23,8 @@ env:
 jobs:
   changesets:
     runs-on: ${{ inputs.os }}
+    if: github.repository == 'justeattakeaway/pie' && ${{ github.event_name != 'pull_request' }} &&
+      (contains(github.ref_name, 'main') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'feature'))
     steps:
     # Checkout the Repo
     - name: Checkout
@@ -42,6 +44,8 @@ jobs:
         EOF
     # Build Packages
     - name: Build
+      if: ${{ github.event_name != 'pull_request' }} &&
+        (contains(github.ref_name, 'main') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'feature'))
       uses: ./.github/actions/run-script
       with:
         script-name: "build"
@@ -53,10 +57,10 @@ jobs:
     - name: exit prerelease mode
       # If .changeset/pre.json does not exist and we did not recently exit
       # prerelease mode.
-      # if: steps.check_files.outputs.files_exists == 'true' && contains(github.ref_name, 'main')
+      if: steps.check_files.outputs.files_exists == 'true' && contains(github.ref_name, 'main')
       run: npx changeset pre exit
     - name: Create latest release PR
-      # if: contains(github.ref_name, 'main')
+      if: contains(github.ref_name, 'main')
       uses: changesets/action@v1
       with:
         version: yarn changeset:version

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -23,8 +23,6 @@ env:
 jobs:
   changesets:
     runs-on: ${{ inputs.os }}
-    if: github.repository == 'justeattakeaway/pie' && ${{ github.event_name != 'pull_request' }} &&
-      (contains(github.ref_name, 'main') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'feature'))
     steps:
     # Checkout the Repo
     - name: Checkout
@@ -44,8 +42,6 @@ jobs:
         EOF
     # Build Packages
     - name: Build
-      if: ${{ github.event_name != 'pull_request' }} &&
-        (contains(github.ref_name, 'main') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'feature'))
       uses: ./.github/actions/run-script
       with:
         script-name: "build"

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -18,6 +18,7 @@ env:
   HUSKY: 0
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   changesets:

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -53,10 +53,10 @@ jobs:
     - name: exit prerelease mode
       # If .changeset/pre.json does not exist and we did not recently exit
       # prerelease mode.
-      if: steps.check_files.outputs.files_exists == 'true' && contains(github.ref_name, 'main')
+      # if: steps.check_files.outputs.files_exists == 'true' && contains(github.ref_name, 'main')
       run: npx changeset pre exit
     - name: Create latest release PR
-      if: contains(github.ref_name, 'main')
+      # if: contains(github.ref_name, 'main')
       uses: changesets/action@v1
       with:
         version: yarn changeset:version


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
This PR adds the GITHUB_TOKEN to the changeset dispatchable workflow action

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
