### PR TITLE
refactor(pie-webc-core): [Changed] - Use factory pattern for decorators

### DIFF
--- a/.changeset/cyan-countries-scream.md
+++ b/.changeset/cyan-countries-scream.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+---
+
+[Changed] - Use factory pattern for decorators

--- a/.changeset/friendly-carrots-remain.md
+++ b/.changeset/friendly-carrots-remain.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-icon-button": minor
+"@justeattakeaway/pie-button": minor
+"@justeattakeaway/pie-modal": minor
+---
+
+[Changed] - Use new decorator factories

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -14,8 +14,8 @@ export {
     variants,
 };
 
-const componentName = 'pie-button';
-const validPropertyValues = validPropertyValuesDecoratorFactory(componentName);
+const componentSelector = 'pie-button';
+const validPropertyValues = validPropertyValuesDecoratorFactory(componentSelector);
 
 export class PieButton extends LitElement {
     @property()
@@ -57,10 +57,10 @@ export class PieButton extends LitElement {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentName, PieButton);
+customElements.define(componentSelector, PieButton);
 
 declare global {
     interface HTMLElementTagNameMap {
-        [componentName]: PieButton;
+        [componentSelector]: PieButton;
     }
 }

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValuesDecoratorFactory } from '@justeattakeaway/pie-webc-core';
 import styles from './button.scss?inline';
 import {
     ButtonProps, sizes, types, variants,
@@ -14,19 +14,20 @@ export {
     variants,
 };
 
-const componentSelector = 'pie-button';
+const componentName = 'pie-button';
+const validPropertyValues = validPropertyValuesDecoratorFactory(componentName);
 
 export class PieButton extends LitElement {
     @property()
-    @validPropertyValues(componentSelector, sizes, 'medium')
+    @validPropertyValues(sizes, 'medium')
         size: ButtonProps['size'] = 'medium';
 
     @property()
-    @validPropertyValues(componentSelector, types, 'submit')
+    @validPropertyValues(types, 'submit')
         type: ButtonProps['type'] = 'submit';
 
     @property()
-    @validPropertyValues(componentSelector, variants, 'primary')
+    @validPropertyValues(variants, 'primary')
         variant: ButtonProps['variant'] = 'primary';
 
     @property({ type: Boolean })
@@ -56,10 +57,10 @@ export class PieButton extends LitElement {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieButton);
+customElements.define(componentName, PieButton);
 
 declare global {
     interface HTMLElementTagNameMap {
-        [componentSelector]: PieButton;
+        [componentName]: PieButton;
     }
 }

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -10,8 +10,8 @@ import {
 // Valid values available to consumers
 export { type IconButtonProps, sizes, variants };
 
-const componentName = 'pie-icon-button';
-const validPropertyValues = validPropertyValuesDecoratorFactory(componentName);
+const componentSelector = 'pie-icon-button';
+const validPropertyValues = validPropertyValuesDecoratorFactory(componentSelector);
 
 export class PieIconButton extends LitElement {
     @property()
@@ -47,10 +47,10 @@ export class PieIconButton extends LitElement {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentName, PieIconButton);
+customElements.define(componentSelector, PieIconButton);
 
 declare global {
     interface HTMLElementTagNameMap {
-        [componentName]: PieIconButton;
+        [componentSelector]: PieIconButton;
     }
 }

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValuesDecoratorFactory } from '@justeattakeaway/pie-webc-core';
 
 import styles from './iconButton.scss?inline';
 import {
@@ -10,15 +10,16 @@ import {
 // Valid values available to consumers
 export { type IconButtonProps, sizes, variants };
 
-const componentSelector = 'pie-icon-button';
+const componentName = 'pie-icon-button';
+const validPropertyValues = validPropertyValuesDecoratorFactory(componentName);
 
 export class PieIconButton extends LitElement {
     @property()
-    @validPropertyValues(componentSelector, sizes, 'medium')
+    @validPropertyValues(sizes, 'medium')
         size: IconButtonProps['size'] = 'medium';
 
     @property()
-    @validPropertyValues(componentSelector, variants, 'primary')
+    @validPropertyValues(variants, 'primary')
         variant: IconButtonProps['variant'] = 'primary';
 
     @property({ type: Boolean })
@@ -46,10 +47,10 @@ export class PieIconButton extends LitElement {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieIconButton);
+customElements.define(componentName, PieIconButton);
 
 declare global {
     interface HTMLElementTagNameMap {
-        [componentSelector]: PieIconButton;
+        [componentName]: PieIconButton;
     }
 }

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -16,9 +16,9 @@ import {
 // Valid values available to consumers
 export { type ModalProps, headingLevels };
 
-const componentName = 'pie-modal';
-const validPropertyValues = validPropertyValuesDecoratorFactory(componentName);
-const requiredProperty = requiredPropertyDecoratorFactory(componentName);
+const componentSelector = 'pie-modal';
+const validPropertyValues = validPropertyValuesDecoratorFactory(componentSelector);
+const requiredProperty = requiredPropertyDecoratorFactory(componentSelector);
 
 export class PieModal extends RtlMixin(LitElement) {
     @property({ type: Boolean })
@@ -196,10 +196,10 @@ export class PieModal extends RtlMixin(LitElement) {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentName, PieModal);
+customElements.define(componentSelector, PieModal);
 
 declare global {
     interface HTMLElementTagNameMap {
-        [componentName]: PieModal;
+        [componentSelector]: PieModal;
     }
 }

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -2,7 +2,9 @@ import { LitElement, unsafeCSS } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { property, query } from 'lit/decorators.js';
 import {
-    RtlMixin, validPropertyValues, requiredProperty,
+    RtlMixin,
+    validPropertyValuesDecoratorFactory,
+    requiredPropertyDecoratorFactory,
 } from '@justeattakeaway/pie-webc-core';
 import type { DependentMap } from '@justeattakeaway/pie-webc-core';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
@@ -14,18 +16,20 @@ import {
 // Valid values available to consumers
 export { type ModalProps, headingLevels };
 
-const componentSelector = 'pie-modal';
+const componentName = 'pie-modal';
+const validPropertyValues = validPropertyValuesDecoratorFactory(componentName);
+const requiredProperty = requiredPropertyDecoratorFactory(componentName);
 
 export class PieModal extends RtlMixin(LitElement) {
     @property({ type: Boolean })
         isOpen = false;
 
     @property({ type: String })
-    @requiredProperty(componentSelector)
+    @requiredProperty()
         heading!: string;
 
     @property()
-    @validPropertyValues(componentSelector, headingLevels, 'h2')
+    @validPropertyValues(headingLevels, 'h2')
         headingLevel: ModalProps['headingLevel'] = 'h2';
 
     @query('dialog')
@@ -192,10 +196,10 @@ export class PieModal extends RtlMixin(LitElement) {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieModal);
+customElements.define(componentName, PieModal);
 
 declare global {
     interface HTMLElementTagNameMap {
-        [componentSelector]: PieModal;
+        [componentName]: PieModal;
     }
 }

--- a/packages/components/pie-webc-core/src/decorators/required-property.ts
+++ b/packages/components/pie-webc-core/src/decorators/required-property.ts
@@ -1,25 +1,32 @@
 /**
- * A decorator for marking a property as required.
- * If the property's value is `undefined`, `null` or empty string, an error is logged.
- * @returns {Function} - The decorator function.
+ * @param componentName - The name of your component. This is included in any error logs.
+ * @returns - A function that returns the decorator function.
  */
-export const requiredProperty = <T>(componentName: string) => function validateRequiredProperty (target: object, propertyKey: string): void {
-    const privatePropertyKey = `#${propertyKey}`;
+export const requiredPropertyDecoratorFactory = (componentName: string) => {
+    /**
+     * A decorator for marking a property as required.
+     * If the property's value is `undefined`, `null` or empty string, an error is logged.
+     * @returns {Function} - The decorator function.
+     */
+    const requiredProperty = <T>() => function validateRequiredProperty (target: object, propertyKey: string): void {
+        const privatePropertyKey = `#${propertyKey}`;
 
-    Object.defineProperty(target, propertyKey, {
-        get (): T {
-            return this[privatePropertyKey];
-        },
-        set (value: T): void {
-            const oldValue = this[privatePropertyKey];
+        Object.defineProperty(target, propertyKey, {
+            get (): T {
+                return this[privatePropertyKey];
+            },
+            set (value: T): void {
+                const oldValue = this[privatePropertyKey];
 
-            if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) {
-                console.error(`<${componentName}> Missing required attribute "${propertyKey}"`);
-            }
-            this[privatePropertyKey] = value;
+                if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) {
+                    console.error(`<${componentName}> Missing required attribute "${propertyKey}"`);
+                }
+                this[privatePropertyKey] = value;
 
-            this.requestUpdate(propertyKey, oldValue);
-        },
-    });
+                this.requestUpdate(propertyKey, oldValue);
+            },
+        });
+    };
+
+    return requiredProperty;
 };
-

--- a/packages/components/pie-webc-core/src/decorators/test/required-property.spec.ts
+++ b/packages/components/pie-webc-core/src/decorators/test/required-property.spec.ts
@@ -9,8 +9,8 @@ import {
 
 import { requiredPropertyDecoratorFactory } from '../required-property';
 
-const mockComponentName = 'mock-component';
-const requiredProperty = requiredPropertyDecoratorFactory(mockComponentName);
+const mockComponentSelector = 'mock-component';
+const requiredProperty = requiredPropertyDecoratorFactory(mockComponentSelector);
 
 describe('requiredProperty', () => {
     let consoleErrorSpy: unknown;

--- a/packages/components/pie-webc-core/src/decorators/test/required-property.spec.ts
+++ b/packages/components/pie-webc-core/src/decorators/test/required-property.spec.ts
@@ -7,7 +7,10 @@ import {
     vi,
 } from 'vitest';
 
-import { requiredProperty } from '../required-property';
+import { requiredPropertyDecoratorFactory } from '../required-property';
+
+const mockComponentName = 'mock-component';
+const requiredProperty = requiredPropertyDecoratorFactory(mockComponentName);
 
 describe('requiredProperty', () => {
     let consoleErrorSpy: unknown;
@@ -23,7 +26,7 @@ describe('requiredProperty', () => {
 
     // Mock class to test the decorator
     class MockComponent {
-        @requiredProperty('mock-component')
+        @requiredProperty()
             color?: string | null;
 
         private _requestUpdateArgs = {};

--- a/packages/components/pie-webc-core/src/decorators/test/valid-property-values.spec.ts
+++ b/packages/components/pie-webc-core/src/decorators/test/valid-property-values.spec.ts
@@ -9,8 +9,8 @@ import {
 
 import { validPropertyValuesDecoratorFactory } from '../valid-property-values';
 
-const mockComponentName = 'mock-component';
-const validPropertyValues = validPropertyValuesDecoratorFactory(mockComponentName);
+const mockComponentSelector = 'mock-component';
+const validPropertyValues = validPropertyValuesDecoratorFactory(mockComponentSelector);
 
 describe('validPropertyValues', () => {
     let consoleErrorSpy: unknown;

--- a/packages/components/pie-webc-core/src/decorators/test/valid-property-values.spec.ts
+++ b/packages/components/pie-webc-core/src/decorators/test/valid-property-values.spec.ts
@@ -7,7 +7,10 @@ import {
     vi,
 } from 'vitest';
 
-import { validPropertyValues } from '../valid-property-values';
+import { validPropertyValuesDecoratorFactory } from '../valid-property-values';
+
+const mockComponentName = 'mock-component';
+const validPropertyValues = validPropertyValuesDecoratorFactory(mockComponentName);
 
 describe('validPropertyValues', () => {
     let consoleErrorSpy: unknown;
@@ -23,7 +26,7 @@ describe('validPropertyValues', () => {
 
     // Mock class to test the decorator
     class MockComponent {
-        @validPropertyValues('mock-component', ['red', 'green', 'blue'], 'red')
+        @validPropertyValues(['red', 'green', 'blue'], 'red')
             color = 'red';
 
         private _requestUpdateArgs = {};

--- a/packages/components/pie-webc-core/src/decorators/valid-property-values.ts
+++ b/packages/components/pie-webc-core/src/decorators/valid-property-values.ts
@@ -1,32 +1,41 @@
+
 /**
- * A decorator for specifying a list of valid values for a property.
- * If this property's setter is called with an invalid value, an error is logged and the default value will be assigned instead.
- * @param validValues - The array of valid values
- * @param defaultValue - The value to fall back on
- * @returns  - The decorator function
+ * @param componentName - The name of your component. This is included in any error logs.
+ * @returns - A function that returns the decorator function.
  */
-export const validPropertyValues = <T>(componentName: string, validValues: readonly T[], defaultValue: T) => function validatePropertyValues (target: object, propertyKey: string): void {
-    const privatePropertyKey = `#${propertyKey}`;
+export const validPropertyValuesDecoratorFactory = (componentName: string) => {
+    /**
+     * A decorator for specifying a list of valid values for a property.
+     * If this property's setter is called with an invalid value, an error is logged and the default value will be assigned instead.
+     * @param validValues - The array of valid values
+     * @param defaultValue - The value to fall back on
+     * @returns  - The decorator function
+     */
+    const validPropertyValues = <T>(validValues: readonly T[], defaultValue: T) => function validatePropertyValues (target: object, propertyKey: string): void {
+        const privatePropertyKey = `#${propertyKey}`;
 
-    Object.defineProperty(target, propertyKey, {
-        get (): T {
-            return this[privatePropertyKey];
-        },
-        set (value: T): void {
-            const oldValue = this[privatePropertyKey];
+        Object.defineProperty(target, propertyKey, {
+            get (): T {
+                return this[privatePropertyKey];
+            },
+            set (value: T): void {
+                const oldValue = this[privatePropertyKey];
 
-            if (!validValues.includes(value)) {
-                console.error(
-                        `<${componentName}> Invalid value "${value}" provided for property "${propertyKey}".`,
-                        `Must be one of: ${validValues.join(' | ')}.`,
-                        `Falling back to default value: "${defaultValue}"`,
-                );
-                this[privatePropertyKey] = defaultValue;
-            } else {
-                this[privatePropertyKey] = value;
-            }
+                if (!validValues.includes(value)) {
+                    console.error(
+                            `<${componentName}> Invalid value "${value}" provided for property "${propertyKey}".`,
+                            `Must be one of: ${validValues.join(' | ')}.`,
+                            `Falling back to default value: "${defaultValue}"`,
+                    );
+                    this[privatePropertyKey] = defaultValue;
+                } else {
+                    this[privatePropertyKey] = value;
+                }
 
-            this.requestUpdate(propertyKey, oldValue);
-        },
-    });
+                this.requestUpdate(propertyKey, oldValue);
+            },
+        });
+    };
+
+    return validPropertyValues;
 };


### PR DESCRIPTION
I recommend hiding whitespace changes when reviewing to limit the (nesting) diffs in the decorator files.

## Describe your changes (can list changeset entries if preferable)
Testing the waters to see if we like the look of this pattern or if it adds an unnecessary layer.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
