### PR TITLE
fix(pie-wrapper-react): add events to custom-elements.json

### DIFF
--- a/.changeset/bright-carpets-compete.md
+++ b/.changeset/bright-carpets-compete.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-wrapper-react": minor
+---
+
+[Fixed] - Correctly handle event casing and their descriptions in react wrappers

--- a/.changeset/cuddly-jeans-brush.md
+++ b/.changeset/cuddly-jeans-brush.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Added] - @fires jsdoc comments for modal events for react wrapper to analyse

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -22,6 +22,10 @@ export { type ModalProps, headingLevels, sizes };
 
 const componentSelector = 'pie-modal';
 
+/**
+ * @fires pie-modal-open - when the modal is opened.
+ * @fires pie-modal-close - when the modal is closed.
+ */
 export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     @property({ type: String })
     @requiredProperty(componentSelector)

--- a/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
+++ b/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
@@ -3,16 +3,18 @@
 exports[`React Wrapper should be added from mock custom elements JSON 1`] = `
 "
 import * as React from 'react';
+import { createComponent, EventName } from '@lit-labs/react';
 import { MockComponent as MockComponentReact } from './index';
-import { createComponent } from '@lit-labs/react';
-import { EventName } from '@lit-labs/react';
 
 export const MockComponent = createComponent({
     displayName: 'MockComponent',
     elementClass: MockComponentReact,
     react: React,
     tagName: 'mock-component',
-    events: { onCustomEvent: 'CustomEvent' as EventName<CustomEvent>, onAnotherCustomEvent: 'AnotherCustomEvent' as EventName<CustomEvent>, },
+    events: {
+        onCustomEvent: 'CustomEvent' as EventName<CustomEvent>, 
+        onAnotherCustomEvent: 'AnotherCustomEvent' as EventName<CustomEvent>, 
+    },
 });
 "
 `;
@@ -20,15 +22,15 @@ export const MockComponent = createComponent({
 exports[`React Wrapper should be named the same as the component itself 1`] = `
 "
 import * as React from 'react';
-import { ButtonComponent as ButtonComponentReact } from './index';
 import { createComponent } from '@lit-labs/react';
+import { ButtonComponent as ButtonComponentReact } from './index';
 
 export const ButtonComponent = createComponent({
     displayName: 'ButtonComponent',
     elementClass: ButtonComponentReact,
     react: React,
     tagName: 'mock-component',
-    events: { },
+    events: {},
 });
 "
 `;
@@ -36,15 +38,15 @@ export const ButtonComponent = createComponent({
 exports[`React Wrapper should leave the events object empty if the component contains no custom events 1`] = `
 "
 import * as React from 'react';
-import { MockComponent as MockComponentReact } from './index';
 import { createComponent } from '@lit-labs/react';
+import { MockComponent as MockComponentReact } from './index';
 
 export const MockComponent = createComponent({
     displayName: 'MockComponent',
     elementClass: MockComponentReact,
     react: React,
     tagName: 'mock-component',
-    events: { },
+    events: {},
 });
 "
 `;

--- a/packages/tools/pie-wrapper-react/__tests__/wrapper.test.js
+++ b/packages/tools/pie-wrapper-react/__tests__/wrapper.test.js
@@ -32,7 +32,7 @@ describe('React Wrapper', () => {
 
         const wrapper = addReactWrapper(mockExample, 'pie-wrapper-react');
 
-        const result = 'events: { }';
+        const result = 'events: {}';
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.includes(result)).toBe(true);

--- a/packages/tools/pie-wrapper-react/custom-elements.json
+++ b/packages/tools/pie-wrapper-react/custom-elements.json
@@ -405,6 +405,16 @@
                             }
                         }
                     ],
+                    "events": [
+                        {
+                            "description": "when the modal is opened.",
+                            "name": "pie-modal-open"
+                        },
+                        {
+                            "description": "when the modal is closed.",
+                            "name": "pie-modal-close"
+                        }
+                    ],
                     "mixins": [
                         {
                             "name": "RtlMixin",
@@ -601,14 +611,6 @@
                     "name": "variants",
                     "declaration": {
                         "name": "variants",
-                        "module": "../../components/pie-button/src/index.js"
-                    }
-                },
-                {
-                    "kind": "js",
-                    "name": "IconLoading",
-                    "declaration": {
-                        "name": "IconLoading",
                         "module": "../../components/pie-button/src/index.js"
                     }
                 },

--- a/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
+++ b/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
@@ -81,27 +81,33 @@ export function addReactWrapper (customElementsObject, folderName = process.argv
         components.forEach((component) => {
             const events = getEvents(component.class);
 
+            // Prepare the event names and comments
+            let eventNames = '';
+            if (component.class.events && component.class.events.length > 0) {
+                eventNames = events?.flat().reduce((pre, event) => {
+                    const eventNameClone = event.name.slice();
+                    return `${pre
+                    }        ${`on${eventNameClone.replace(/-/g, '')}`}: '${event.name}' as EventName<${event.type}>, ${event.description ? `// ${event.description}` : ''}\n`;
+                }, '');
+            }
+
+            let eventsObject = '{}';
+            if (eventNames) {
+                eventsObject = `{\n${eventNames}    }`;
+            }
+
+            // Create the main source code
             componentSrc = `
 import * as React from 'react';
-import { ${component.class.name} as ${`${component.class.name}React`} } from './index';
-import { createComponent } from '@lit-labs/react';${
-component.class.events?.length > 0
-    ? "\nimport { EventName } from '@lit-labs/react';"
-    : ''
-}
+import { createComponent${component.class.events?.length > 0 ? ', EventName' : ''} } from '@lit-labs/react';
+import { ${component.class.name} as ${component.class.name}React } from './index';
 
 export const ${component.class.name} = createComponent({
     displayName: '${component.class.name}',
-    elementClass: ${`${component.class.name}React`},
+    elementClass: ${component.class.name}React,
     react: React,
     tagName: '${component.class.tagName}',
-    events: { ${events?.flat().reduce(
-    (pre, event) => `${pre
-                }${`on${event.name}`}: '${event.name}' as EventName<${event.type}>, ${
-                    event.description ? `// ${event.description}` : ''
-                }`,
-    '',
-)}},
+    events: ${eventsObject},
 });
 `;
             let reactFile;


### PR DESCRIPTION
Currently when a component is build, the `cem analyser` will create a `custom-elements.json` entry for each component. This file is used to create a facade that React uses to interface with our web components.

Part of this facade adds callback hooks to our components where they emit events. This is because React is callback based rather than event-based. React is working to address this for improved integration with Web Components in the future.

A bug in our current implementation is that the `custom-elements.json` file is, for some reason, not detecting emitted events in our components. This means that the events never get added to the json file, never have callbacks added for React, meaning React cannot add callbacks to our components.

To aid in fixing this, I have found that adding `@jsdoc` comments declaring what events a component can emit at the top of the class ensures that they are added to the json file. 

To adhere to callback naming syntax I have read in the Lit docs, I then transform these event names to remove hyphens. So `pie-modal-open` becomes `onpiemodalopen`. [Example in the Lit docs showing this](https://lit.dev/docs/frameworks/react/#usage). Note - `on` is prepended to the event name.

I have also fixed the code so that event description comments are correctly added. Before, they would break the formatting of the `react.ts` files generated and thus would break the component build.

### Before
`react.ts`:

```
import * as React from 'react';
import { createComponent, EventName } from '@lit-labs/react';
import { PieModal as PieModalReact } from './index';

export const PieModal = createComponent({
    displayName: 'PieModal',
    elementClass: PieModalReact,
    react: React,
    tagName: 'pie-modal',
    events: { },
});
```

### After:
```

import * as React from 'react';
import { createComponent, EventName } from '@lit-labs/react';
import { PieModal as PieModalReact } from './index';

export const PieModal = createComponent({
    displayName: 'PieModal',
    elementClass: PieModalReact,
    react: React,
    tagName: 'pie-modal',
    events: {
        onpiemodalopen: 'pie-modal-open' as EventName<Event>, // when the modal is opened.
        onpiemodalclose: 'pie-modal-close' as EventName<Event>, // when the modal is closed.
    },
});

```
