### PR TITLE
refactor(pie-icons): fix vulnerability in pie-icons

### DIFF
--- a/.changeset/five-dolphins-relax.md
+++ b/.changeset/five-dolphins-relax.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-icons-react": patch
+"@justeattakeaway/pie-icons-vue": patch
+"@justeattakeaway/pie-icons": patch
+---
+
+[Changed] - Replaced html-minifier by html-minifier-terser
+[Changed] - Updated icons object builder function and script to async

--- a/packages/tools/pie-icons/bin/build-icons-json.js
+++ b/packages/tools/pie-icons/bin/build-icons-json.js
@@ -4,17 +4,23 @@ import path from 'path';
 import getAllSvgs from './get-svgs';
 import buildIconsObject from './build-icons-object';
 
-const IN_DIR = `${process.cwd()}/src/assets/_optimised`; // get optimised SVG files
-const OUT_FILE = `${process.cwd()}/dist/icons.json`;
+/**
+ * Read SVG files and write a JSON file for an object in the format: `{ <icon-name>: {attrs:Object, content:string } }`
+ */
+async function buildIconsJson () {
+    const IN_DIR = `${process.cwd()}/src/assets/_optimised`; // get optimised SVG files
+    const OUT_FILE = `${process.cwd()}/dist/icons.json`;
 
-console.log(`Building ${OUT_FILE}...`);
+    console.log(`Building ${OUT_FILE}...`);
 
-const svgFiles = getAllSvgs(IN_DIR)
-    .filter((file) => path.extname(file.fileName) === '.svg')
-    .map((file) => path.join(file.path, file.fileName));
+    const svgFiles = getAllSvgs(IN_DIR)
+        .filter((file) => path.extname(file.fileName) === '.svg')
+        .map((file) => path.join(file.path, file.fileName));
 
-const getSvg = (svgFile) => fs.readFileSync(svgFile);
+    const getSvg = (svgFile) => fs.readFileSync(svgFile);
+    const icons = await buildIconsObject(svgFiles, getSvg);
 
-const icons = buildIconsObject(svgFiles, getSvg);
+    fs.writeFileSync(OUT_FILE, JSON.stringify(icons));
+}
 
-fs.writeFileSync(OUT_FILE, JSON.stringify(icons));
+buildIconsJson();

--- a/packages/tools/pie-icons/package.json
+++ b/packages/tools/pie-icons/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "cheerio": "1.0.0-rc.12",
     "classnames": "2.3.2",
-    "html-minifier": "4.0.0",
     "prettier": "2.8.7",
     "svgo": "3.0.2"
   },

--- a/packages/tools/pie-icons/package.json
+++ b/packages/tools/pie-icons/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "cheerio": "1.0.0-rc.12",
     "classnames": "2.3.2",
+    "html-minifier-terser": "7.2.0",
     "prettier": "2.8.7",
     "svgo": "3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,6 +4224,7 @@ __metadata:
   dependencies:
     cheerio: 1.0.0-rc.12
     classnames: 2.3.2
+    html-minifier-terser: 7.2.0
     lint-staged: 12.5.0
     nodemon: 2.0.22
     prettier: 2.8.7
@@ -12224,7 +12225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-css@npm:^5.2.2":
+"clean-css@npm:^5.2.2, clean-css@npm:~5.3.2":
   version: 5.3.2
   resolution: "clean-css@npm:5.3.2"
   dependencies:
@@ -12618,6 +12619,13 @@ __metadata:
   dependencies:
     delayed-stream: ~1.0.0
   checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
+  languageName: node
+  linkType: hard
+
+"commander@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "commander@npm:10.0.1"
+  checksum: 436901d64a818295803c1996cd856621a74f30b9f9e28a588e726b2b1670665bccd7c1a77007ebf328729f0139838a88a19265858a0fa7a8728c4656796db948
   languageName: node
   linkType: hard
 
@@ -18599,6 +18607,23 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
+  languageName: node
+  linkType: hard
+
+"html-minifier-terser@npm:7.2.0":
+  version: 7.2.0
+  resolution: "html-minifier-terser@npm:7.2.0"
+  dependencies:
+    camel-case: ^4.1.2
+    clean-css: ~5.3.2
+    commander: ^10.0.0
+    entities: ^4.4.0
+    param-case: ^3.0.4
+    relateurl: ^0.2.7
+    terser: ^5.15.1
+  bin:
+    html-minifier-terser: cli.js
+  checksum: 39feed354b5a8aafc8e910977d68cfd961d6db330a8e1a5b16a528c86b8ee7745d8945134822cf00acf7bf0d0135bf1abad650bf308bee4ea73adb003f5b8656
   languageName: node
   linkType: hard
 
@@ -33305,6 +33330,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: 4bb4bbee170bee4cf897545b602999e0b74d2cd035387514c6859fae6a71d623f8d1319de47bcf6a157358355cc7afaa62a5d5661bfc72968d13b35113022486
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.15.1":
+  version: 5.17.5
+  resolution: "terser@npm:5.17.5"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.2
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: f9990932a62ef6fcc424894f483d71aa647b0524ac18167f945201a32401c09702e480a3198dcaf9d6d755243d3d73c13418cdb28711ef167c028d3ff2a866bf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,7 +4224,6 @@ __metadata:
   dependencies:
     cheerio: 1.0.0-rc.12
     classnames: 2.3.2
-    html-minifier: 4.0.0
     lint-staged: 12.5.0
     nodemon: 2.0.22
     prettier: 2.8.7
@@ -18637,7 +18636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-minifier@npm:4.0.0, html-minifier@npm:^4.0.0":
+"html-minifier@npm:^4.0.0":
   version: 4.0.0
   resolution: "html-minifier@npm:4.0.0"
   dependencies:


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### @justeattakeaway/pie-icons

[Changed] - Replaced `html-minifier` by `html-minifier-terser`
[Changed] - Updated icons object builder function and script to async

## Author Checklist (complete before requesting a review)
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
