### PR TITLE
feat(pie-wrapper-react): use camelcase for react event callbacks

### DIFF
--- a/.changeset/nice-ladybugs-provide.md
+++ b/.changeset/nice-ladybugs-provide.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-wrapper-react": minor
+---
+
+[Changed] - ensure onEventName format used for react wrapper callbacks

--- a/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
+++ b/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
@@ -12,8 +12,8 @@ export const MockComponent = createComponent({
     react: React,
     tagName: 'mock-component',
     events: {
-        onCustomEvent: 'CustomEvent' as EventName<CustomEvent>, 
-        onAnotherCustomEvent: 'AnotherCustomEvent' as EventName<CustomEvent>, 
+        onCustomEvent: 'custom-event' as EventName<CustomEvent>, 
+        onAnotherCustomEvent: 'another-custom-event' as EventName<CustomEvent>, 
     },
 });
 "

--- a/packages/tools/pie-wrapper-react/__tests__/mocks/mock-custom-elements.json
+++ b/packages/tools/pie-wrapper-react/__tests__/mocks/mock-custom-elements.json
@@ -18,13 +18,13 @@
             ],
             "events": [
                 {
-                "name": "CustomEvent",
+                "name": "custom-event",
                 "type": {
                     "text": "CustomEvent"
                 }
                 },
                 {
-                    "name": "AnotherCustomEvent",
+                    "name": "another-custom-event",
                     "type": {
                         "text": "CustomEvent"
                     }

--- a/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
+++ b/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
@@ -76,6 +76,15 @@ export function addReactWrapper (customElementsObject, folderName = process.argv
         return events;
     }
 
+    // format event names in a React friendly way - removes hyphens and capitalises
+    // i.e. foo-bar-baz becomes FooBarBaz
+    function formatEventName (eventName) {
+        return eventName
+            .split('-')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join('');
+    }
+
     // create wrapper src code and add to react.ts file
     if (components.length > 0) {
         components.forEach((component) => {
@@ -84,11 +93,8 @@ export function addReactWrapper (customElementsObject, folderName = process.argv
             // Prepare the event names and comments
             let eventNames = '';
             if (component.class.events && component.class.events.length > 0) {
-                eventNames = events?.flat().reduce((pre, event) => {
-                    const eventNameClone = event.name.slice();
-                    return `${pre
-                    }        ${`on${eventNameClone.replace(/-/g, '')}`}: '${event.name}' as EventName<${event.type}>, ${event.description ? `// ${event.description}` : ''}\n`;
-                }, '');
+                eventNames = events?.flat().reduce((pre, event) => `${pre
+                    }        ${`on${formatEventName(event.name)}`}: '${event.name}' as EventName<${event.type}>, ${event.description ? `// ${event.description}` : ''}\n`, '');
             }
 
             let eventsObject = '{}';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5226,7 +5226,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.18.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.19.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
@@ -5242,16 +5242,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@npm:0.7.0":
-  version: 0.7.0
-  resolution: "@justeattakeaway/pie-icon-button@npm:0.7.0"
-  dependencies:
-    "@justeattakeaway/pie-icons-webc": "workspace:*"
-  checksum: d946b860cdf24fa9c2fd4ff0689e2ce09e6a237f2a80d2bfeaa1ddaf58438fbe161b9923e22d920a18bf5f1317dba20f7e92efa9686d88f150629bc22a149d42
-  languageName: node
-  linkType: hard
-
-"@justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.9.0, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
@@ -37359,8 +37350,8 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.3.0
-    "@justeattakeaway/pie-button": 0.18.0
-    "@justeattakeaway/pie-icon-button": 0.7.0
+    "@justeattakeaway/pie-button": 0.19.0
+    "@justeattakeaway/pie-icon-button": 0.9.0
     vite: 4.3.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Ensures that React callbacks use camel case for events emitted from our lit components:

Before:
```javascript

import * as React from 'react';
import { createComponent, EventName } from '@lit-labs/react';
import { PieModal as PieModalReact } from './index';

export const PieModal = createComponent({
    displayName: 'PieModal',
    elementClass: PieModalReact,
    react: React,
    tagName: 'pie-modal',
    events: {
        onpiemodalopen: 'pie-modal-open' as EventName<CustomEvent>, // when the modal is opened.
        onpiemodalclose: 'pie-modal-close' as EventName<CustomEvent>, // when the modal is closed.
    },
});
```

After:
```javascript

import * as React from 'react';
import { createComponent, EventName } from '@lit-labs/react';
import { PieModal as PieModalReact } from './index';

export const PieModal = createComponent({
    displayName: 'PieModal',
    elementClass: PieModalReact,
    react: React,
    tagName: 'pie-modal',
    events: {
        onPieModalOpen: 'pie-modal-open' as EventName<CustomEvent>, // when the modal is opened.
        onPieModalClose: 'pie-modal-close' as EventName<CustomEvent>, // when the modal is closed.
    },
});
```

Verified it is working in a CRA project:
<img width="475" alt="Screenshot 2023-07-13 at 10 45 23" src="https://github.com/justeattakeaway/pie/assets/16766185/859ea131-5079-4bb5-a8dd-da34315e9857">
