### PR TITLE
fix(pie-icon-button): DSW-000 fixed issue with incorrect peerDependency name

### DIFF
--- a/.changeset/bright-students-doubt.md
+++ b/.changeset/bright-students-doubt.md
@@ -1,0 +1,11 @@
+---
+"@justeattakeaway/pie-icon-button": patch
+---
+
+[Fixed] - Corrected the following peerDependency:
+
+```js
+  "peerDependencies": {
+    "@justeat/pie-design-tokens": "5.4.0"
+  },
+```

--- a/packages/components/pie-icon-button/package.json
+++ b/packages/components/pie-icon-button/package.json
@@ -24,7 +24,7 @@
     "@justeattakeaway/pie-webc-core": "workspace:*"
   },
   "peerDependencies": {
-    "pie-design-tokens": "5.4.0"
+    "@justeat/pie-design-tokens": "5.4.0"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5435,7 +5435,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.23.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.24.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
@@ -5452,7 +5452,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-css@0.1.0, @justeattakeaway/pie-css@workspace:*, @justeattakeaway/pie-css@workspace:packages/tools/pie-css":
+"@justeattakeaway/pie-css@0.2.0, @justeattakeaway/pie-css@workspace:*, @justeattakeaway/pie-css@workspace:packages/tools/pie-css":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-css@workspace:packages/tools/pie-css"
   dependencies:
@@ -5471,14 +5471,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.13.0, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.13.1, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
     "@justeattakeaway/pie-icons-webc": "workspace:*"
     "@justeattakeaway/pie-webc-core": "workspace:*"
   peerDependencies:
-    pie-design-tokens: 5.4.0
+    "@justeat/pie-design-tokens": 5.4.0
   languageName: unknown
   linkType: soft
 
@@ -5576,16 +5576,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@npm:0.14.0":
-  version: 0.14.0
-  resolution: "@justeattakeaway/pie-modal@npm:0.14.0"
-  peerDependencies:
-    body-scroll-lock: 4.0.0-beta.0
-  checksum: ac92c4e2724d1894db5c70167cb1146252e6a96d3f561a83b011cc4d920d9560c66246cc74bfc25283a5b7ec438d3a5d5b9bdcfd5c84fd2d4cb186c8e566703a
-  languageName: node
-  linkType: hard
-
-"@justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.17.0, @justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
@@ -36531,11 +36522,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.4.0
-    "@justeattakeaway/pie-button": 0.23.0
-    "@justeattakeaway/pie-css": 0.1.0
-    "@justeattakeaway/pie-icon-button": 0.13.0
+    "@justeattakeaway/pie-button": 0.24.0
+    "@justeattakeaway/pie-css": 0.2.0
+    "@justeattakeaway/pie-icon-button": 0.13.1
     "@justeattakeaway/pie-icons-webc": 0.5.0
-    "@justeattakeaway/pie-modal": 0.14.0
+    "@justeattakeaway/pie-modal": 0.17.0
     vite: 4.3.9
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
---
"@justeattakeaway/pie-icon-button": patch
---

[Fixed] - Corrected the following peerDependency:

```js
  "peerDependencies": {
    "@justeat/pie-design-tokens": "5.4.0"
  },
```

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
