### PR TITLE
cosmetic(pie-button): new primary colour and larger size

### DIFF
--- a/.changeset/brown-bananas-grin.md
+++ b/.changeset/brown-bananas-grin.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": minor
+---
+
+[Changed] - Using a new colour for primary buttons and larger height for the large size

--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -3,7 +3,7 @@
 $button-height-xs: 32px;
 $button-height-s: 40px;
 $button-height-m: 48px;
-$button-height-l: 56px;
+$button-height-l: 70px;
 
 $button-border-radius: dt.$radius-rounded-e;
 $button-font: dt.$font-interactive-m-family;
@@ -128,7 +128,7 @@ $button-sizes: (
 
 // Variants
 .o-btn--primary {
-    @include button-variant($button-bg-color-primary, $button-text-color-primary);
+    @include button-variant(saddlebrown, $button-text-color-primary);
 }
 
 .o-btn--secondary {


### PR DESCRIPTION
# This is not a real PR

[Changed] - Using a new colour for primary buttons and larger height for the large size

This PR introduces a new background colour for primary buttons, and increases the size to `70px` for `large` buttons.