### PR TITLE
chore(pie-monorepo): correct renovate config & add example app groupings

### DIFF
--- a/.changeset/fuzzy-stingrays-protect.md
+++ b/.changeset/fuzzy-stingrays-protect.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Fixed] - Invalid JSON in `renovate.json`

--- a/.changeset/shy-onions-turn.md
+++ b/.changeset/shy-onions-turn.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Added] - New renovate groupings for example apps

--- a/renovate.json
+++ b/renovate.json
@@ -129,6 +129,16 @@
       "enabled": true
     },
     {
+      "commitMessagePrefix": "chore(wc-next10): ",
+      "description": "Group dependencies from package.json within wc-next10",
+      "matchFiles": ["apps/examples/wc-next10/package.json"],
+      "matchDepTypes": ["devDependencies", "dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "wc-next10",
+      "groupSlug": "wc-next10-deps",
+      "enabled": true
+    },
+    {
       "commitMessagePrefix": "chore(wc-next13): ",
       "description": "Group dependencies from package.json within wc-next13",
       "matchFiles": ["apps/examples/wc-next13/package.json"],
@@ -136,6 +146,16 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "wc-next13",
       "groupSlug": "wc-next13-deps",
+      "enabled": true
+    },
+    {
+      "commitMessagePrefix": "chore(wc-nuxt2): ",
+      "description": "Group dependencies from package.json within wc-nuxt2",
+      "matchFiles": ["apps/examples/wc-nuxt2/package.json"],
+      "matchDepTypes": ["devDependencies", "dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "wc-nuxt2",
+      "groupSlug": "wc-nuxt2-deps",
       "enabled": true
     },
     {
@@ -157,7 +177,7 @@
       "groupName": "wc-react17",
       "groupSlug": "wc-react17-deps",
       "enabled": true
-    }
+    },
     {
       "commitMessagePrefix": "chore(wc-react18): ",
       "description": "Group dependencies from package.json within wc-react18",
@@ -166,6 +186,16 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "wc-react18",
       "groupSlug": "wc-react18-deps",
+      "enabled": true
+    },
+    {
+      "commitMessagePrefix": "chore(wc-vanilla): ",
+      "description": "Group dependencies from package.json within wc-vanilla",
+      "matchFiles": ["apps/examples/wc-vanilla/package.json"],
+      "matchDepTypes": ["devDependencies", "dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "wc-vanilla",
+      "groupSlug": "wc-vanilla-deps",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Added] - New renovate groupings for example apps
[Fixed] - Invalid JSON in `renovate.json`
## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
