### PR TITLE
chore(pie-webc-core): make package public

### DIFF
--- a/.changeset/pink-shrimps-cheer.md
+++ b/.changeset/pink-shrimps-cheer.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+"pie-monorepo": patch
+---
+
+[Changed] - Make pie-webc-core public

--- a/packages/components/pie-webc-core/package.json
+++ b/packages/components/pie-webc-core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@justeattakeaway/pie-webc-core",
-  "private": true,
   "version": "0.2.0",
   "description": "PIE design system base classes, mixins and utilities for web components",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4636,7 +4636,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.13.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.14.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
@@ -4726,7 +4726,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
-    "@justeat/pie-design-tokens": 5.1.0
     "@justeattakeaway/pie-components-config": "workspace:*"
     "@justeattakeaway/pie-webc-core": "workspace:*"
   languageName: unknown
@@ -36420,7 +36419,7 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.0.1
-    "@justeattakeaway/pie-button": 0.13.0
+    "@justeattakeaway/pie-button": 0.14.0
     vite: ^4.3.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Makes the `pie-webc-core` package public as we will look to make this a dev dependency in components going forward