### PR TITLE
feat(pie-modal): Modal heading props

### DIFF
--- a/.changeset/cold-maps-breathe.md
+++ b/.changeset/cold-maps-breathe.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Added] heading and headingLevels props

--- a/.changeset/cold-maps-breathe.md
+++ b/.changeset/cold-maps-breathe.md
@@ -1,5 +1,4 @@
 ---
 "@justeattakeaway/pie-modal": minor
 ---
-
-[Added] heading and headingLevels props
+[Added] `heading` and `headingLevel` props to the

--- a/.changeset/cold-maps-breathe.md
+++ b/.changeset/cold-maps-breathe.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-modal": minor
 ---
-[Added] `heading` and `headingLevel` props to the
+[Added] - `heading` and `headingLevel` props to the modal component

--- a/.changeset/itchy-donkeys-grab.md
+++ b/.changeset/itchy-donkeys-grab.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+---
+
+[Added] required property decorator

--- a/.changeset/itchy-donkeys-grab.md
+++ b/.changeset/itchy-donkeys-grab.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-webc-core": minor
 ---
-[Added] **- `required`** property decorator
+[Added] - `required` property decorator

--- a/.changeset/itchy-donkeys-grab.md
+++ b/.changeset/itchy-donkeys-grab.md
@@ -1,5 +1,4 @@
 ---
 "@justeattakeaway/pie-webc-core": minor
 ---
-
-[Added] required property decorator
+[Added] **- `required`** property decorator

--- a/.changeset/long-yaks-grin.md
+++ b/.changeset/long-yaks-grin.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-wrapper-react": minor
 ---
-[Fixed] React wrapper points to the wrong value when a variable is used to define custom elements
+[Fixed] - React wrapper points to the wrong value when a variable is used to define custom elements

--- a/.changeset/long-yaks-grin.md
+++ b/.changeset/long-yaks-grin.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-wrapper-react": minor
 ---
-[Fixed] react wrapper points to the wrong value when a variable is used to define custom elements
+[Fixed] React wrapper points to the wrong value when a variable is used to define custom elements

--- a/.changeset/long-yaks-grin.md
+++ b/.changeset/long-yaks-grin.md
@@ -1,0 +1,4 @@
+---
+"@justeattakeaway/pie-wrapper-react": minor
+---
+[Fixed] react wrapper points to the wrong value when a variable is used to define custom elements

--- a/.changeset/mighty-moles-argue.md
+++ b/.changeset/mighty-moles-argue.md
@@ -1,5 +1,4 @@
 ---
 "@justeattakeaway/pie-icon-button": patch
 ---
-
-[Changed] - Use componentSelector to define the custom element
+[Changed] Use `componentSelector` to define the custom element

--- a/.changeset/mighty-moles-argue.md
+++ b/.changeset/mighty-moles-argue.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icon-button": patch
+---
+
+[Changed] - Use componentSelector to define the custom element

--- a/.changeset/mighty-moles-argue.md
+++ b/.changeset/mighty-moles-argue.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-icon-button": patch
 ---
-[Changed] Use `componentSelector` to define the custom element
+[Changed] - Use `componentSelector` to define the custom element

--- a/.changeset/nasty-houses-perform.md
+++ b/.changeset/nasty-houses-perform.md
@@ -1,4 +1,4 @@
 ---
 "pie-storybook": minor
 ---
-[Added] `heading` and `headingLevel` story controls
+[Added] - `heading` **and** `headingLevel` story controls

--- a/.changeset/nasty-houses-perform.md
+++ b/.changeset/nasty-houses-perform.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] heading and headingLevel controls

--- a/.changeset/nasty-houses-perform.md
+++ b/.changeset/nasty-houses-perform.md
@@ -1,4 +1,4 @@
 ---
 "pie-storybook": minor
 ---
-[Added] `heading` and `headingLevel` controls
+[Added] `heading` and `headingLevel` story controls

--- a/.changeset/nasty-houses-perform.md
+++ b/.changeset/nasty-houses-perform.md
@@ -1,5 +1,4 @@
 ---
 "pie-storybook": minor
 ---
-
-[Added] heading and headingLevel controls
+[Added] `heading` and `headingLevel` controls

--- a/.changeset/shaggy-lions-work.md
+++ b/.changeset/shaggy-lions-work.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-button": patch
 ---
-[Changed] - Use `componentSelector` to define the custom element
+[Changed] Use `componentSelector` to define the custom element

--- a/.changeset/shaggy-lions-work.md
+++ b/.changeset/shaggy-lions-work.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": patch
+---
+
+[Changed] - Use componentSelector to define the custom element

--- a/.changeset/shaggy-lions-work.md
+++ b/.changeset/shaggy-lions-work.md
@@ -1,4 +1,4 @@
 ---
 "@justeattakeaway/pie-button": patch
 ---
-[Changed] Use `componentSelector` to define the custom element
+[Changed] - Use `componentSelector` to define the custom element

--- a/.changeset/shaggy-lions-work.md
+++ b/.changeset/shaggy-lions-work.md
@@ -1,5 +1,4 @@
 ---
 "@justeattakeaway/pie-button": patch
 ---
-
-[Changed] - Use componentSelector to define the custom element
+[Changed] - Use `componentSelector` to define the custom element

--- a/apps/pie-storybook/stories/pie-modal.stories.ts
+++ b/apps/pie-storybook/stories/pie-modal.stories.ts
@@ -2,6 +2,13 @@ import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { HEADING_LEVELS } from '@justeattakeaway/pie-modal';
 import { html, TemplateResult } from 'lit';
 
+const defaultArgs = {
+    isOpen: false,
+    heading: 'Modal header',
+    headingLevel: HEADING_LEVELS.H2,
+    slot: 'This is Lit!',
+};
+
 export default {
     title: 'Modal',
     component: 'pie-modal',
@@ -20,11 +27,7 @@ export default {
             control: 'text',
         },
     },
-    args: {
-        isOpen: false,
-        heading: 'Model Header',
-        headingLevel: HEADING_LEVELS.H2,
-    },
+    args: { ...defaultArgs },
     parameters: {
         design: {
             type: 'figma',
@@ -53,13 +56,6 @@ const Template = ({
             ${slot}
         </pie-modal>
     `;
-
-const defaultArgs = {
-    isOpen: false,
-    heading: 'Modal header',
-    headingLevel: HEADING_LEVELS.H2,
-    slot: 'This is Lit!',
-};
 
 export const Default: Story = Template.bind({});
 Default.args = {

--- a/apps/pie-storybook/stories/pie-modal.stories.ts
+++ b/apps/pie-storybook/stories/pie-modal.stories.ts
@@ -1,22 +1,29 @@
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
-import { PieModal } from '@justeattakeaway/pie-modal';
+import { HEADING_LEVELS } from '@justeattakeaway/pie-modal';
 import { html, TemplateResult } from 'lit';
-
-const keptReference = PieModal; // TODO: Remove this const when other exports from PieModal are used on Stories, otherwise tree-shaking will get rid of the web component definition
 
 export default {
     title: 'Modal',
     component: 'pie-modal',
     argTypes: {
-        slot: {
-            control: 'text',
-        },
         isOpen: {
             control: 'boolean',
         },
+        heading: {
+            control: 'text',
+        },
+        headingLevel: {
+            control: 'select',
+            options: Object.values(HEADING_LEVELS),
+        },
+        slot: {
+            control: 'text',
+        },
     },
     args: {
-        isOpen: false
+        isOpen: false,
+        heading: 'Model Header',
+        headingLevel: HEADING_LEVELS.H2,
     },
     parameters: {
         design: {
@@ -27,23 +34,31 @@ export default {
 } as Meta;
 
 interface ModalProps {
-    slot: string;
     isOpen: boolean;
+    heading: string;
+    headingLevel: HEADING_LEVELS;
+    slot: TemplateResult;
 }
 
 const Template = ({
-    slot,
     isOpen,
+    heading,
+    headingLevel,
+    slot,
 }: ModalProps): TemplateResult => html`
-        <pie-modal ?isOpen="${isOpen}">
+        <pie-modal 
+        ?isOpen="${isOpen}"
+        heading="${heading}"
+        headingLevel="${headingLevel}">
             ${slot}
-            ${isOpen}
         </pie-modal>
     `;
 
 const defaultArgs = {
-    slot: 'This is Lit!',
     isOpen: false,
+    heading: 'Modal header',
+    headingLevel: HEADING_LEVELS.H2,
+    slot: 'This is Lit!',
 };
 
 export const Default: Story = Template.bind({});

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -50,7 +50,7 @@ export class PieButton extends LitElement {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define('pie-button', PieButton);
+customElements.define(componentSelector, PieButton);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -38,7 +38,7 @@ export class PieIconButton extends LitElement {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define('pie-icon-button', PieIconButton);
+customElements.define(componentSelector, PieIconButton);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-modal/README.md
+++ b/packages/components/pie-modal/README.md
@@ -52,6 +52,8 @@ import { PieModal } from '@justeattakeaway/pie-button/dist/react';
 | Property | Type      | Default | Description                                     |
 |----------|-----------|---------|-------------------------------------------------|
 | isOpen   | `Boolean` | `false` | Controls if the modal element is open or closed |
+| heading*   | `String` | - | Sets the heading of the modal |
+| headingLevel   | `String` | `h2` | Allows you to set the heading tag (from `h1` to `h6`) |
 
 
 ## Testing
@@ -77,4 +79,3 @@ Under scripts `test:visual` replace the environment variable with the below:
 
 ```
 PERCY_TOKEN_PIE_MODAL=abcde
-

--- a/packages/components/pie-modal/package.json
+++ b/packages/components/pie-modal/package.json
@@ -11,6 +11,8 @@
     "watch": "run -T vite build --watch",
     "test": "echo \"Error: no test specified\" && exit 0",
     "test:ci": "yarn test",
+    "test:browsers": "npx playwright test -c ./playwright-lit.config.ts",
+    "test:browsers:ci": "yarn test:browsers",
     "test:visual": "run -T cross-env-shell PERCY_TOKEN=${PERCY_TOKEN_PIE_MODAL} percy exec --allowed-hostname cloudfront.net -- npx playwright test -c ./playwright-lit-visual.config.ts",
     "test:visual:ci": "yarn test:visual"
   },

--- a/packages/components/pie-modal/src/defs.ts
+++ b/packages/components/pie-modal/src/defs.ts
@@ -1,0 +1,11 @@
+/**
+ * Modal heading levels/tags
+ */
+export enum HEADING_LEVELS {
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6'
+}

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -17,7 +17,7 @@ export class PieModal extends RtlMixin(LitElement) {
 
     @property({ type: String })
     @requiredProperty(componentSelector)
-        heading: string | undefined;
+        heading!: string;
 
     @property()
     @validPropertyValues(componentSelector, Object.values(HEADING_LEVELS), HEADING_LEVELS.H2)

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -1,18 +1,38 @@
-import { LitElement, html, unsafeCSS } from 'lit'; // eslint-disable-line import/no-extraneous-dependencies
-import { property } from 'lit/decorators.js';
-import { RtlMixin } from '@justeattakeaway/pie-webc-core';
+import { LitElement, unsafeCSS } from 'lit'; // eslint-disable-line import/no-extraneous-dependencies
+import { html, unsafeStatic } from 'lit/static-html.js';
+import { property } from 'lit/decorators.js'; // eslint-disable-line import/no-extraneous-dependencies
+import { RtlMixin, validPropertyValues, requiredProperty } from '@justeattakeaway/pie-webc-core';
 
 import styles from './modal.scss?inline';
+import { HEADING_LEVELS } from './defs';
+
+// Valid values available to consumers
+export { HEADING_LEVELS };
+
+const componentSelector = 'pie-modal';
 
 export class PieModal extends RtlMixin(LitElement) {
     @property({ type: Boolean })
         isOpen = false;
 
-    // eslint-disable-next-line class-methods-use-this
+    @property({ type: String })
+    @requiredProperty(componentSelector)
+        heading: string | undefined;
+
+    @property()
+    @validPropertyValues(componentSelector, Object.values(HEADING_LEVELS), HEADING_LEVELS.H2)
+        headingLevel : HEADING_LEVELS = HEADING_LEVELS.H2;
+
     render () {
+        const {
+            heading,
+        } = this;
+
+        const headingTag = unsafeStatic(this.headingLevel);
+
         return html`
             <dialog class="c-modal" ?open="${this.isOpen}">
-                <h3 class="c-modal-heading">Modal header</h3>
+                <${headingTag} class="c-modal-heading">${heading}</${headingTag}>
                 <div class="c-modal-contentWrapper">
                     <slot></slot>
                 </div>
@@ -24,7 +44,7 @@ export class PieModal extends RtlMixin(LitElement) {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define('pie-modal', PieModal);
+customElements.define(componentSelector, PieModal);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -25,13 +25,15 @@ export class PieModal extends RtlMixin(LitElement) {
 
     render () {
         const {
+            isOpen,
             heading,
+            headingLevel,
         } = this;
 
-        const headingTag = unsafeStatic(this.headingLevel);
+        const headingTag = unsafeStatic(headingLevel);
 
         return html`
-            <dialog class="c-modal" ?open="${this.isOpen}">
+            <dialog class="c-modal" ?open="${isOpen}">
                 <${headingTag} class="c-modal-heading">${heading}</${headingTag}>
                 <div class="c-modal-contentWrapper">
                     <slot></slot>

--- a/packages/components/pie-modal/test/component/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/component/pie-modal.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@sand4rt/experimental-ct-web';
+import { PieModal } from '@/index';
+import { HEADING_LEVELS } from '@/defs';
+
+Object.values(HEADING_LEVELS).forEach((headingLevel) => test(`should render the correct heading tag based on the value of headingLevel: ${headingLevel} `, async ({ mount }) => {
+    const props = {
+        heading: 'Modal Header',
+        headingLevel,
+    };
+
+    const component = await mount(PieModal, { props });
+
+    await expect(component.locator(`${props.headingLevel}.c-modal-heading`)).toContainText(props.heading);
+}));
+
+['span', 'section'].forEach((headingLevel) => test(`should render the fallback heading level ${HEADING_LEVELS.H2} if invalid headingLevel: ${headingLevel} is passed`, async ({ mount }) => {
+    const props = {
+        heading: 'Modal Header',
+        // assert type checking to purposely provide incorrect value
+        headingLevel: headingLevel as HEADING_LEVELS,
+    };
+
+    const component = await mount(PieModal, { props });
+
+    // h2 is the default / fallback value
+    await expect(component.locator(`${HEADING_LEVELS.H2}.c-modal-heading`)).toContainText(props.heading);
+}));

--- a/packages/components/pie-modal/test/component/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/component/pie-modal.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@sand4rt/experimental-ct-web';
 import { PieModal } from '@/index';
 import { HEADING_LEVELS } from '@/defs';
 
-Object.values(HEADING_LEVELS).forEach((headingLevel) => test(`should render the correct heading tag based on the value of headingLevel: ${headingLevel} `, async ({ mount }) => {
+Object.values(HEADING_LEVELS).forEach((headingLevel) => test(`should render the correct heading tag based on the value of headingLevel: ${headingLevel}`, async ({ mount }) => {
     const props = {
         heading: 'Modal Header',
         headingLevel,
@@ -16,7 +16,7 @@ Object.values(HEADING_LEVELS).forEach((headingLevel) => test(`should render the 
 ['span', 'section'].forEach((headingLevel) => test(`should render the fallback heading level ${HEADING_LEVELS.H2} if invalid headingLevel: ${headingLevel} is passed`, async ({ mount }) => {
     const props = {
         heading: 'Modal Header',
-        // assert type checking to purposely provide incorrect value
+        // assert type checking as we purposely provide incorrect value
         headingLevel: headingLevel as HEADING_LEVELS,
     };
 

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -1,22 +1,60 @@
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
+import type {
+    PropObject, WebComponentPropValues, WebComponentTestInput,
+} from '@justeattakeaway/pie-webc-core/src/test-helpers/defs.ts';
+import {
+    getAllPropCombinations, splitCombinationsByPropertyValue,
+} from '@justeattakeaway/pie-webc-core/src/test-helpers/get-all-prop-combos.ts';
+import {
+    createTestWebComponent,
+} from '@justeattakeaway/pie-webc-core/src/test-helpers/rendering.ts';
+import {
+    WebComponentTestWrapper,
+} from '@justeattakeaway/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import { PieModal } from '@/index';
+import { HEADING_LEVELS } from '@/defs';
 
-const propIsOpenValues = [
-    { heading: 'Modal Header / isOpen = true', isOpen: true },
-    { heading: 'Modal Header / isOpen = false', isOpen: false }
-];
+const props: PropObject = {
+    heading: 'Modal heading',
+    headingLevel: Object.values(HEADING_LEVELS),
+    isOpen: [true, false],
+};
 
-propIsOpenValues.forEach((props) => test(`should render Modal correctly when prop isOpen is set to ${props.isOpen}`, async ({ page, mount }) => {
+// Renders a <pie-modal> HTML string with the given prop values
+const renderTestPieModal = (propVals: WebComponentPropValues) => `<pie-modal isOpen="${propVals.isOpen}" heading="${propVals.heading}" headingLevel="${propVals.headingLevel}">Hello, this is the Pie Modal!</pie-modal>`;
+
+const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(props);
+const componentPropsMatrixByIsOpenValues: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'isOpen');
+const componentIsOpenValues: string[] = Object.keys(componentPropsMatrixByIsOpenValues);
+
+// This ensures the component is registered in the DOM for each test
+// This is not required if your tests mount the web component directly in the tests
+test('Component registered in the DOM', async ({ mount }) => {
     await mount(
         PieModal,
         {
-            props,
-            slots: {
-                default: 'Hello, this is the Pie Modal!',
-            },
+            props: {},
+            slots: {},
         },
     );
+});
 
-    await percySnapshot(page, `PIE Modal when isOpen is set to ${props.isOpen}`);
+componentIsOpenValues.forEach((isOpen) => test(`Render all prop variations for isOpen: ${isOpen}`, async ({ page, mount }) => {
+    await Promise.all(componentPropsMatrixByIsOpenValues[isOpen].map(async (combo: WebComponentPropValues) => {
+        const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieModal);
+        const propKeyValues = `heading: ${testComponent.propValues.heading}, headingLevel: ${testComponent.propValues.headingLevel}`;
+
+        await mount(
+            WebComponentTestWrapper,
+            {
+                props: { propKeyValues },
+                slots: {
+                    default: testComponent.renderedString.trim(),
+                },
+            },
+        );
+    }));
+
+    await percySnapshot(page, `PIE Modal - isOpen: ${isOpen}`);
 }));

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -1,60 +1,19 @@
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
-import type {
-    PropObject, WebComponentPropValues, WebComponentTestInput,
-} from '@justeattakeaway/pie-webc-core/src/test-helpers/defs.ts';
-import {
-    getAllPropCombinations, splitCombinationsByPropertyValue,
-} from '@justeattakeaway/pie-webc-core/src/test-helpers/get-all-prop-combos.ts';
-import {
-    createTestWebComponent,
-} from '@justeattakeaway/pie-webc-core/src/test-helpers/rendering.ts';
-import {
-    WebComponentTestWrapper,
-} from '@justeattakeaway/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import { PieModal } from '@/index';
-import { HEADING_LEVELS } from '@/defs';
 
-const props: PropObject = {
-    heading: 'Modal heading',
-    headingLevel: Object.values(HEADING_LEVELS),
-    isOpen: [true, false],
-};
+const componentProps = [{ heading: 'Modal Heading', isOpen: true }, { isOpen: false }];
 
-// Renders a <pie-modal> HTML string with the given prop values
-const renderTestPieModal = (propVals: WebComponentPropValues) => `<pie-modal isOpen="${propVals.isOpen}" heading="${propVals.heading}" headingLevel="${propVals.headingLevel}">Hello, this is the Pie Modal!</pie-modal>`;
-
-const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(props);
-const componentPropsMatrixByIsOpenValues: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'isOpen');
-const componentIsOpenValues: string[] = Object.keys(componentPropsMatrixByIsOpenValues);
-
-// This ensures the component is registered in the DOM for each test
-// This is not required if your tests mount the web component directly in the tests
-test('Component registered in the DOM', async ({ mount }) => {
+componentProps.forEach((props) => test(`should render Modal correctly when prop isOpen is set to ${props.isOpen}`, async ({ page, mount }) => {
     await mount(
         PieModal,
         {
-            props: {},
-            slots: {},
+            props,
+            slots: {
+                default: 'Hello, this is the Pie Modal!',
+            },
         },
     );
-});
 
-componentIsOpenValues.forEach((isOpen) => test(`Render all prop variations for isOpen: ${isOpen}`, async ({ page, mount }) => {
-    await Promise.all(componentPropsMatrixByIsOpenValues[isOpen].map(async (combo: WebComponentPropValues) => {
-        const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieModal);
-        const propKeyValues = `heading: ${testComponent.propValues.heading}, headingLevel: ${testComponent.propValues.headingLevel}`;
-
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues },
-                slots: {
-                    default: testComponent.renderedString.trim(),
-                },
-            },
-        );
-    }));
-
-    await percySnapshot(page, `PIE Modal - isOpen: ${isOpen}`);
+    await percySnapshot(page, `PIE Modal when isOpen is set to ${props.isOpen}`);
 }));

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -2,21 +2,21 @@ import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
 import { PieModal } from '@/index';
 
-const propIsOpenValues = [true, false];
+const propIsOpenValues = [
+    { heading: 'Modal Header / isOpen = true', isOpen: true },
+    { heading: 'Modal Header / isOpen = false', isOpen: false }
+];
 
-propIsOpenValues.forEach(propValue =>
-    test(`should render Modal correctly when prop isOpen is set to ${propValue}`, async ({ page, mount }) => {
-        await mount(
-            PieModal,
-            {
-                props: {
-                    isOpen: propValue
-                },
-                slots: {
-                    default: 'Hello, this is the Pie Modal!',
-                },
+propIsOpenValues.forEach((props) => test(`should render Modal correctly when prop isOpen is set to ${props.isOpen}`, async ({ page, mount }) => {
+    await mount(
+        PieModal,
+        {
+            props,
+            slots: {
+                default: 'Hello, this is the Pie Modal!',
             },
-        );
+        },
+    );
 
-        await percySnapshot(page, `PIE Modal when isOpen is set to ${propValue}`);
+    await percySnapshot(page, `PIE Modal when isOpen is set to ${props.isOpen}`);
 }));

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -2,9 +2,9 @@ import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
 import { PieModal } from '@/index';
 
-const componentProps = [{ heading: 'Modal Heading', isOpen: true }, { isOpen: false }];
+const propIsOpenValues = [{ heading: 'Modal Heading', isOpen: true }, { isOpen: false }];
 
-componentProps.forEach((props) => test(`should render Modal correctly when prop isOpen is set to ${props.isOpen}`, async ({ page, mount }) => {
+propIsOpenValues.forEach((props) => test(`should render Modal correctly when prop isOpen is set to ${props.isOpen}`, async ({ page, mount }) => {
     await mount(
         PieModal,
         {

--- a/packages/components/pie-webc-core/src/decorators/index.ts
+++ b/packages/components/pie-webc-core/src/decorators/index.ts
@@ -1,1 +1,3 @@
-export * from './valid-property-values/validPropertyValues';
+export * from './valid-property-values';
+export * from './required-property';
+

--- a/packages/components/pie-webc-core/src/decorators/required-property.ts
+++ b/packages/components/pie-webc-core/src/decorators/required-property.ts
@@ -1,0 +1,24 @@
+/**
+ * A decorator for marking a property as required.
+ * If the property's value is `undefined` or `null`, an error is logged.
+ * @returns {Function} - The decorator function.
+ */
+export const requiredProperty = (componentName: string) => function (target: any, propertyKey: string) : void {
+    const privatePropertyKey = `#${propertyKey}`;
+
+    Object.defineProperty(target, propertyKey, {
+        get () : any {
+            return this[privatePropertyKey];
+        },
+        set (value: any) : void {
+            const oldValue = this[privatePropertyKey];
+
+            if (value === undefined || value === null || value === '') {
+                console.error(`<${componentName}> Missing required attribute "${propertyKey}"`);
+            }
+            this[privatePropertyKey] = value;
+
+            this.requestUpdate(propertyKey, oldValue);
+        },
+    });
+};

--- a/packages/components/pie-webc-core/src/decorators/required-property.ts
+++ b/packages/components/pie-webc-core/src/decorators/required-property.ts
@@ -1,6 +1,6 @@
 /**
  * A decorator for marking a property as required.
- * If the property's value is `undefined` or `null`, an error is logged.
+ * If the property's value is `undefined`, `null` or empty string, an error is logged.
  * @returns {Function} - The decorator function.
  */
 export const requiredProperty = (componentName: string) => function (target: any, propertyKey: string) : void {

--- a/packages/components/pie-webc-core/src/decorators/valid-property-values.ts
+++ b/packages/components/pie-webc-core/src/decorators/valid-property-values.ts
@@ -3,7 +3,7 @@
  * If this property's setter is called with an invalid value, an error is logged and the default value will be assigned instead.
  * @param validValues - The array of valid values
  * @param defaultValue - The value to fall back on
- * @returns
+ * @returns  - The decorator function
  */
 export const validPropertyValues = (componentName: string, validValues: any[], defaultValue: any) => function (target: any, propertyKey: string) : void {
     const privatePropertyKey = `#${propertyKey}`;

--- a/packages/components/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts
+++ b/packages/components/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts
@@ -45,10 +45,14 @@ export class WebComponentTestWrapper extends LitElement {
     }
 }
 
-customElements.define('web-component-test-wrapper', WebComponentTestWrapper);
+const componentSelector = 'web-component-test-wrapper';
+
+if (!customElements.get(componentSelector)) {
+    customElements.define(componentSelector, WebComponentTestWrapper);
+}
 
 declare global {
     interface HTMLElementTagNameMap {
-        'web-component-test-wrapper': WebComponentTestWrapper;
+        [componentSelector]: WebComponentTestWrapper;
     }
 }

--- a/packages/tools/pie-wrapper-react/custom-elements.json
+++ b/packages/tools/pie-wrapper-react/custom-elements.json
@@ -125,88 +125,80 @@
     },
     {
       "kind": "javascript-module",
-      "path": "../../components/pie-icon-button/src/defs.js",
+      "path": "../../components/pie-webc-core/src/index.js",
       "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "../../components/pie-icon-button/src/index.js",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PieIconButton",
-          "members": [
-            {
-              "kind": "field",
-              "name": "variant",
-              "type": {
-                "text": "ICON_BUTTON_VARIANT"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "method",
-              "name": "render"
-            },
-            {
-              "kind": "field",
-              "name": "styles",
-              "static": true
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "pie-icon-button",
-          "customElement": true
-        }
-      ],
       "exports": [
         {
           "kind": "js",
-          "name": "ICON_BUTTON_VARIANT",
+          "name": "*",
           "declaration": {
-            "name": "ICON_BUTTON_VARIANT",
-            "module": "../../components/pie-icon-button/src/index.js"
+            "name": "*",
+            "package": "./mixins"
           }
         },
         {
           "kind": "js",
-          "name": "PieIconButton",
+          "name": "*",
           "declaration": {
-            "name": "PieIconButton",
-            "module": "../../components/pie-icon-button/src/index.js"
+            "name": "*",
+            "package": "./decorators"
           }
         },
         {
-          "kind": "custom-element-definition",
-          "name": "pie-icon-button",
+          "kind": "js",
+          "name": "*",
           "declaration": {
-            "name": "PieIconButton",
-            "module": "../../components/pie-icon-button/src/index.js"
+            "name": "*",
+            "package": "./test-helpers"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
+      "path": "../../components/pie-modal/src/defs.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "../../components/pie-modal/src/index.js",
       "declarations": [
+        {
+          "kind": "variable",
+          "name": "componentSelector",
+          "type": {
+            "text": "string"
+          },
+          "default": "'pie-modal'"
+        },
         {
           "kind": "class",
           "description": "",
           "name": "PieModal",
           "members": [
+            {
+              "kind": "field",
+              "name": "isOpen",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "heading",
+              "type": {
+                "text": "string | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "headingLevel",
+              "type": {
+                "text": "HEADING_LEVELS"
+              }
+            },
             {
               "kind": "method",
               "name": "render"
@@ -252,11 +244,19 @@
             "name": "LitElement",
             "package": "lit"
           },
-          "tagName": "pie-modal",
+          "tagName": "componentSelector",
           "customElement": true
         }
       ],
       "exports": [
+        {
+          "kind": "js",
+          "name": "HEADING_LEVELS",
+          "declaration": {
+            "name": "HEADING_LEVELS",
+            "module": "../../components/pie-modal/src/index.js"
+          }
+        },
         {
           "kind": "js",
           "name": "PieModal",
@@ -267,7 +267,7 @@
         },
         {
           "kind": "custom-element-definition",
-          "name": "pie-modal",
+          "name": "componentSelector",
           "declaration": {
             "name": "PieModal",
             "module": "../../components/pie-modal/src/index.js"
@@ -277,31 +277,83 @@
     },
     {
       "kind": "javascript-module",
-      "path": "../../components/pie-webc-core/src/index.js",
+      "path": "../../components/pie-icon-button/src/defs.js",
       "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-icon-button/src/index.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "componentSelector",
+          "type": {
+            "text": "string"
+          },
+          "default": "'pie-icon-button'"
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PieIconButton",
+          "members": [
+            {
+              "kind": "field",
+              "name": "variant",
+              "type": {
+                "text": "ICON_BUTTON_VARIANT"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            },
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "componentSelector",
+          "customElement": true
+        }
+      ],
       "exports": [
         {
           "kind": "js",
-          "name": "*",
+          "name": "ICON_BUTTON_VARIANT",
           "declaration": {
-            "name": "*",
-            "package": "./mixins"
+            "name": "ICON_BUTTON_VARIANT",
+            "module": "../../components/pie-icon-button/src/index.js"
           }
         },
         {
           "kind": "js",
-          "name": "*",
+          "name": "PieIconButton",
           "declaration": {
-            "name": "*",
-            "package": "./decorators"
+            "name": "PieIconButton",
+            "module": "../../components/pie-icon-button/src/index.js"
           }
         },
         {
-          "kind": "js",
-          "name": "*",
+          "kind": "custom-element-definition",
+          "name": "componentSelector",
           "declaration": {
-            "name": "*",
-            "package": "./test-helpers"
+            "name": "PieIconButton",
+            "module": "../../components/pie-icon-button/src/index.js"
           }
         }
       ]
@@ -316,7 +368,112 @@
           "name": "*",
           "declaration": {
             "name": "*",
-            "package": "./valid-property-values/validPropertyValues"
+            "package": "./valid-property-values"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./required-property"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/decorators/required-property.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "requiredProperty",
+          "parameters": [
+            {
+              "name": "componentName",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "description": "A decorator for marking a property as required.\nIf the property's value is `undefined`, `null` or empty string, an error is logged.",
+          "return": {
+            "type": {
+              "text": "Function"
+            }
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "requiredProperty",
+          "declaration": {
+            "name": "requiredProperty",
+            "module": "../../components/pie-webc-core/src/decorators/required-property.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/decorators/valid-property-values.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "validPropertyValues",
+          "parameters": [
+            {
+              "name": "componentName",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "validValues",
+              "type": {
+                "text": "any[]"
+              },
+              "description": "The array of valid values"
+            },
+            {
+              "name": "defaultValue",
+              "type": {
+                "text": "any"
+              },
+              "description": "The value to fall back on"
+            }
+          ],
+          "description": "A decorator for specifying a list of valid values for a property.\nIf this property's setter is called with an invalid value, an error is logged and the default value will be assigned instead.",
+          "return": {
+            "type": {
+              "text": ""
+            }
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "validPropertyValues",
+          "declaration": {
+            "name": "validPropertyValues",
+            "module": "../../components/pie-webc-core/src/decorators/valid-property-values.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/mixins/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./rtl/rtlMixin"
           }
         }
       ]
@@ -476,6 +633,54 @@
     },
     {
       "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js",
+      "declarations": [
+        {
+          "kind": "mixin",
+          "description": "",
+          "name": "RtlMixin",
+          "members": [
+            {
+              "kind": "field",
+              "name": "dir",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "isRTL",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Returns true if the element is in Right to Left mode.\nIf a dir attribute is not explicitly set on the web component\nthen it falls back to the nearest parent with a dir attribute set.\n\nA dir attribute being set will result in a reactive property.\nIf the component falls back to a parent dir attribute then the value\nwill not be reactive and is only computed once",
+              "readonly": true
+            }
+          ],
+          "parameters": [
+            {
+              "name": "superClass",
+              "type": {
+                "text": "T"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RtlMixin",
+          "declaration": {
+            "name": "RtlMixin",
+            "module": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "../../components/pie-webc-core/src/test-helpers/components/index.js",
       "declarations": [],
       "exports": [
@@ -485,69 +690,6 @@
           "declaration": {
             "name": "*",
             "package": "./web-component-test-wrapper/WebComponentTestWrapper"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "../../components/pie-webc-core/src/mixins/index.js",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "*",
-          "declaration": {
-            "name": "*",
-            "package": "./rtl/rtlMixin"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "../../components/pie-webc-core/src/decorators/valid-property-values/validPropertyValues.js",
-      "declarations": [
-        {
-          "kind": "function",
-          "name": "validPropertyValues",
-          "parameters": [
-            {
-              "name": "componentName",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "validValues",
-              "type": {
-                "text": "any[]"
-              },
-              "description": "The array of valid values"
-            },
-            {
-              "name": "defaultValue",
-              "type": {
-                "text": "any"
-              },
-              "description": "The value to fall back on"
-            }
-          ],
-          "description": "A decorator for specifying a list of valid values for a property.\nIf this property's setter is called with an invalid value, an error is logged and the default value will be assigned instead.",
-          "return": {
-            "type": {
-              "text": ""
-            }
-          }
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "validPropertyValues",
-          "declaration": {
-            "name": "validPropertyValues",
-            "module": "../../components/pie-webc-core/src/decorators/valid-property-values/validPropertyValues.js"
           }
         }
       ]
@@ -607,54 +749,6 @@
           "declaration": {
             "name": "WebComponentTestWrapper",
             "module": "../../components/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js",
-      "declarations": [
-        {
-          "kind": "mixin",
-          "description": "",
-          "name": "RtlMixin",
-          "members": [
-            {
-              "kind": "field",
-              "name": "dir",
-              "type": {
-                "text": "string"
-              },
-              "default": "''"
-            },
-            {
-              "kind": "field",
-              "name": "isRTL",
-              "type": {
-                "text": "boolean"
-              },
-              "description": "Returns true if the element is in Right to Left mode.\nIf a dir attribute is not explicitly set on the web component\nthen it falls back to the nearest parent with a dir attribute set.\n\nA dir attribute being set will result in a reactive property.\nIf the component falls back to a parent dir attribute then the value\nwill not be reactive and is only computed once",
-              "readonly": true
-            }
-          ],
-          "parameters": [
-            {
-              "name": "superClass",
-              "type": {
-                "text": "T"
-              }
-            }
-          ]
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "RtlMixin",
-          "declaration": {
-            "name": "RtlMixin",
-            "module": "../../components/pie-webc-core/src/mixins/rtl/rtlMixin.js"
           }
         }
       ]

--- a/packages/tools/pie-wrapper-react/custom-elements.json
+++ b/packages/tools/pie-wrapper-react/custom-elements.json
@@ -4,6 +4,127 @@
   "modules": [
     {
       "kind": "javascript-module",
+      "path": "../../components/pie-button/src/defs.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-button/src/index.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "componentSelector",
+          "type": {
+            "text": "string"
+          },
+          "default": "'pie-button'"
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PieButton",
+          "members": [
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "BUTTON_SIZE"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "BUTTON_TYPE"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "variant",
+              "type": {
+                "text": "BUTTON_VARIANT"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "isFullWidth",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            },
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "componentSelector",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BUTTON_SIZE",
+          "declaration": {
+            "name": "BUTTON_SIZE",
+            "module": "../../components/pie-button/src/index.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "BUTTON_TYPE",
+          "declaration": {
+            "name": "BUTTON_TYPE",
+            "module": "../../components/pie-button/src/index.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "BUTTON_VARIANT",
+          "declaration": {
+            "name": "BUTTON_VARIANT",
+            "module": "../../components/pie-button/src/index.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "PieButton",
+          "declaration": {
+            "name": "PieButton",
+            "module": "../../components/pie-button/src/index.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "componentSelector",
+          "declaration": {
+            "name": "PieButton",
+            "module": "../../components/pie-button/src/index.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "../../components/pie-icon-button/src/defs.js",
       "declarations": [],
       "exports": []
@@ -156,119 +277,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "../../components/pie-button/src/defs.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "../../components/pie-button/src/index.js",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PieButton",
-          "members": [
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "BUTTON_SIZE"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "type",
-              "type": {
-                "text": "BUTTON_TYPE"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "variant",
-              "type": {
-                "text": "BUTTON_VARIANT"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "isFullWidth",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "method",
-              "name": "render"
-            },
-            {
-              "kind": "field",
-              "name": "styles",
-              "static": true
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "pie-button",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "BUTTON_SIZE",
-          "declaration": {
-            "name": "BUTTON_SIZE",
-            "module": "../../components/pie-button/src/index.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "BUTTON_TYPE",
-          "declaration": {
-            "name": "BUTTON_TYPE",
-            "module": "../../components/pie-button/src/index.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "BUTTON_VARIANT",
-          "declaration": {
-            "name": "BUTTON_VARIANT",
-            "module": "../../components/pie-button/src/index.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "PieButton",
-          "declaration": {
-            "name": "PieButton",
-            "module": "../../components/pie-button/src/index.js"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "pie-button",
-          "declaration": {
-            "name": "PieButton",
-            "module": "../../components/pie-button/src/index.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "../../components/pie-webc-core/src/index.js",
       "declarations": [],
       "exports": [
@@ -315,18 +323,9 @@
     },
     {
       "kind": "javascript-module",
-      "path": "../../components/pie-webc-core/src/mixins/index.js",
+      "path": "../../components/pie-webc-core/src/test-helpers/defs.js",
       "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "*",
-          "declaration": {
-            "name": "*",
-            "package": "./rtl/rtlMixin"
-          }
-        }
-      ]
+      "exports": []
     },
     {
       "kind": "javascript-module",
@@ -337,7 +336,7 @@
           "name": "getAllPropCombinations",
           "return": {
             "type": {
-              "text": "Combination[]"
+              "text": "WebComponentPropValues[]"
             }
           },
           "parameters": [
@@ -356,14 +355,14 @@
           "name": "splitCombinationsByPropertyValue",
           "return": {
             "type": {
-              "text": "Record<string, Combination[]>"
+              "text": "Record<string, WebComponentPropValues[]>"
             }
           },
           "parameters": [
             {
-              "name": "combinations",
+              "name": "propValueCombinations",
               "type": {
-                "text": "Combination[]"
+                "text": "WebComponentPropValues[]"
               },
               "description": "The array of combinations to split."
             },
@@ -408,6 +407,99 @@
           "declaration": {
             "name": "*",
             "package": "./get-all-prop-combos"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./defs"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./rendering"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./components"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/test-helpers/rendering.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "createTestWebComponent",
+          "return": {
+            "type": {
+              "text": "WebComponentTestInput"
+            }
+          },
+          "parameters": [
+            {
+              "name": "propVals",
+              "type": {
+                "text": "WebComponentPropValues"
+              }
+            },
+            {
+              "name": "componentRenderFn",
+              "type": {
+                "text": "WebComponentRenderFn"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "createTestWebComponent",
+          "declaration": {
+            "name": "createTestWebComponent",
+            "module": "../../components/pie-webc-core/src/test-helpers/rendering.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/test-helpers/components/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./web-component-test-wrapper/WebComponentTestWrapper"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/mixins/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./rtl/rtlMixin"
           }
         }
       ]
@@ -456,6 +548,65 @@
           "declaration": {
             "name": "validPropertyValues",
             "module": "../../components/pie-webc-core/src/decorators/valid-property-values/validPropertyValues.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "../../components/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "This is a Web Component used for visual testing purposes.\nIt allows us to wrap a component we'd like to test in a container\nthat displays the component's props as a label.\n\nComponents can be tested without this, but it's useful if your tests\nrequire additional markup when testing a component.",
+          "name": "WebComponentTestWrapper",
+          "members": [
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "propKeyValues",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The prop key and values to display above the component.\nThis should be a single string representing a comma separated list of prop key/value pairs.\nSuch as: 'size: small, isFullWidth: true'"
+            },
+            {
+              "kind": "method",
+              "name": "_renderPropKeyValues"
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "web-component-test-wrapper",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "WebComponentTestWrapper",
+          "declaration": {
+            "name": "WebComponentTestWrapper",
+            "module": "../../components/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "web-component-test-wrapper",
+          "declaration": {
+            "name": "WebComponentTestWrapper",
+            "module": "../../components/pie-webc-core/src/test-helpers/components/web-component-test-wrapper/WebComponentTestWrapper.js"
           }
         }
       ]

--- a/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
+++ b/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
@@ -26,7 +26,10 @@ export function addReactWrapper (customElementsObject, folderName = process.argv
             value.forEach((k) => {
                 if (k.path.includes(folderName)) {
                     k.declarations.forEach((decl) => {
-                        if (decl.customElement === true) components.push({ class: decl, path: k.path.replace('index.js', 'react.ts') });
+                        if (decl.customElement === true) {
+                            const variableKind = k.declarations.filter((i) => i.kind === 'variable');
+                            components.push({ class: { ...decl, tagName: variableKind[0]?.default.replace(/'/g, '') ?? decl.tagName }, path: k.path.replace('index.js', 'react.ts') });
+                        }
                     });
                 }
             });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- adds heading props to modal
- modifies the react-wrapper script to take care of cases where the custom element is defined via a variable

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If it is a component change, I have reviewed the Storybook preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
