### PR TITLE
test(pie-docs): added colour page toggle system test

### DIFF
--- a/.changeset/tidy-carrots-shave.md
+++ b/.changeset/tidy-carrots-shave.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": major
+---
+
+[Added] - Colour page toggle test

--- a/apps/pie-docs/src/_includes/layouts/toggle-page-layout.njk
+++ b/apps/pie-docs/src/_includes/layouts/toggle-page-layout.njk
@@ -13,6 +13,7 @@ bodyDataAttribute: data-toggle-page
 <div class="c-toggle u-spacing-e--top">
     <div
         id="toggle-option-a-wrapper"
+        data-test-id="toggle-option-a"
         class="c-toggle-item {% if isToggleASelected %}is-active{% endif %}">
         <input
             id="toggle-option-a"
@@ -27,6 +28,7 @@ bodyDataAttribute: data-toggle-page
     </div>
     <div
         id="toggle-option-b-wrapper"
+        data-test-id="toggle-option-b"
         class="c-toggle-item {% if not isToggleASelected %}is-active{% endif %}">
         <input
             id="toggle-option-b"

--- a/apps/pie-docs/test/system/colour-toggle.spec.js
+++ b/apps/pie-docs/test/system/colour-toggle.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { disableCookieBanner } from '../playwright/playwright-helper';
+
+test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(baseURL);
+});
+
+test.describe('PIE - colour page toggle - @desktop', () => {
+    test.beforeEach(async ({ page, context }) => {
+        await disableCookieBanner(page, context);
+    });
+
+    test('Should check the functionality of the colour page toggle', async ({ page }) => {
+        // Arrange
+        await page.goto('foundations/colour/tokens/alias/light');
+
+        const toggleOptionA = page.getByTestId('toggle-option-a');
+        const toggleOptionB = page.getByTestId('toggle-option-b');
+
+        const lightTokens = page.locator('[id="toggle-content-a"]');
+        const darkTokens = page.locator('[id="toggle-content-b"]');
+
+        // Act - Clicks the dark theme toggle
+        await toggleOptionB.click();
+
+        // Assert - Dark tokens are visible and the light tokens are not visible
+        await expect.soft(darkTokens).toBeVisible();
+        await expect.soft(lightTokens).not.toBeVisible();
+
+        // Act - Clicks the light theme toggle
+        await toggleOptionA.click();
+
+        // Assert - Light tokens are visible and the dark tokens are not visible
+        await expect.soft(lightTokens).toBeVisible();
+        await expect(darkTokens).not.toBeVisible();
+    });
+});

--- a/apps/pie-docs/test/system/colour-toggle.spec.js
+++ b/apps/pie-docs/test/system/colour-toggle.spec.js
@@ -10,7 +10,7 @@ test.describe('PIE - colour page toggle - @desktop', () => {
         await disableCookieBanner(page, context);
     });
 
-    test('Should check the functionality of the colour page toggle', async ({ page }) => {
+    test('Should display the content associated with the toggle that has been clicked', async ({ page }) => {
         // Arrange
         await page.goto('foundations/colour/tokens/alias/light');
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Test added for testing the page toggle on the Pie Docs colour page.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
