### PR TITLE
chore(pie-components-config): DSW-1071 exclude react from final bundle

### DIFF
--- a/.changeset/lucky-tips-switch.md
+++ b/.changeset/lucky-tips-switch.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-button": minor
+"@justeattakeaway/pie-components-config": minor
+---
+
+[Added] vite config setting to exclude react from wrapper.

--- a/configs/pie-components-config/vite.config.js
+++ b/configs/pie-components-config/vite.config.js
@@ -12,7 +12,7 @@ const sharedConfig = (extendedConfig = {}) => defineConfig({
             formats: ['es'],
         },
         rollupOptions: {
-            external: /^lit/,
+            external: ['react', /^lit/],
         },
     },
     plugins: [dts({

--- a/packages/components/pie-button/README.md
+++ b/packages/components/pie-button/README.md
@@ -170,3 +170,9 @@ Under scripts `test:visual` replace the environment variable with the below:
 ```bash
 PERCY_TOKEN_PIE_BUTTON=abcde
 ```
+
+# Peer Dependencies
+
+Before using `@justeattakeaway/pie-button`, please make sure you have the following peer dependencies installed in your project:
+
+- `react` (for React integration only)

--- a/packages/components/pie-button/package.json
+++ b/packages/components/pie-button/package.json
@@ -33,6 +33,10 @@
     "@justeattakeaway/pie-css": "workspace:*",
     "@justeattakeaway/pie-webc-core": "workspace:*"
   },
+  "peerDependencies": {
+    "react": "^17.0.0",
+    "@lit-labs/react": "^2.0.1"
+  },
   "volta": {
     "extends": "../../../package.json"
   }

--- a/packages/components/pie-button/package.json
+++ b/packages/components/pie-button/package.json
@@ -34,8 +34,7 @@
     "@justeattakeaway/pie-webc-core": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "@lit-labs/react": "^2.0.1"
+    "react": "^17.0.0"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5251,7 +5251,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.24.1, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.25.0, @justeattakeaway/pie-button@workspace:*, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
@@ -5259,6 +5259,8 @@ __metadata:
     "@justeattakeaway/pie-components-config": "workspace:*"
     "@justeattakeaway/pie-css": "workspace:*"
     "@justeattakeaway/pie-webc-core": "workspace:*"
+  peerDependencies:
+    react: ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -5287,7 +5289,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.13.2, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.14.0, @justeattakeaway/pie-icon-button@workspace:*, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
@@ -5386,7 +5388,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.17.0, @justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.18.0, @justeattakeaway/pie-modal@workspace:*, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
@@ -35789,11 +35791,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.5.0
-    "@justeattakeaway/pie-button": 0.24.1
+    "@justeattakeaway/pie-button": 0.25.0
     "@justeattakeaway/pie-css": 0.2.0
-    "@justeattakeaway/pie-icon-button": 0.13.2
+    "@justeattakeaway/pie-icon-button": 0.14.0
     "@justeattakeaway/pie-icons-webc": 0.5.0
-    "@justeattakeaway/pie-modal": 0.17.0
+    "@justeattakeaway/pie-modal": 0.18.0
     vite: 4.3.9
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

I've tried to remove the lit labs deps from the types declarations that's generated but specifying it as a external doesn't work. I did find you can create a stubbed file to strip the types of all imports but i feel this is sort of hacky. If there is a way to specify which types are imported then happy to look at this in this same PR.

### Screenshot:
 59kb > 2kb
<img width="449" alt="Screenshot 2023-08-17 at 13 14 19" src="https://github.com/justeattakeaway/pie/assets/2299779/01f36d91-e845-437c-850c-49c914274a19">


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
