### PR TITLE
fix(pie-docs): fix missing token for nav icon fill

### DIFF
--- a/.changeset/gorgeous-buses-buy.md
+++ b/.changeset/gorgeous-buses-buy.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Changed] - ensure pieDesignTokenColours.js throws an error if a token is undefined

--- a/.changeset/light-cameras-rush.md
+++ b/.changeset/light-cameras-rush.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Changed] - use content-default colour design token for nav icon svg fill. Previous token no longer existed and was empty

--- a/apps/pie-docs/src/_11ty/filters/pieDesignTokenColours.js
+++ b/apps/pie-docs/src/_11ty/filters/pieDesignTokenColours.js
@@ -24,10 +24,11 @@ module.exports = function (options = {
     tokenName: '',
     tokenPath: [],
 }) {
-    try {
-        return getDesignTokenColour(options.tokenName, options.tokenPath);
-    } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(`Could not find design token color of name: ${options.tokenName}. Error: ${error}`);
+    const colourValue = getDesignTokenColour(options.tokenName, options.tokenPath);
+
+    if (!colourValue || colourValue === '') {
+        throw new Error(`No colour value found for design token ${options.tokenName}`);
     }
+
+    return colourValue;
 };

--- a/apps/pie-docs/src/_includes/header.njk
+++ b/apps/pie-docs/src/_includes/header.njk
@@ -1,4 +1,4 @@
-{% set toggleIconFill = { tokenName: 'interactive-dark', tokenPath: ['alias', 'default'] } | pieDesignTokenColours %}
+{% set toggleIconFill = { tokenName: 'content-default', tokenPath: ['alias', 'default'] } | pieDesignTokenColours %}
 <input id="navToggle" class="c-navToggle-input is-visuallyHidden" data-test-id='nav_toggle_input' type="checkbox" aria-label="Toggle Navigation"/>
 <label class="c-navToggle" data-test-id='nav_toggle_label' for="navToggle" style="--icon-fill: {{ toggleIconFill }};">
     {{ { name: 'menu', attrs: { fill: toggleIconFill, height: '24', width: '24', class: 'u-iconFilled' } } | pieIconsSvg | safe }}


### PR DESCRIPTION
[Changed] - ensure pieDesignTokenColours.js throws an error if a token is undefined
[Changed] - use content-default colour design token for nav icon svg fill. Previous token no longer existed and was empty

### Context

I was running the docs site through an HTML validator and spotted that the `--icon-fill` CSS custom property value was missing. This is because the `header.njk` was querying for a token, `interactive-dark` which no longer exists. The JS function retrieving the colour was silently failing, which led to the value being empty. By luck, the SVG was falling back to a dark colour so it wasn't very noticeable.

I have updated the JS function to throw a build error to prevent this happening again, and updated the icon fill to use the `content-default` token as specified in the Figma design.

### Before (on Production)
<img width="530" alt="Screenshot 2023-05-12 at 12 12 47" src="https://github.com/justeattakeaway/pie/assets/16766185/78490e60-9045-47ea-9e08-990c981883b4">

### The build error you'd now see if it happens again
<img width="438" alt="Screenshot 2023-05-12 at 12 12 54" src="https://github.com/justeattakeaway/pie/assets/16766185/a90f0c02-db6a-4274-a80d-4dc25d5c8b6b">

### After
<img width="528" alt="Screenshot 2023-05-12 at 12 20 58" src="https://github.com/justeattakeaway/pie/assets/16766185/a6471098-4af1-4034-81eb-de9cc311a3a6">

