### PR TITLE
feat(pie-monorepo): ensure modal and icon-button implement interfaces

### DIFF
--- a/.changeset/mean-singers-camp.md
+++ b/.changeset/mean-singers-camp.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-icon-button": minor
+"@justeattakeaway/pie-modal": minor
+---
+
+[Changed] - Ensure component implements it's props interface

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -14,7 +14,7 @@ export { IconCloseLarge };
 
 const componentSelector = 'pie-icon-button';
 
-export class PieIconButton extends LitElement {
+export class PieIconButton extends LitElement implements IconButtonProps {
     @property()
     @validPropertyValues(componentSelector, sizes, 'medium')
     public size: IconButtonProps['size'] = 'medium';

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -22,7 +22,7 @@ export { type ModalProps, headingLevels, sizes };
 
 const componentSelector = 'pie-modal';
 
-export class PieModal extends RtlMixin(LitElement) {
+export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     @property({ type: String })
     @requiredProperty(componentSelector)
     public heading!: string;


### PR DESCRIPTION
---
"@justeattakeaway/pie-icon-button": minor
"@justeattakeaway/pie-modal": minor
---

[Changed] - Ensure component implements it's props interface