### PR TITLE
feat(pie-modal): add basic styling for the opened state

### DIFF
--- a/.changeset/good-drinks-compare.md
+++ b/.changeset/good-drinks-compare.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Added] - Modal heading added to component
+[Added] - Basic styling for modal default state

--- a/.changeset/new-actors-wave.md
+++ b/.changeset/new-actors-wave.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-wrapper-react": minor
+---
+
+[Changed] - Custom Element Definitions

--- a/.changeset/polite-waves-buy.md
+++ b/.changeset/polite-waves-buy.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Changed] - Added modal component to storybook file

--- a/.changeset/strong-doors-walk.md
+++ b/.changeset/strong-doors-walk.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Changed] - yarn.lock

--- a/apps/pie-storybook/stories/pie-modal.stories.ts
+++ b/apps/pie-storybook/stories/pie-modal.stories.ts
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
+import { PieModal } from '@justeattakeaway/pie-modal';
 import { html, TemplateResult } from 'lit';
+
+const keptReference = PieModal; // TODO: Remove this const when other exports from PieModal are used on Stories, otherwise tree-shaking will get rid of the web component definition
 
 export default {
     title: 'Modal',

--- a/packages/components/pie-modal/package.json
+++ b/packages/components/pie-modal/package.json
@@ -10,7 +10,9 @@
     "build": "yarn build:wrapper pie-modal && run -T vite build",
     "watch": "run -T vite build --watch",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "test:ci": "yarn test"
+    "test:ci": "yarn test",
+    "test:visual": "run -T cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_PIE_MODAL} percy exec --allowed-hostname cloudfront.net -- npx playwright test -c ./playwright-lit-visual.config.ts",
+    "test:visual:ci": "yarn test:visual"
   },
   "author": "JustEatTakeaway - Design System Web Team",
   "license": "Apache-2.0",

--- a/packages/components/pie-modal/playwright-lit-visual.config.ts
+++ b/packages/components/pie-modal/playwright-lit-visual.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@sand4rt/experimental-ct-web';
+import { getPlaywrightVisualConfig } from '@justeattakeaway/pie-components-config';
+
+// @ts-ignore
+export default defineConfig(getPlaywrightVisualConfig());

--- a/packages/components/pie-modal/playwright-lit.config.ts
+++ b/packages/components/pie-modal/playwright-lit.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@sand4rt/experimental-ct-web';
+import { getPlaywrightConfig } from '@justeattakeaway/pie-components-config'
+
+// @ts-ignore
+export default defineConfig(getPlaywrightConfig());

--- a/packages/components/pie-modal/playwright/index.html
+++ b/packages/components/pie-modal/playwright/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Bold-optimised.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-ExtraBold-optimised.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+        @font-face {
+            font-family: JETSansDigital;
+            src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff2') format("woff2"),
+            url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff') format("woff");
+            font-weight: 400;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: JETSansDigital;
+            src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Bold-optimised.woff2') format("woff2"),
+            url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Bold-optimised.woff') format("woff");
+            font-weight: 700;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: JETSansDigital;
+            src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-ExtraBold-optimised.woff2') format("woff2"),
+            url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-ExtraBold-optimised.woff') format("woff");
+            font-weight: 800;
+            font-display: swap;
+        }
+        body {
+            font-feature-settings: "tnum"; /* Enable tabular numbers */
+        }
+        /* basic styles to center align components and give them some spacing */
+        #root {
+            padding: 1em;
+        }
+
+        #root > * {
+            display: block;
+            margin-inline: auto;
+        }
+
+        #root > * + * {
+            margin-top: 1em;
+        }
+    </style>
+    <title>Testing Page</title>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@justeat/pie-design-tokens/dist/jet.css" />
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@justeat/pie-design-tokens/dist/jet-hsl-colors.css" />
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="./index.ts"></script>
+</body>
+</html>

--- a/packages/components/pie-modal/playwright/index.ts
+++ b/packages/components/pie-modal/playwright/index.ts
@@ -1,0 +1,1 @@
+//Import common styles here

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -1,14 +1,23 @@
-import { LitElement, html } from 'lit'; // eslint-disable-line import/no-extraneous-dependencies
+import { LitElement, html, unsafeCSS } from 'lit'; // eslint-disable-line import/no-extraneous-dependencies
 import { RtlMixin } from '@justeattakeaway/pie-webc-core';
+
+import styles from './modal.scss?inline';
 
 export class PieModal extends RtlMixin(LitElement) {
     // eslint-disable-next-line class-methods-use-this
     render () {
         return html`
-            <div>This is the Pie Modal
-                <slot></slot>
-            </div>`;
+            <dialog class="c-modal" open>
+                <h3 class="c-modal-heading">Modal header</h3>
+                <div class="c-modal-contentWrapper">
+                    <slot></slot>
+                </div>
+            </dialog>
+        `;
     }
+
+    // Renders a `CSSResult` generated from SCSS by Vite
+    static styles = unsafeCSS(styles);
 }
 
 customElements.define('pie-modal', PieModal);

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -1,0 +1,51 @@
+$modal-size-l: 1080px;
+$modal-size-m: 600px;
+$modal-size-s: 450px;
+
+$modal-border-radius: var(--dt-radius-rounded-d);
+$modal-font: var(--dt-font-interactive-m-family);
+$modal-bg-color: var(--dt-color-container-default);
+$modal-elevation: var(--dt-elevation-04);
+
+$modal-header-font-size: calc(var(--dt-font-heading-m-size--wide) * 1px);
+$modal-header-font-line-height: calc(var(--dt-font-heading-m-line-height--wide) * 1px);
+$modal-header-font-weight: var(--dt-font-heading-m-weight);
+$modal-header-padding: var(--dt-spacing-e);
+$modal-header-padding-block-end: var(--dt-spacing-d);
+
+$modal-contentWrapper-font-size: calc(var(--dt-font-size-16) * 1px);
+$modal-contentWrapper-line-height: calc(var(--dt-font-size-16-line-height) * 1px);
+$modal-contentWrapper-font-weight: var(--dt-font-weight-regular);
+$modal-contentWrapper-padding: var(--dt-spacing-e);
+$modal-contentWrapper-padding-block-start: var(--dt-spacing-a);
+
+.c-modal {
+  border-radius: $modal-border-radius;
+  border: none;
+  font-family: $modal-font;
+  background-color: $modal-bg-color;
+
+  padding: 0;
+  width: $modal-size-m;
+
+  box-shadow: $modal-elevation;
+
+  & .c-modal-heading {
+    font-size: $modal-header-font-size;
+    line-height: $modal-header-font-line-height;
+    font-weight: $modal-header-font-weight;
+
+    margin: 0;
+    padding-block: $modal-header-padding $modal-header-padding-block-end;
+    padding-inline: $modal-header-padding;
+  }
+
+  & .c-modal-contentWrapper {
+    font-size: $modal-contentWrapper-font-size;
+    line-height: $modal-contentWrapper-line-height;
+    font-weight: $modal-contentWrapper-font-weight;
+
+    padding-block: $modal-contentWrapper-padding-block-start $modal-contentWrapper-padding;
+    padding-inline: $modal-contentWrapper-padding;
+  }
+}

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@sand4rt/experimental-ct-web';
+import percySnapshot from '@percy/playwright';
+import { PieModal } from '@/index';
+
+test('should render Modal', async ({ page, mount }) => {
+    await mount(
+        PieModal,
+        {
+            slots: {
+                default: 'Hello, this is the Pie Modal!',
+            },
+        },
+    );
+
+    await percySnapshot(page, 'PIE Modal');
+});

--- a/packages/tools/pie-wrapper-react/custom-elements.json
+++ b/packages/tools/pie-wrapper-react/custom-elements.json
@@ -4,78 +4,6 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "../../components/pie-modal/src/index.js",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PieModal",
-          "members": [
-            {
-              "kind": "method",
-              "name": "render"
-            },
-            {
-              "kind": "field",
-              "name": "dir",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "inheritedFrom": {
-                "name": "RtlMixin",
-                "module": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "isRTL",
-              "type": {
-                "text": "boolean"
-              },
-              "description": "Returns true if the element is in Right to Left mode.\nIf a dir attribute is not explicitly set on the web component\nthen it falls back to the nearest parent with a dir attribute set.\n\nA dir attribute being set will result in a reactive property.\nIf the component falls back to a parent dir attribute then the value\nwill not be reactive and is only computed once",
-              "readonly": true,
-              "inheritedFrom": {
-                "name": "RtlMixin",
-                "module": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js"
-              }
-            }
-          ],
-          "mixins": [
-            {
-              "name": "RtlMixin",
-              "package": "@justeattakeaway/pie-webc-core"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "pie-modal",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PieModal",
-          "declaration": {
-            "name": "PieModal",
-            "module": "../../components/pie-modal/src/index.js"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "pie-modal",
-          "declaration": {
-            "name": "PieModal",
-            "module": "../../components/pie-modal/src/index.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "../../components/pie-icon-button/src/defs.js",
       "declarations": [],
       "exports": []
@@ -145,6 +73,83 @@
           "declaration": {
             "name": "PieIconButton",
             "module": "../../components/pie-icon-button/src/index.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-modal/src/index.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PieModal",
+          "members": [
+            {
+              "kind": "method",
+              "name": "render"
+            },
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "dir",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "inheritedFrom": {
+                "name": "RtlMixin",
+                "module": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "isRTL",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Returns true if the element is in Right to Left mode.\nIf a dir attribute is not explicitly set on the web component\nthen it falls back to the nearest parent with a dir attribute set.\n\nA dir attribute being set will result in a reactive property.\nIf the component falls back to a parent dir attribute then the value\nwill not be reactive and is only computed once",
+              "readonly": true,
+              "inheritedFrom": {
+                "name": "RtlMixin",
+                "module": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js"
+              }
+            }
+          ],
+          "mixins": [
+            {
+              "name": "RtlMixin",
+              "package": "@justeattakeaway/pie-webc-core"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "pie-modal",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PieModal",
+          "declaration": {
+            "name": "PieModal",
+            "module": "../../components/pie-modal/src/index.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "pie-modal",
+          "declaration": {
+            "name": "PieModal",
+            "module": "../../components/pie-modal/src/index.js"
           }
         }
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4726,6 +4726,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
+    "@justeat/pie-design-tokens": 5.1.0
     "@justeattakeaway/pie-components-config": "workspace:*"
     "@justeattakeaway/pie-webc-core": "workspace:*"
   languageName: unknown


### PR DESCRIPTION
## @justeattakeaway/pie-modal

- [Added] - Basic styling for modal default state
- [Added] - Modal heading added to component
- [Updated] - Added modal component to storybook file

## @justeattakeaway/pie-wrapper-react

[Changed] - Custom Element Definitions

## pie-monorepo

[Updated] - yarn.lock
