### PR TITLE
fix(pie-monorepo): Remove duplicate caching functionality to prevent issues with node_modules cache

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -18,13 +18,6 @@ runs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: "yarn"
-      # Restore node_modules if cache exists. If not, cache is created at end of build.
-      - name: Cache Node Modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: node-modules-${{ inputs.node-version }}-${{ inputs.os }}-${{ hashFiles('**/yarn.lock') }}
       # Run 'yarn' if cache doesn't exist. Use --prefer-offline to download packages from yarn cache folder where possible
       - name: Install Dependencies
         shell: bash


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
This PR fixes an issue around our usage on node_modules caching. It should prevent issues like this occuring:
https://github.com/justeattakeaway/pie/actions/runs/5000836437/jobs/8958758557

Turns out we don't actually need to use `actions/cache`, as the `setup-node` action handles caching for us under-the-hood - https://github.com/actions/setup-node#caching-global-packages-data



## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
