### PR TITLE
test(pie-monorepo): added new code to fix Safari Visual Regression tests for Lit components

### DIFF
--- a/.changeset/tidy-pianos-repair.md
+++ b/.changeset/tidy-pianos-repair.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+---
+
+[Added] - New function to fix CSS loading in Safari Percy tests

--- a/configs/pie-components-config/playwright-lit-visual-config.js
+++ b/configs/pie-components-config/playwright-lit-visual-config.js
@@ -8,7 +8,7 @@ import path from 'path';
 export function getPlaywrightVisualConfig () {
     return {
         /* Maximum time one test can run for. */
-        timeout: 10 * 1000,
+        timeout: 30 * 1000,
         /* Run tests in files in parallel */
         fullyParallel: true,
         /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -1,4 +1,5 @@
 import { test } from '@sand4rt/experimental-ct-web';
+import { getLitPercyOptions } from '@justeattakeaway/pie-webc-core/src/test-helpers/percy-lit-options.ts';
 import percySnapshot from '@percy/playwright';
 import type {
     PropObject, WebComponentPropValues, WebComponentTestInput,
@@ -58,5 +59,5 @@ componentVariants.forEach((variant) => test(`Render all prop variations for Vari
         );
     }));
 
-    await percySnapshot(page, `PIE Button - Variant: ${variant}`);
+    await percySnapshot(page, `PIE Button - Variant: ${variant}`, getLitPercyOptions());
 }));

--- a/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
+++ b/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
+import { getLitPercyOptions } from '@justeattakeaway/pie-webc-core/src/test-helpers/percy-lit-options.ts';
 import type {
     PropObject, WebComponentPropValues, WebComponentTestInput,
 } from '@justeattakeaway/pie-webc-core/src/test-helpers/defs.ts';
@@ -54,5 +55,5 @@ componentVariants.forEach((variant) => test(`Render all prop variations for Vari
         );
     }));
 
-    await percySnapshot(page, `PIE Icon Button - Variant: ${variant}`);
+    await percySnapshot(page, `PIE Icon Button - Variant: ${variant}`, getLitPercyOptions());
 }));

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
 import { PieModal } from '@/index';
+import { getLitPercyOptions } from '@justeattakeaway/pie-webc-core/src/test-helpers/percy-lit-options.ts';
 
 const propIsOpenValues = [{ heading: 'Modal Heading', isOpen: true }, { isOpen: false }];
 
@@ -15,5 +16,5 @@ propIsOpenValues.forEach((props) => test(`should render Modal correctly when pro
         },
     );
 
-    await percySnapshot(page, `PIE Modal when isOpen is set to ${props.isOpen}`);
+    await percySnapshot(page, `PIE Modal when isOpen is set to ${props.isOpen}`, getLitPercyOptions());
 }));

--- a/packages/components/pie-webc-core/src/test-helpers/index.ts
+++ b/packages/components/pie-webc-core/src/test-helpers/index.ts
@@ -2,3 +2,4 @@ export * from './get-all-prop-combos';
 export * from './defs';
 export * from './rendering';
 export * from './components';
+export * from './percy-lit-options';

--- a/packages/components/pie-webc-core/src/test-helpers/percy-lit-options.ts
+++ b/packages/components/pie-webc-core/src/test-helpers/percy-lit-options.ts
@@ -1,0 +1,37 @@
+///*
+///* This code snippet was provided by Percy as a way to get our Lit components working correctly when running against the Safari browser.
+///* Safari blocks requests coming from localhost, resulting in our CSS not loading when requested.
+///* This function is passed to Percy and executed against the serialised DOM to rewrite all 'localhost' urls to 'render.percy.local'.
+///* This is a temporary workaround, and a long-term solution will be implemented by Percy at a later date.
+///*
+const percyOptions = {
+    domTransformation: (documentElement: any) => {
+        function updateLinks(root : any) {
+        root.querySelectorAll('[data-percy-adopted-stylesheets-serialized]').forEach((link : any) => {
+            console.log(link);
+            let href = link.getAttribute('data-percy-serialized-attribute-href');
+            href = href.replace(/localhost[:\d+]*/, 'render.percy.local');
+            link.setAttribute('data-percy-serialized-attribute-href', href);
+        });
+
+        root.querySelectorAll('[data-percy-shadow-host]')
+            .forEach((shadowHost : any) => {
+                console.log(shadowHost);
+                if (shadowHost?.shadowRoot)
+                updateLinks(shadowHost.shadowRoot);
+            }
+        );
+        }
+        updateLinks(documentElement);
+    }
+}
+
+const getLitPercyOptions = () => {
+    const options = {
+        domTransformation: percyOptions.domTransformation.toString()
+    }
+
+    return options;
+}
+
+export { getLitPercyOptions }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Added] - New function to fix CSS loading in Safari Percy tests

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
