### PR TITLE
feat(pie-monorepo): DSW-000 update Turborepo settings for caching build esm

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
         "^build"
       ],
       "outputs": [
-        "dist/**"
+        "dist/**",
+        "esm/**"
       ]
     },
     "build:examples": {


### PR DESCRIPTION
Some of our packages build process output not only to `dist` but also to the `esm` folder. The `esm` folder is not being cached by Turborepo, so whenever someone expects to see that folder content, it's necessary to turn off cache in `turbo.json`, and re-run the`build` script.

This PR addresses this issue by adding the `esm` folder to Turborepo cache.