### PR TITLE
Upgrade lit ssr dom shim

### DIFF
--- a/.changeset/shiny-buses-rush.md
+++ b/.changeset/shiny-buses-rush.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": patch
+---
+
+[Removed] the custom decorator and uses the native `customElement` decorator instead

--- a/.changeset/tender-bears-accept.md
+++ b/.changeset/tender-bears-accept.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+- [Updated] Yarn module resolution for `@lit-labs/ssr-dom-shim` to use the latest version (1.1.1)

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -9,16 +9,7 @@ import { BUTTON_SIZE, BUTTON_TYPE, BUTTON_VARIANT } from './defs';
 // Valid values available to consumers
 export { BUTTON_SIZE, BUTTON_TYPE, BUTTON_VARIANT };
 
-// TODO: Extract as a utility function in a shared package
-function defineCustomElement(elementName:string) {
-    return (elementClass:typeof LitElement) => {
-        if(customElements.get(elementName)) return;
-
-        return customElement(elementName)(elementClass);
-    }
-}
-
-@defineCustomElement('pie-button')
+@customElement('pie-button')
 export class PieButton extends LitElement {
     @property()
     @validPropertyValues(Object.values(BUTTON_SIZE), BUTTON_SIZE.MEDIUM)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4254,9 +4254,9 @@ __metadata:
   linkType: hard
 
 "@lit-labs/ssr-dom-shim@npm:^1.0.0, @lit-labs/ssr-dom-shim@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@lit-labs/ssr-dom-shim@npm:1.1.0"
-  checksum: 7d6f2331418164ee65816db0670b0a958572c6b91c95e3b41bc1874c6f1465febbe8ac88d4f8367d69fbaba44820d7b255c5e384beab61fa7ee4135d1694b603
+  version: 1.1.1
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.1.1"
+  checksum: 7a7add78e3ee570a7b987b9bf85e700b20d35d31c8b54cf4c8b2e3c8458ed4e2b0ff328706e5be7887f0ca8a02878c186e76609defb78f0d1b3c0e6b47c9f6ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [Updated] Yarn module resolution for `@lit-labs/ssr-dom-shim` to use the latest version (1.1.1)
- [Removed] the custom decorator and uses the native `customElement` decorator instead

## Context

More about the context can be found in this [GH discussion](https://github.com/justeattakeaway/pie/discussions/408).

The Lit team released [version 1.1.1](https://github.com/lit/lit/blob/main/packages/labs/ssr-dom-shim/CHANGELOG.md#111) of `@lit-labs/ssr-dom-shim` that solves the issue with Next.js dev mode reloads.

The new package was tested with both Next.js 10 and 13 example apps.