### PR TITLE
feat(pie-modal): DSW-1013 implement dialog polyfill

### DIFF
--- a/.changeset/quick-horses-visit.md
+++ b/.changeset/quick-horses-visit.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+- [Changed] - updated Modal component dependencies adding the `dialog-polyfill` package
+- [Changed] - updated Modal component to use `dialog-polyfill`
+- [Changed] - updated Modal documentation regarding the legacy browser support for Dialog element and polyfill usage and limitations
+- [Changed] - vanilla example app for testing Modal with `dialog-polyfill`

--- a/apps/examples/wc-vanilla/index.html
+++ b/apps/examples/wc-vanilla/index.html
@@ -36,5 +36,6 @@
         <script type="module" src="./node_modules/@justeattakeaway/pie-icon-button"></script>
         <script type="module" src="./node_modules/@justeattakeaway/pie-icons-webc/dist/icons/IconSearch.js"></script>
         <script type="module" src="./node_modules/@justeattakeaway/pie-icons-webc/dist/icons/IconSearch.js"></script>
+        <script type="module" src="./node_modules/@justeattakeaway/pie-modal"></script>
     </body>
 </html>

--- a/apps/examples/wc-vanilla/main.js
+++ b/apps/examples/wc-vanilla/main.js
@@ -2,6 +2,12 @@ import './style.css';
 import { setupCounter } from './counter';
 
 document.querySelector('#app').innerHTML = `
+    <h2>pie-modal</h2>
+    <pie-button id="modal-trigger" type="button">open modal</pie-button>
+    <pie-modal id="modal" heading='My Awesome Heading' headingLevel='h3' isDismissible>
+        Modal content
+    </pie-modal>
+
     <h2>pie-button Component Counter</h2>
     <pie-button id="counter" type="button"></pie-button>
 
@@ -17,3 +23,7 @@ document.querySelector('#app').innerHTML = `
 `;
 
 setupCounter(document.querySelector('#counter'));
+
+document.querySelector('#modal-trigger').addEventListener('click', () => {
+    document.querySelector('#modal').setAttribute('isOpen', true);
+});

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -15,7 +15,8 @@
     "@justeat/pie-design-tokens": "5.3.0",
     "@justeattakeaway/pie-button": "0.23.0",
     "@justeattakeaway/pie-icon-button": "0.13.0",
-    "@justeattakeaway/pie-icons-webc": "0.5.0"
+    "@justeattakeaway/pie-icons-webc": "0.5.0",
+    "@justeattakeaway/pie-modal": "0.14.0"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -16,7 +16,7 @@
     "@justeattakeaway/pie-button": "0.23.0",
     "@justeattakeaway/pie-icon-button": "0.13.0",
     "@justeattakeaway/pie-icons-webc": "0.5.0",
-    "@justeattakeaway/pie-modal": "0.14.0"
+    "@justeattakeaway/pie-modal": "workspace:*"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -16,7 +16,7 @@
     "@justeattakeaway/pie-button": "0.23.0",
     "@justeattakeaway/pie-icon-button": "0.13.0",
     "@justeattakeaway/pie-icons-webc": "0.5.0",
-    "@justeattakeaway/pie-modal": "workspace:*"
+    "@justeattakeaway/pie-modal": "0.14.0"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/packages/components/pie-modal/README.md
+++ b/packages/components/pie-modal/README.md
@@ -131,4 +131,4 @@ The polyfill comes with a few limitations, as noted on its [documentation page](
 - The browser's chrome may not always be accessible via the tab key
 - Changes to the CSS top/bottom values while open aren't retained
 
-For more details, check the package documentation.
+For more details, check the package documentation mentioned above.

--- a/packages/components/pie-modal/README.md
+++ b/packages/components/pie-modal/README.md
@@ -15,6 +15,7 @@
 3. [Importing the component](#importing-the-component)
 4. [Props](#props)
 5. [Testing](#testing)
+5. [Legacy browser support](#legacy-browser-support)
 
 # pie-modal
 
@@ -118,3 +119,16 @@ Under scripts `test:visual` replace the environment variable with the below:
 ```bash
 PERCY_TOKEN_PIE_MODAL=abcde
 ```
+
+## Legacy browser support
+
+`pie-modal` uses the Dialog element which might not be supported by legacy browsers.
+
+To support them, `pie-modal` uses the [dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill) package. It works automatically and doesn't need any setup.
+
+The polyfill comes with a few limitations, as noted on its [documentation page](https://github.com/GoogleChrome/dialog-polyfill#limitations):
+- Dialogs should not be contained by parents that create a stacking context
+- The browser's chrome may not always be accessible via the tab key
+- Changes to the CSS top/bottom values while open aren't retained
+
+For more details, check the package documentation.

--- a/packages/components/pie-modal/package.json
+++ b/packages/components/pie-modal/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
+  },
+  "dependencies": {
+    "dialog-polyfill": "0.5.6"
   }
 }

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -12,6 +12,8 @@ import '@justeattakeaway/pie-icons-webc/dist/icons/IconClose.js';
 import '@justeattakeaway/pie-icons-webc/dist/icons/IconChevronLeft.js';
 import '@justeattakeaway/pie-icons-webc/dist/icons/IconChevronRight.js';
 
+import dialogPolyfill from 'dialog-polyfill';
+
 import styles from './modal.scss?inline';
 import {
     type AriaProps,
@@ -113,12 +115,15 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     }
 
     firstUpdated (changedProperties: DependentMap<ModalProps>) : void {
-        this._dialog?.addEventListener('cancel', (event) => this._handleDialogCancelEvent(event));
-        this._handleModalOpenStateOnFirstRender(changedProperties);
+        if (this._dialog) {
+            dialogPolyfill.registerDialog(this._dialog);
+            this._dialog.addEventListener('cancel', (event) => this._handleDialogCancelEvent(event));
+            this._dialog.addEventListener('close', () => {
+                this.isOpen = false;
+            });
+        }
 
-        this._dialog?.addEventListener('close', () => {
-            this.isOpen = false;
-        });
+        this._handleModalOpenStateOnFirstRender(changedProperties);
     }
 
     updated (changedProperties: DependentMap<ModalProps>) : void {

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -1,4 +1,5 @@
 @use '@justeat/pie-design-tokens/dist/jet.scss' as dt;
+@use 'dialog-polyfill/dist/dialog-polyfill.css';
 
 // TODO - add to CSS lib once created
 *,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,6 +5578,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@justeattakeaway/pie-modal@npm:0.14.0":
+  version: 0.14.0
+  resolution: "@justeattakeaway/pie-modal@npm:0.14.0"
+  peerDependencies:
+    body-scroll-lock: 4.0.0-beta.0
+  checksum: ac92c4e2724d1894db5c70167cb1146252e6a96d3f561a83b011cc4d920d9560c66246cc74bfc25283a5b7ec438d3a5d5b9bdcfd5c84fd2d4cb186c8e566703a
+  languageName: node
+  linkType: hard
+
 "@justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
@@ -38257,7 +38266,7 @@ __metadata:
     "@justeattakeaway/pie-button": 0.22.0
     "@justeattakeaway/pie-icon-button": 0.12.0
     "@justeattakeaway/pie-icons-webc": 0.5.0
-    "@justeattakeaway/pie-modal": "workspace:*"
+    "@justeattakeaway/pie-modal": 0.14.0
     vite: 4.3.9
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5457,7 +5457,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.22.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.23.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
@@ -5484,7 +5484,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.12.0, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.13.0, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
@@ -5507,7 +5507,7 @@ __metadata:
   dependencies:
     "@babel/node": 7.20.7
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-icons": 4.4.0
+    "@justeattakeaway/pie-icons": 4.5.0
     "@justeattakeaway/pie-icons-configs": "workspace:*"
     "@rollup/plugin-node-resolve": 15.1.0
     "@svgr/core": 6.4.0
@@ -5527,7 +5527,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-vue@workspace:packages/tools/pie-icons-vue"
   dependencies:
-    "@justeattakeaway/pie-icons": 4.4.0
+    "@justeattakeaway/pie-icons": 4.5.0
     "@justeattakeaway/pie-icons-configs": "workspace:*"
     "@vue/babel-helper-vue-jsx-merge-props": 1.4.0
     "@vue/babel-preset-jsx": 1.4.0
@@ -5547,7 +5547,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
     "@babel/node": 7.20.7
-    "@justeattakeaway/pie-icons": 4.4.0
+    "@justeattakeaway/pie-icons": 4.5.0
     "@justeattakeaway/pie-icons-configs": "workspace:*"
     "@justeattakeaway/pie-webc-core": 0.6.0
     "@open-wc/testing": 3.2.0
@@ -5562,7 +5562,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons@4.4.0, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
+"@justeattakeaway/pie-icons@4.5.0, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons@workspace:packages/tools/pie-icons"
   dependencies:
@@ -28610,7 +28610,7 @@ __metadata:
     "@11ty/eleventy": 1.0.2
     "@11ty/eleventy-navigation": 0.3.5
     "@justeat/f-cookie-banner": 4.7.0
-    "@justeattakeaway/pie-icons": 4.4.0
+    "@justeattakeaway/pie-icons": 4.5.0
     eleventy-plugin-clean: 1.2.5
     eleventy-plugin-rev: 1.1.1
     eleventy-sass: 2.2.1
@@ -38263,8 +38263,8 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.3.0
-    "@justeattakeaway/pie-button": 0.22.0
-    "@justeattakeaway/pie-icon-button": 0.12.0
+    "@justeattakeaway/pie-button": 0.23.0
+    "@justeattakeaway/pie-icon-button": 0.13.0
     "@justeattakeaway/pie-icons-webc": 0.5.0
     "@justeattakeaway/pie-modal": 0.14.0
     vite: 4.3.9

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,6 +5578,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@justeattakeaway/pie-modal@npm:0.14.0":
+  version: 0.14.0
+  resolution: "@justeattakeaway/pie-modal@npm:0.14.0"
+  peerDependencies:
+    body-scroll-lock: 4.0.0-beta.0
+  checksum: ac92c4e2724d1894db5c70167cb1146252e6a96d3f561a83b011cc4d920d9560c66246cc74bfc25283a5b7ec438d3a5d5b9bdcfd5c84fd2d4cb186c8e566703a
+  languageName: node
+  linkType: hard
+
 "@justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
@@ -38249,6 +38258,7 @@ __metadata:
     "@justeattakeaway/pie-button": 0.22.0
     "@justeattakeaway/pie-icon-button": 0.12.0
     "@justeattakeaway/pie-icons-webc": 0.5.0
+    "@justeattakeaway/pie-modal": 0.14.0
     vite: 4.3.9
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,15 +5578,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@npm:0.14.0":
-  version: 0.14.0
-  resolution: "@justeattakeaway/pie-modal@npm:0.14.0"
-  peerDependencies:
-    body-scroll-lock: 4.0.0-beta.0
-  checksum: ac92c4e2724d1894db5c70167cb1146252e6a96d3f561a83b011cc4d920d9560c66246cc74bfc25283a5b7ec438d3a5d5b9bdcfd5c84fd2d4cb186c8e566703a
-  languageName: node
-  linkType: hard
-
 "@justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
@@ -38258,7 +38249,7 @@ __metadata:
     "@justeattakeaway/pie-button": 0.22.0
     "@justeattakeaway/pie-icon-button": 0.12.0
     "@justeattakeaway/pie-icons-webc": 0.5.0
-    "@justeattakeaway/pie-modal": 0.14.0
+    "@justeattakeaway/pie-modal": "workspace:*"
     vite: 4.3.9
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,6 +5588,7 @@ __metadata:
     "@justeattakeaway/pie-icons-webc": "workspace:*"
     "@justeattakeaway/pie-webc-core": "workspace:*"
     "@types/body-scroll-lock": 3.1.0
+    dialog-polyfill: 0.5.6
   peerDependencies:
     body-scroll-lock: 4.0.0-beta.0
   languageName: unknown
@@ -17040,6 +17041,13 @@ __metadata:
   version: 0.0.1
   resolution: "di@npm:0.0.1"
   checksum: 3f09a99534d33e49264585db7f863ea8bc76c25c4d5a60df387c946018ecf1e1516b2c05a2092e5ca51fcdc08cefe609a6adc5253fa831626cb78cad4746505e
+  languageName: node
+  linkType: hard
+
+"dialog-polyfill@npm:0.5.6":
+  version: 0.5.6
+  resolution: "dialog-polyfill@npm:0.5.6"
+  checksum: dde8d4b6a62b63b710e0d0d70b615d92ff08f3cb2b521e1f99b17e8220d9d55d0fdf9fc17fbe77b0ff1be817094e14b60c4c4bacd5456fba427ede48d2d90230
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [Changed] - updated Modal component dependencies adding the `dialog-polyfill` package
- [Changed] - updated Modal component to use `dialog-polyfill`
- [Changed] - updated Modal documentation regarding the legacy browser support for Dialog element and polyfill usage and limitations
- [Changed] - vanilla example app for testing Modal with `dialog-polyfill`

## Notes

Behaviours noticed during legacy testing:

- I used the browser mentioned in the ticket (Safari 14) and Firefox 97 (which doesn't support the Dialog element)

- Safari 14
	- ✅ The polyfill itself works with Safari 14
	- ❌ Pie Web Components styles are not displayed
	- ❌ Without the polyfill, the Modal component content is rendered as a regular div, regardless of the `isOpen` attribute value, likely due the lack of styles

- Firefox 97
	- ✅ The polyfill works as expected
	- ✅ Pie Web Components styles also work as expected
	- ✅ Without the polyfill, unlike Safari 14, the behaviour is correct, the modal is not displayed

## Screenshots

The compiled package size increased after adding the polyfill:

<img width="664" alt="image" src="https://github.com/justeattakeaway/pie/assets/448801/b6476785-c7d2-4e91-9195-af4a2cefa1d3">

Safari 14 doesn't displays styles

![image](https://github.com/justeattakeaway/pie/assets/448801/d0012f20-4249-43bf-a81b-3372b779e7c8)

Safari 14 without polyfill

![image](https://github.com/justeattakeaway/pie/assets/448801/02350ca8-62a9-4f30-b32c-eeba53718ca6)

Safari 14 with polyfill and opened Modal (without styles)

![image](https://github.com/justeattakeaway/pie/assets/448801/ef7af813-2364-47c8-91f1-3a240684008c)

Firefox 97 with polyfill and opened Modal

![image](https://github.com/justeattakeaway/pie/assets/448801/d5ce42b1-3b9f-4e1a-8617-6e552071aaf7)

