### PR TITLE
fix(pie-icons-configs): removes a console error if iconSize prop is not passed

### DIFF
--- a/.changeset/wet-hounds-trade.md
+++ b/.changeset/wet-hounds-trade.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-icons-configs": patch
+"@justeattakeaway/pie-icons-react": patch
+"@justeattakeaway/pie-icons-vue": patch
+---
+
+[Fixed]: removes a console error if iconSize prop is not passed

--- a/.changeset/wet-hounds-trade.md
+++ b/.changeset/wet-hounds-trade.md
@@ -5,3 +5,4 @@
 ---
 
 [Fixed]: removes a console error if iconSize prop is not passed
+[Changed]: in case of invalid `iconSize` being passed to large icons now the size defaults to the `largeIconSizeDefault`

--- a/packages/tools/pie-icons-configs/__tests__/configs.test.js
+++ b/packages/tools/pie-icons-configs/__tests__/configs.test.js
@@ -112,70 +112,129 @@ describe('validateGetRegularIconSize', () => {
 });
 
 describe('getSvgProps', () => {
-    describe('when provided with a class for regular size icon', () => {
-        const iconName = 'IconAppOrder';
-
-        describe('when provided with valid parameters', () => {
-            it('returns an object that contains a class and width and height properties', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order', null, regularIconSizeDefault, iconName);
+    const regularIconSizeName = 'IconTest';
+    describe('when provided with a', () => {
+        describe('svgClasses parameter', () => {
+            it('returns an object that contains a class attr with the expected classes', () => {
+                const received = getSvgProps('icon-test', null, null, regularIconSizeName);
 
                 expect(received).toHaveProperty('class');
-                expect(received).toHaveProperty('width');
-                expect(received).toHaveProperty('height');
-            });
-
-            it('has expected width and height values', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order', null, regularIconSizeDefault, iconName);
-                const expectedRegularIconSizeValue = sizeToValueMap[regularIconSizeDefault];
-
-                expect(received.width).toEqual(expectedRegularIconSizeValue);
-                expect(received.height).toEqual(expectedRegularIconSizeValue);
-            });
-
-            describe('when provided with a staticClasses parameter', () => {
-                it('returns an object with the expected classes', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order', 'FOO BAR', regularIconSizeDefault, iconName);
-
-                    expect(received.class).toEqual(expect.stringContaining('pie-icon'));
-                    expect(received.class).toEqual(expect.stringContaining('pie-icon--app-order'));
-                    expect(received.class).toEqual(expect.stringContaining('FOO BAR'));
-                });
+                expect(received.class).toEqual('icon-test');
             });
         });
 
-        describe('when provided with invalid parameters', () => {
-            it('returns an object with the expected classes', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order', null, 'n', iconName);
+        describe('staticClasses parameter', () => {
+            it('returns an object that contains a class attr with the expected classes', () => {
+                const received = getSvgProps('icon-test', 'FOO BAR', null, regularIconSizeName);
 
-                expect(received.class).toEqual(expect.stringContaining('pie-icon'));
-                expect(received.class).toEqual(expect.stringContaining('pie-icon--app-order'));
+                expect(received).toHaveProperty('class');
+                expect(received.class).toEqual('icon-test FOO BAR');
+            });
+        });
+
+        describe('valid iconSizeValue parameter', () => {
+            it('returns an object that contains a width and height attr with the correct values', () => {
+                const received = getSvgProps('icon-test', null, regularIconSizeDefault, regularIconSizeName);
+                const expectedRegularIconSizeValue = sizeToValueMap[regularIconSizeDefault];
+
+                expect(received).toHaveProperty('width');
+                expect(received).toHaveProperty('height');
+                expect(received.width).toEqual(expectedRegularIconSizeValue);
+                expect(received.height).toEqual(expectedRegularIconSizeValue);
+            });
+        });
+    });
+
+    describe('when provided with invalid iconSizeValue parameter', () => {
+        const invalidIconSizeValue = 'n';
+
+        it('returns an object with valid width and height properties', () => {
+            const errorMock = vi.fn();
+            console.error = errorMock;
+            const received = getSvgProps('icon-test', null, invalidIconSizeValue, regularIconSizeName);
+
+            expect(received.width).toEqual(defaultRegularIconSize);
+            expect(received.height).toEqual(defaultRegularIconSize);
+        });
+
+        it('outputs a console error', () => {
+            const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+
+            getSvgProps('icon-test', null, invalidIconSizeValue, regularIconSizeName);
+
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining(regularIconSizeName));
+            spy.mockRestore();
+        });
+    });
+
+    describe('when iconSizeValue is not provided', () => {
+        it('returns an object with default icon width and height properties', () => {
+            const received = getSvgProps('icon-test', null, null, regularIconSizeName);
+
+            expect(received.width).toEqual(defaultRegularIconSize);
+            expect(received.height).toEqual(defaultRegularIconSize);
+        });
+        it('does not output a console error', () => {
+            const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+
+            expect(spy).not.toHaveBeenCalled();
+            spy.mockRestore();
+        });
+    });
+
+    describe('when svgClasses parameter contains -large in class name', () => {
+        const largeIconSizeName = 'IconTestLarge';
+        describe('when provided with valid iconSizeValue parameter', () => {
+            it('returns an object that contains a width and height attr with the correct values', () => {
+                const validLargeIconSize = 48;
+                const received = getSvgProps('icon-test-large', null, validLargeIconSize, largeIconSizeName);
+
+                expect(received).toHaveProperty('width');
+                expect(received).toHaveProperty('height');
+                expect(received.width).toEqual(validLargeIconSize);
+                expect(received.height).toEqual(validLargeIconSize);
+            });
+        });
+
+        describe('when provided with invalid iconSizeValue parameter', () => {
+            const invalidSize = 49;
+            const errorMock = vi.fn();
+            console.error = errorMock;
+
+            it('returns an object with the default width and height', () => {
+                const received = getSvgProps('icon-test-large', null, invalidSize, largeIconSizeName);
+
+                expect(received.width).toEqual(largeIconSizeDefault);
+                expect(received.height).toEqual(largeIconSizeDefault);
             });
 
-            it('returns an object with valid width and height properties', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order', null, 'n', iconName);
+            it('returns an object with the expected classes', () => {
+                const received = getSvgProps('icon-test-large', null, invalidSize, largeIconSizeName);
 
-                expect(received.width).toEqual(defaultRegularIconSize);
-                expect(received.height).toEqual(defaultRegularIconSize);
+                expect(received).toHaveProperty('class');
+                expect(received.class).toEqual('icon-test-large');
             });
 
             it('outputs a console error', () => {
-                const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+                const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
-                getSvgProps('pie-icon pie-icon--app-order', 'FOO', 'n', iconName);
+                getSvgProps('icon-test-large', null, invalidSize, largeIconSizeName);
 
                 expect(spy).toHaveBeenCalled();
                 expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
-                expect(spy).toHaveBeenCalledWith(expect.stringContaining(iconName));
+                expect(spy).toHaveBeenCalledWith(expect.stringContaining(largeIconSizeName));
                 spy.mockRestore();
             });
         });
 
         describe('when iconSize is not provided', () => {
             it('returns an object with default icon width and height properties', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order', null, null, iconName);
+                const received = getSvgProps('test-large', null, null, largeIconSizeName);
 
-                expect(received.width).toEqual(defaultRegularIconSize);
-                expect(received.height).toEqual(defaultRegularIconSize);
+                expect(received.width).toEqual(largeIconSizeDefault);
+                expect(received.height).toEqual(largeIconSizeDefault);
             });
             it('does not output a console error', () => {
                 const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
@@ -185,84 +244,4 @@ describe('getSvgProps', () => {
             });
         });
     });
-
-    describe('when provided with a class for large size icon', () => {
-        describe('when provided with valid parameters', () => {
-            it('returns an object that contains a class and width and height properties', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order-large', null, largeIconSizeDefault);
-
-                expect(received).toHaveProperty('class');
-                expect(received).toHaveProperty('width');
-                expect(received).toHaveProperty('height');
-            });
-
-            describe('when provided with a staticClasses parameter', () => {
-                it('returns an object with the expected classes', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', 'FOO BAR', largeIconSizeDefault);
-
-                    expect(received.class).toEqual(expect.stringContaining('pie-icon'));
-                    expect(received.class).toEqual(expect.stringContaining('pie-icon--app-order'));
-                    expect(received.class).toEqual(expect.stringContaining('FOO BAR'));
-                });
-            });
-        });
-
-        describe('when provided with invalid parameters', () => {
-            const iconName = 'IconAppOrder';
-            const errorMock = vi.fn();
-            console.error = errorMock;
-            const invalidSize = 49;
-            const expectedSize = 48;
-
-            describe('when provided with an invalid iconSize', () => {
-                it('returns an object with the default width and height', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
-
-                    expect(received).toHaveProperty('class');
-                    expect(received.width).toEqual(expectedSize);
-                    expect(received.height).toEqual(expectedSize);
-                });
-
-                it('returns an object with the expected classes', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
-
-                    expect(received.class).toEqual(expect.stringContaining('pie-icon'));
-                    expect(received.class).toEqual(expect.stringContaining('pie-icon--app-order-large'));
-                });
-
-                it('returns an object with valid width and height properties', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
-
-                    expect(received.width).toEqual(expectedSize);
-                    expect(received.height).toEqual(expectedSize);
-                });
-
-                it('outputs a console error', () => {
-                    const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
-
-                    getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
-
-                    expect(spy).toHaveBeenCalled();
-                    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
-                    expect(spy).toHaveBeenCalledWith(expect.stringContaining(iconName));
-                    spy.mockRestore();
-                });
-            });
-            describe('when iconSize is not provided', () => {
-                it('returns an object with default icon width and height properties', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, null, iconName);
-
-                    expect(received.width).toEqual(largeIconSizeDefault);
-                    expect(received.height).toEqual(largeIconSizeDefault);
-                });
-                it('does not output a console error', () => {
-                    const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
-
-                    expect(spy).not.toHaveBeenCalled();
-                    spy.mockRestore();
-                });
-            });
-        });
-    });
 });
-

--- a/packages/tools/pie-icons-configs/__tests__/configs.test.js
+++ b/packages/tools/pie-icons-configs/__tests__/configs.test.js
@@ -1,4 +1,5 @@
 import {
+    afterEach,
     describe,
     it,
     expect,
@@ -16,6 +17,10 @@ import {
 const defaultRegularIconSize = sizeToValueMap[regularIconSizeDefault];
 
 describe('validateGetLargeIconSize', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     describe('when provided with valid iconSize value', () => {
         it('returns an object with the expected keys and values', () => {
             const received = validateGetLargeIconSize(largeIconSizeDefault);
@@ -148,9 +153,8 @@ describe('getSvgProps', () => {
     describe('when provided with invalid iconSizeValue parameter', () => {
         const invalidIconSizeValue = 'n';
 
-        it('returns an object with valid width and height properties', () => {
-            const errorMock = vi.fn();
-            console.error = errorMock;
+        it('returns an object with default width and height properties', () => {
+            vi.spyOn(console, 'error').mockImplementation(vi.fn());
             const received = getSvgProps('icon-test', null, invalidIconSizeValue, regularIconSizeName);
 
             expect(received.width).toEqual(defaultRegularIconSize);
@@ -159,13 +163,11 @@ describe('getSvgProps', () => {
 
         it('outputs a console error', () => {
             const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
-
             getSvgProps('icon-test', null, invalidIconSizeValue, regularIconSizeName);
 
             expect(spy).toHaveBeenCalled();
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
             expect(spy).toHaveBeenCalledWith(expect.stringContaining(regularIconSizeName));
-            spy.mockRestore();
         });
     });
 
@@ -180,7 +182,6 @@ describe('getSvgProps', () => {
             const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
             expect(spy).not.toHaveBeenCalled();
-            spy.mockRestore();
         });
     });
 
@@ -200,10 +201,9 @@ describe('getSvgProps', () => {
 
         describe('when provided with invalid iconSizeValue parameter', () => {
             const invalidSize = 49;
-            const errorMock = vi.fn();
-            console.error = errorMock;
 
             it('returns an object with the default width and height', () => {
+                vi.spyOn(console, 'error').mockImplementation(vi.fn());
                 const received = getSvgProps('icon-test-large', null, invalidSize, largeIconSizeName);
 
                 expect(received.width).toEqual(largeIconSizeDefault);
@@ -211,6 +211,7 @@ describe('getSvgProps', () => {
             });
 
             it('returns an object with the expected classes', () => {
+                vi.spyOn(console, 'error').mockImplementation(vi.fn());
                 const received = getSvgProps('icon-test-large', null, invalidSize, largeIconSizeName);
 
                 expect(received).toHaveProperty('class');
@@ -219,13 +220,11 @@ describe('getSvgProps', () => {
 
             it('outputs a console error', () => {
                 const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
-
                 getSvgProps('icon-test-large', null, invalidSize, largeIconSizeName);
 
                 expect(spy).toHaveBeenCalled();
                 expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
                 expect(spy).toHaveBeenCalledWith(expect.stringContaining(largeIconSizeName));
-                spy.mockRestore();
             });
         });
 
@@ -240,7 +239,6 @@ describe('getSvgProps', () => {
                 const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
                 expect(spy).not.toHaveBeenCalled();
-                spy.mockRestore();
             });
         });
     });

--- a/packages/tools/pie-icons-configs/__tests__/configs.test.js
+++ b/packages/tools/pie-icons-configs/__tests__/configs.test.js
@@ -13,6 +13,8 @@ import {
     getSvgProps,
 } from '../configs';
 
+const defaultRegularIconSize = sizeToValueMap[regularIconSizeDefault];
+
 describe('validateGetLargeIconSize', () => {
     describe('when provided with valid iconSize value', () => {
         it('returns an object with the expected keys and values', () => {
@@ -66,7 +68,7 @@ describe('validateGetRegularIconSize', () => {
         it('returns an object with the expected keys and values', () => {
             const received = validateGetRegularIconSize('xs');
             const expected = {
-                iconSize: sizeToValueMap[regularIconSizeDefault],
+                iconSize: defaultRegularIconSize,
                 isValid: true,
             };
             expect(received).toEqual(expected);
@@ -75,7 +77,7 @@ describe('validateGetRegularIconSize', () => {
 
     describe('when provided with invalid iconSize value', () => {
         const expected = {
-            iconSize: sizeToValueMap[regularIconSizeDefault],
+            iconSize: defaultRegularIconSize,
             isValid: false,
         };
 
@@ -143,20 +145,42 @@ describe('getSvgProps', () => {
 
         describe('when provided with invalid parameters', () => {
             it('returns an object with the expected classes', () => {
-                const received = getSvgProps('pie-icon pie-icon--app-order', 'FOO', null, iconName);
+                const received = getSvgProps('pie-icon pie-icon--app-order', null, 'n', iconName);
 
                 expect(received.class).toEqual(expect.stringContaining('pie-icon'));
                 expect(received.class).toEqual(expect.stringContaining('pie-icon--app-order'));
             });
 
+            it('returns an object with valid width and height properties', () => {
+                const received = getSvgProps('pie-icon pie-icon--app-order', null, 'n', iconName);
+
+                expect(received.width).toEqual(defaultRegularIconSize);
+                expect(received.height).toEqual(defaultRegularIconSize);
+            });
+
             it('outputs a console error', () => {
                 const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-                getSvgProps('pie-icon pie-icon--app-order', 'FOO', null, iconName);
+                getSvgProps('pie-icon pie-icon--app-order', 'FOO', 'n', iconName);
 
                 expect(spy).toHaveBeenCalled();
                 expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
                 expect(spy).toHaveBeenCalledWith(expect.stringContaining(iconName));
+                spy.mockRestore();
+            });
+        });
+
+        describe('when iconSize is not provided', () => {
+            it('returns an object with default icon width and height properties', () => {
+                const received = getSvgProps('pie-icon pie-icon--app-order', null, null, iconName);
+
+                expect(received.width).toEqual(defaultRegularIconSize);
+                expect(received.height).toEqual(defaultRegularIconSize);
+            });
+            it('does not output a console error', () => {
+                const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+
+                expect(spy).not.toHaveBeenCalled();
                 spy.mockRestore();
             });
         });
@@ -184,48 +208,57 @@ describe('getSvgProps', () => {
         });
 
         describe('when provided with invalid parameters', () => {
-            describe('when provided with an invalid iconSize', () => {
-                const iconName = 'IconAppOrder';
-                const errorMock = vi.fn();
-                console.error = errorMock;
+            const iconName = 'IconAppOrder';
+            const errorMock = vi.fn();
+            console.error = errorMock;
+            const invalidSize = 49;
+            const expectedSize = 48;
 
-                it('returns an object with width and height properties', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, null, iconName);
+            describe('when provided with an invalid iconSize', () => {
+                it('returns an object with the default width and height', () => {
+                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
 
                     expect(received).toHaveProperty('class');
-                    expect(received).toHaveProperty('width');
-                    expect(received).toHaveProperty('height');
-                });
-
-                it('returns an object with the default width and height', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, null, iconName);
-
-                    expect(received.width).toEqual(largeIconSizeDefault);
-                    expect(received.height).toEqual(largeIconSizeDefault);
+                    expect(received.width).toEqual(expectedSize);
+                    expect(received.height).toEqual(expectedSize);
                 });
 
                 it('returns an object with the expected classes', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, null, iconName);
+                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
 
                     expect(received.class).toEqual(expect.stringContaining('pie-icon'));
                     expect(received.class).toEqual(expect.stringContaining('pie-icon--app-order-large'));
                 });
 
                 it('returns an object with valid width and height properties', () => {
-                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, 49, iconName);
-                    const expected = 48;
-                    expect(received.width).toEqual(expected);
-                    expect(received.height).toEqual(expected);
+                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
+
+                    expect(received.width).toEqual(expectedSize);
+                    expect(received.height).toEqual(expectedSize);
                 });
 
                 it('outputs a console error', () => {
                     const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
-                    getSvgProps('pie-icon pie-icon--app-order-large', 'FOO', null, iconName);
+                    getSvgProps('pie-icon pie-icon--app-order-large', null, invalidSize, iconName);
 
                     expect(spy).toHaveBeenCalled();
                     expect(spy).toHaveBeenCalledWith(expect.stringContaining('Invalid prop "iconSize" value'));
                     expect(spy).toHaveBeenCalledWith(expect.stringContaining(iconName));
+                    spy.mockRestore();
+                });
+            });
+            describe('when iconSize is not provided', () => {
+                it('returns an object with default icon width and height properties', () => {
+                    const received = getSvgProps('pie-icon pie-icon--app-order-large', null, null, iconName);
+
+                    expect(received.width).toEqual(largeIconSizeDefault);
+                    expect(received.height).toEqual(largeIconSizeDefault);
+                });
+                it('does not output a console error', () => {
+                    const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+
+                    expect(spy).not.toHaveBeenCalled();
                     spy.mockRestore();
                 });
             });

--- a/packages/tools/pie-icons-configs/configs.js
+++ b/packages/tools/pie-icons-configs/configs.js
@@ -40,17 +40,9 @@ export const iconSizeValidator = {
 export function validateGetLargeIconSize (iconSizeValue) {
     const isValid = iconSizeValidator.large(iconSizeValue);
 
-    if (!isValid) {
-        const parsedValue = parseInt(iconSizeValue, 10) || 0;
-        // Ensure the size is a multiple of module
-        const multipleOfModule = Math.floor(parsedValue / largeIconSizeModule) * largeIconSizeModule;
-        // Ensure to return the default size if the size is smaller than the default size
-        const normalizedIconSize = Math.max(multipleOfModule, largeIconSizeDefault);
+    const iconSize = isValid ? iconSizeValue : largeIconSizeDefault;
 
-        return { isValid: false, iconSize: normalizedIconSize };
-    }
-
-    return { isValid: true, iconSize: iconSizeValue };
+    return { isValid, iconSize };
 }
 
 /**

--- a/packages/tools/pie-icons-configs/configs.js
+++ b/packages/tools/pie-icons-configs/configs.js
@@ -80,16 +80,23 @@ export function validateGetRegularIconSize (iconSizeValue) {
 export const getSvgProps = (svgClasses, staticClasses, iconSizeValue, componentName) => {
     const isLargeIcon = svgClasses.endsWith('Large') || svgClasses.endsWith('-large');
 
-    const { isValid, iconSize } = isLargeIcon
-        ? validateGetLargeIconSize(iconSizeValue)
-        : validateGetRegularIconSize(iconSizeValue);
+    let isValid;
+    let iconSize;
 
-    if (!isValid) {
-        const errorMessage = isLargeIcon
-            ? `Invalid prop "iconSize" value supplied to "${componentName}". The prop value should be a number equal or greater than ${largeIconSizeDefault} and multiple of ${largeIconSizeModule}.`
-            : `Invalid prop "iconSize" value supplied to "${componentName}". The prop value should be one of the following values: ${regularIconSizes.join(', ')}.`;
+    if (iconSizeValue) {
+        ({ isValid, iconSize } = isLargeIcon
+            ? validateGetLargeIconSize(iconSizeValue)
+            : validateGetRegularIconSize(iconSizeValue));
 
-        console.error(errorMessage);
+        if (!isValid) {
+            const errorMessage = isLargeIcon
+                ? `Invalid prop "iconSize" value supplied to "${componentName}". The prop value should be a number equal or greater than ${largeIconSizeDefault} and multiple of ${largeIconSizeModule}.`
+                : `Invalid prop "iconSize" value supplied to "${componentName}". The prop value should be one of the following values: ${regularIconSizes.join(', ')}.`;
+
+            console.error(errorMessage);
+        }
+    } else {
+        iconSize = isLargeIcon ? largeIconSizeDefault : sizeToValueMap[regularIconSizeDefault];
     }
 
     return {


### PR DESCRIPTION
[Fixed]: removes a console error if `iconSize` prop is not passed
[Changed]: in case of invalid `iconSize` being passed to large icons now the size defaults to the `largeIconSizeDefault`