### PR TITLE
fix(pie-icons-configs): removes class attr application for react icons

### DIFF
--- a/.changeset/moody-fans-pump.md
+++ b/.changeset/moody-fans-pump.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-icons-configs": patch
+"@justeattakeaway/pie-icons-react": patch
+---
+
+[Changed]: removes class attr application for react icons

--- a/packages/tools/pie-icons-configs/__tests__/configs-react.test.js
+++ b/packages/tools/pie-icons-configs/__tests__/configs-react.test.js
@@ -8,6 +8,7 @@ describe('getReactSvgProps', () => {
             const received = getReactSvgProps('c-pieIcon c-pieIcon--app-order', null, 'xs', 'IconAppOrder');
 
             expect(received).toHaveProperty('className');
+            expect(received).not.toHaveProperty('class');
             expect(received).toHaveProperty('width');
             expect(received).toHaveProperty('height');
         });

--- a/packages/tools/pie-icons-configs/configs-react.js
+++ b/packages/tools/pie-icons-configs/configs-react.js
@@ -14,6 +14,7 @@ export const getReactSvgProps = (svgClasses, staticClasses, iconSizeValue, compo
 
     return {
         className: result.class,
-        ...result,
+        width: result.width,
+        height: result.height,
     };
 };


### PR DESCRIPTION
Removes `class` attr application for React icon components