### PR TITLE
feat(pie-button): DSW-867 added slots for leading and trailing icons

### DIFF
--- a/.changeset/great-baboons-rush.md
+++ b/.changeset/great-baboons-rush.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - expanded controls info and pie-button updated to include icon slots

--- a/.changeset/stale-parents-attack.md
+++ b/.changeset/stale-parents-attack.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": minor
+---
+
+[Added] - Slots for leading and trailing icons

--- a/.changeset/warm-numbers-judge.md
+++ b/.changeset/warm-numbers-judge.md
@@ -1,0 +1,5 @@
+---
+"wc-vanilla": minor
+---
+
+[Added] - Leading & Trailing Button Icons and Icon Button examples

--- a/apps/examples/wc-vanilla/index.html
+++ b/apps/examples/wc-vanilla/index.html
@@ -34,5 +34,7 @@
         <script type="module" src="/main.js"></script>
         <script type="module" src="./node_modules/@justeattakeaway/pie-button"></script>
         <script type="module" src="./node_modules/@justeattakeaway/pie-icon-button"></script>
+        <script type="module" src="./node_modules/@justeattakeaway/pie-icons-webc/icons/IconClose"></script>
+        <script type="module" src="./node_modules/@justeattakeaway/pie-icons-webc/icons/IconSearch"></script>
     </body>
 </html>

--- a/apps/examples/wc-vanilla/main.js
+++ b/apps/examples/wc-vanilla/main.js
@@ -2,11 +2,18 @@ import './style.css';
 import { setupCounter } from './counter';
 
 document.querySelector('#app').innerHTML = `
-    <div>
-        <h1>Hello World!</h1>
-        <pie-button id="counter" type="button"></pie-button>
-        <pie-icon-button size="medium" type="button" variant="primary"></pie-icon-button>
-</div>
+    <h2>pie-button Component Counter</h2>
+    <pie-button id="counter" type="button"></pie-button>
+
+    <h2>pie-icon-button Component – trailing and leading icons</h2>
+    <pie-button>
+        <icon-search slot="icon-leading"></icon-search>
+        Search
+        <icon-close slot="icon-trailing"></icon-close>
+    </pie-button>
+
+    <h2>pie-icon-button Component</h2>
+    <pie-icon-button size="medium" type="button" variant="primary"><icon-close></icon-close></pie-icon-button>
 `;
 
 setupCounter(document.querySelector('#counter'));

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@justeat/pie-design-tokens": "5.3.0",
     "@justeattakeaway/pie-button": "0.19.0",
-    "@justeattakeaway/pie-icon-button": "0.9.0"
+    "@justeattakeaway/pie-icon-button": "0.9.0",
+    "@justeattakeaway/pie-icons-webc": "0.3.0"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/apps/pie-storybook/.storybook/preview.js
+++ b/apps/pie-storybook/.storybook/preview.js
@@ -55,6 +55,9 @@ export default {
                     value: '#262626',
                 },
             ]
+        },
+        controls: {
+        expanded: true,
         }
     }
 };

--- a/apps/pie-storybook/.storybook/preview.js
+++ b/apps/pie-storybook/.storybook/preview.js
@@ -57,7 +57,7 @@ export default {
             ]
         },
         controls: {
-        expanded: true,
+            expanded: true,
         }
     }
 };

--- a/apps/pie-storybook/stories/pie-button.stories.ts
+++ b/apps/pie-storybook/stories/pie-button.stories.ts
@@ -5,6 +5,9 @@ import {
 } from '@justeattakeaway/pie-button';
 import { StoryMeta, SlottedComponentProps } from '../types';
 
+import '@justeattakeaway/pie-icons-webc/icons/IconPlusCircle'; // Register icon-plus-circle
+import '@justeattakeaway/pie-icons-webc/icons/IconChevronDown'; // Register icon-chevron-down
+
 type ButtonProps = SlottedComponentProps<ButtonPropsBase>;
 type ButtonStoryMeta = StoryMeta<ButtonProps>;
 
@@ -16,6 +19,7 @@ const defaultArgs: ButtonProps = {
     isFullWidth: false,
     isLoading: false,
     slot: 'This is Lit!',
+    buttonIcons: [],
 };
 
 const buttonStoryMeta: ButtonStoryMeta = {
@@ -23,28 +27,61 @@ const buttonStoryMeta: ButtonStoryMeta = {
     component: 'pie-button',
     argTypes: {
         size: {
+            description: 'Set the size of the button',
             control: 'select',
             options: sizes,
+            defaultValue: {
+                summary: 'medium',
+            },
         },
         type: {
+            description: 'Set the type the button,',
             control: 'select',
             options: types,
+            defaultValue: {
+                summary: 'submit',
+            },
         },
         variant: {
+            description: 'Set the variant of the button.',
             control: 'select',
             options: variants,
+            defaultValue: {
+                summary: 'primary',
+            },
         },
         disabled: {
+            description: 'If `true`, disables the button.',
             control: 'boolean',
+            defaultValue: {
+                summary: false,
+            },
         },
         isFullWidth: {
+            description: 'If `true`, sets the button width to 100% of it’s container.',
             control: 'boolean',
+            defaultValue: {
+                summary: false,
+            },
         },
         isLoading: {
+            description: 'If `true`, displays a loading indicator inside the button.',
             control: 'boolean',
+            defaultValue: {
+                summary: false,
+            },
         },
         slot: {
+            description: 'The default slot is used to pass the button text into the component.',
             control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        buttonIcons: {
+            description: 'Show a leading and/or trailing icon.<br /><br />To use this with pie-button, you can pass an icon into the `icon-leading` or `icon-trailing` slot',
+            control: 'check',
+            options: ['Leading', 'Trailing'],
         },
     },
     args: defaultArgs,
@@ -59,7 +96,7 @@ const buttonStoryMeta: ButtonStoryMeta = {
 export default buttonStoryMeta;
 
 const Template = ({
-    size, variant, type, disabled, isFullWidth, isLoading, slot,
+    size, variant, type, disabled, isFullWidth, isLoading, slot, buttonIcons,
 }: ButtonProps): TemplateResult => html`
         <pie-button
             size="${size}"
@@ -68,7 +105,9 @@ const Template = ({
             ?disabled="${disabled}"
             ?isLoading="${isLoading}"
             ?isFullWidth="${isFullWidth}">
+            ${buttonIcons.includes('Leading') ? html`<icon-plus-circle slot="icon-leading"></icon-plus-circle>` : ''}
             ${slot}
+            ${buttonIcons.includes('Trailing') ? html`<icon-chevron-down slot="icon-trailing"></icon-chevron-down>` : ''}
         </pie-button>
         `;
 
@@ -93,6 +132,12 @@ export const Ghost: Story<ButtonProps> = (args: ButtonProps) => Template(args);
 Ghost.args = {
     ...defaultArgs,
     variant: 'ghost',
+};
+
+Ghost.parameters = {
+    backgrounds: {
+        default: 'dark',
+    },
 };
 
 export const Inverse: Story<ButtonProps> = (args: ButtonProps) => Template(args);

--- a/apps/pie-storybook/stories/pie-button.stories.ts
+++ b/apps/pie-storybook/stories/pie-button.stories.ts
@@ -27,7 +27,7 @@ const buttonStoryMeta: ButtonStoryMeta = {
     component: 'pie-button',
     argTypes: {
         size: {
-            description: 'Set the size of the button',
+            description: 'Set the size of the button.',
             control: 'select',
             options: sizes,
             defaultValue: {
@@ -35,7 +35,7 @@ const buttonStoryMeta: ButtonStoryMeta = {
             },
         },
         type: {
-            description: 'Set the type the button,',
+            description: 'Set the type of the button.',
             control: 'select',
             options: types,
             defaultValue: {

--- a/packages/components/pie-button/README.md
+++ b/packages/components/pie-button/README.md
@@ -65,14 +65,14 @@ import { PieButton } from '@justeattakeaway/pie-button/dist/react';
 
 ## Props
 
-| Property    | Type      | Default         | Description                                                          |
-|-------------|-----------|-----------------|----------------------------------------------------------------------|
-| size        | `String`  | `medium`        | Size of the button, one of `sizes` – `xsmall`, `small-expressive`, `small-productive`, `medium`, `large` |
-| type        | `String`  | `submit`        | Type of the button, one of `types` – `submit`, `button`, `reset`, `menu` |
+| Property    | Type      | Default         | Description                                                                                                       |
+|-------------|-----------|-----------------|-------------------------------------------------------------------------------------------------------------------|
+| size        | `String`  | `medium`        | Size of the button, one of `sizes` – `xsmall`, `small-expressive`, `small-productive`, `medium`, `large`          |
+| type        | `String`  | `submit`        | Type of the button, one of `types` – `submit`, `button`, `reset`, `menu`                                          |
 | variant     | `String`  | `primary`       | Variant of the button, one of `variants` – `primary`, `secondary`, `outline`, `ghost`, `inverse`, `ghost-inverse` |
-| disabled    | `Boolean` | `false`         | If `true`, disables the button.                                      |
-| isFullWidth | `Boolean` | `false`         | If `true`, sets the button width to 100% of it's container.                            |
-| isLoading | `Boolean` | `false`         | If `true`, displays a loading indicator inside the button.
+| disabled    | `Boolean` | `false`         | If `true`, disables the button.                                                                                   |
+| isFullWidth | `Boolean` | `false`         | If `true`, sets the button width to 100% of it's container.                                                       |
+| isLoading   | `Boolean` | `false`         | If `true`, displays a loading indicator inside the button.                                                        |
 
 In your markup or JSX, you can then use these to set the properties for the `pie-button` component:
 
@@ -83,6 +83,31 @@ In your markup or JSX, you can then use these to set the properties for the `pie
 <!-- JSX -->
 <PieButton size='medium' type='button' variant='primary'>Click me!</PieButton>
 ```
+
+## Slots
+
+| Slot          | Description                                                                                                                        |
+|---------------|------------------------------------------------------------------------------------------------------------------------------------|
+| Default slot  | The default slot is used to pass text into the button component.                                                                   |
+| icon-leading  | Used to pass in a leading icon. We recommend using `pie-icons-webc` for defining this icon, but this can also accept an SVG icon.  |
+| icon-trailing | Used to pass in a trailing icon. We recommend using `pie-icons-webc` for defining this icon, but this can also accept an SVG icon. |
+
+### Using `pie-icons-webc` with `pie-button`icon slots
+
+We recommend using `pie-icons-webc` when using the `icon-leading` and `icon-trailing` slots. Here is an example of how you would do this:
+
+```html
+<!--
+  Note that pie-button and the icons that you want to use will need to be imported as components into your application.
+  See the `pie-icons-webc` README for more info on importing these icons.
+-->
+<pie-button>
+    <icon-plus-circle slot="icon-leading"></icon-plus-circle>
+    Search
+    <icon-chevron-down slot="icon-trailing"></icon-chevron-down>
+</pie-button>
+```
+
 
 ## Events
 

--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -294,7 +294,7 @@
     }
 }
 
-// Used to size an SVG if one is passed in (so not using the component icons
+// Used to size an SVG if one is passed in (when not using the component icons)
 ::slotted(svg) {
     height: var(--btn-icon-size);
     width: var(--btn-icon-size);

--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -73,6 +73,7 @@
     display: flex;
     gap: var(--dt-spacing-b);
     align-items: center;
+    justify-content: center;
     box-sizing: border-box;
     padding: var(--btn-padding);
     border: none;
@@ -280,6 +281,10 @@
         border-style: solid;
         will-change: transform;
         opacity: 0;
+    }
+
+    .o-btn-text {
+        flex-grow: 1;
     }
 
     &[isLoading] {

--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -45,6 +45,9 @@
     --btn-bg-color: var(--dt-color-interactive-brand);
     --btn-text-color: var(--dt-color-content-interactive-primary);
 
+    // Sizing is set to Medium button icon size, as that is the default
+    --btn-icon-size: 24px;
+
     // Spinner sizes defaults - currently set for the medium button styles
     --spinner-size-s: 20px;
     --spinner-size-m: 24px;
@@ -67,6 +70,9 @@
     --spinner-animation-iteration-count: infinite;
 
     position: relative;
+    display: flex;
+    gap: var(--dt-spacing-b);
+    align-items: center;
     box-sizing: border-box;
     padding: var(--btn-padding);
     border: none;
@@ -80,6 +86,12 @@
     line-height: var(--btn-line-height);
     cursor: pointer;
     user-select: none;
+
+    // TODO: This should be moved into global CSS typography setting
+    // This should be imported by consuming apps and set on the application body
+    text-rendering: optimizelegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-font-smoothing: antialiased;
 
     &:focus-visible {
         /*
@@ -214,6 +226,7 @@
         --btn-padding: 6px var(--dt-spacing-b);
         --btn-font-size: calc(var(--dt-font-size-14) * 1px);
         --btn-line-height: calc(var(--dt-font-size-14-line-height) * 1px);
+        --btn-icon-size: 16px;
         --spinner-size: var(--spinner-size-s);
         --spinner-border-width: var(--spinner-border-width-s);
     }
@@ -222,6 +235,7 @@
         --btn-padding: 6px var(--dt-spacing-d);
         --btn-font-size: calc(var(--dt-font-size-20) * 1px);
         --btn-line-height: calc(var(--dt-font-size-20-line-height) * 1px);
+        --btn-icon-size: 20px;
         --spinner-size: var(--spinner-size-s);
         --spinner-border-width: var(--spinner-border-width-s);
     }
@@ -230,6 +244,7 @@
         --btn-padding: 8px var(--dt-spacing-d);
         --btn-font-size: calc(var(--dt-font-size-16) * 1px);
         --btn-line-height: calc(var(--dt-font-size-16-line-height) * 1px);
+        --btn-icon-size: 20px;
         --spinner-size: var(--spinner-size-s);
         --spinner-border-width: var(--spinner-border-width-s);
     }
@@ -277,4 +292,10 @@
             opacity: 0;
         }
     }
+}
+
+// Used to size an SVG if one is passed in (so not using the component icons
+::slotted(svg) {
+    height: var(--btn-icon-size);
+    width: var(--btn-icon-size);
 }

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -16,6 +16,11 @@ export {
 
 const componentSelector = 'pie-button';
 
+/**
+ * @slot icon-leading - Leading icon
+ * @slot icon-trailing - Trailing icon
+ * @slot - Default slot
+ */
 export class PieButton extends LitElement implements ButtonProps {
     @property()
     @validPropertyValues(componentSelector, sizes, 'medium')
@@ -52,7 +57,9 @@ export class PieButton extends LitElement implements ButtonProps {
                 ?disabled=${disabled}
                 ?isFullWidth=${isFullWidth}
                 ?isLoading=${isLoading}>
+                <slot name="icon-leading"></slot>
                 <span class="o-btn-text"><slot></slot></span>
+                <slot name="icon-trailing"></slot>
             </button>`;
     }
 

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -65,3 +65,49 @@ componentVariants.forEach((variant) => test(`Render all prop variations for Vari
 
     await percySnapshot(page, `PIE Button - Variant: ${variant}`);
 }));
+
+// TODO: Currently setting the slot to use a straight up SVG
+//       This should be updated to use pie-icons-webc, but after some investigation, we think that we'll
+//       need to convert the webc icons to use Lit, as currently the components don't work well in a Node env like Playwright
+//       Atm, importing them like `import '@justeattakeaway/pie-icons-webc/icons/IconClose.js';` results in an `HTMLElement is not defined` error
+const plusSVG = '<svg xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--plusCircle"><path d="M8.656 4.596H7.344v2.748H4.596v1.312h2.748v2.748h1.312V8.656h2.748V7.344H8.656V4.596Z"></path><path d="M12.795 3.205a6.781 6.781 0 1 0 0 9.625 6.79 6.79 0 0 0 0-9.625Zm-.927 8.662a5.469 5.469 0 1 1-7.734-7.735 5.469 5.469 0 0 1 7.734 7.736Z"></path></svg>';
+const chevronSVG = '<svg xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--chevronDown"><path d="M2.82 5.044 8 10.399 13.197 5l.963.875-5.364 5.565a1.164 1.164 0 0 1-1.636 0L1.875 5.945l.945-.901Z"></path></svg>';
+
+sizes.forEach((size) => test(`Render icon slot variations for Size: ${size}`, async ({ page, mount }) => {
+    const iconSlotVariations = [
+        {
+            'icon-leading': plusSVG,
+        },
+        {
+            'icon-trailing': chevronSVG,
+        },
+        {
+            'icon-leading': plusSVG,
+            'icon-trailing': chevronSVG,
+        },
+    ];
+
+    await Promise.all(iconSlotVariations.map(async (iconSlots) => {
+        const iconLeading = iconSlots['icon-leading'] ? iconSlots['icon-leading'].replace('<svg', '<svg slot="icon-leading"') : '';
+        const iconTrailing = iconSlots['icon-trailing'] ? iconSlots['icon-trailing'].replace('<svg', '<svg slot="icon-trailing"') : '';
+
+        await mount(
+            WebComponentTestWrapper,
+            {
+                props: {
+                    size,
+                },
+                slots: {
+                    component: `<pie-button size="${size}">
+                                    ${iconLeading || ''}
+                                    Hello, ${size} Button!
+                                    ${iconTrailing || ''}
+                                </pie-button>`,
+                },
+            },
+        );
+    }));
+
+    await percySnapshot(page, `PIE Button Leading Icon - Size: ${size}`);
+}));
+

--- a/packages/tools/pie-wrapper-react/custom-elements.json
+++ b/packages/tools/pie-wrapper-react/custom-elements.json
@@ -676,6 +676,20 @@
                     "kind": "class",
                     "description": "",
                     "name": "PieButton",
+                    "slots": [
+                        {
+                            "description": "Leading icon",
+                            "name": "icon-leading"
+                        },
+                        {
+                            "description": "Trailing icon",
+                            "name": "icon-trailing"
+                        },
+                        {
+                            "description": "Default slot",
+                            "name": ""
+                        }
+                    ],
                     "members": [
                         {
                             "kind": "field",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5318,7 +5318,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-webc@workspace:*, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
+"@justeattakeaway/pie-icons-webc@0.3.0, @justeattakeaway/pie-icons-webc@workspace:*, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
@@ -37821,6 +37821,7 @@ __metadata:
     "@justeat/pie-design-tokens": 5.3.0
     "@justeattakeaway/pie-button": 0.19.0
     "@justeattakeaway/pie-icon-button": 0.9.0
+    "@justeattakeaway/pie-icons-webc": 0.3.0
     vite: 4.3.9
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Describe your changes

### `pie-button`

- [Added] - Slots for leading and trailing icons

### `pie-storybook`

- [Added] - expanded controls info and pie-button updated to include icon slots

### `wc-vanilla` example app
- [Added] - Leading & Trailing Button Icons and Icon Button examples


## Author Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If it is a component change, I have reviewed the Storybook preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
