### PR TITLE
chore(pie-icons-vue): DSW-1109 update rollup node resolutions

### DIFF
--- a/.changeset/sweet-sheep-tap.md
+++ b/.changeset/sweet-sheep-tap.md
@@ -2,4 +2,5 @@
 "@justeattakeaway/pie-icons-vue": patch
 ---
 
-[Changed] - resolve all necessary packages in rollup build
+[Changed] - update rollup config to fix build
+[Added] - commonjs plugin to help resolve `@vue/babel-helper-vue-jsx-merge-props`

--- a/.changeset/sweet-sheep-tap.md
+++ b/.changeset/sweet-sheep-tap.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-vue": patch
+---
+
+[Changed] - resolve all necessary packages in rollup build

--- a/packages/tools/pie-icons-vue/package.json
+++ b/packages/tools/pie-icons-vue/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@justeattakeaway/pie-icons": "4.5.0",
     "@justeattakeaway/pie-icons-configs": "workspace:*",
+    "@rollup/plugin-commonjs": "25.0.4",
     "@vue/babel-preset-jsx": "1.4.0",
     "@vue/test-utils": "1.1.3",
     "eslint-plugin-vue": "^9.9.0",

--- a/packages/tools/pie-icons-vue/rollup.config.js
+++ b/packages/tools/pie-icons-vue/rollup.config.js
@@ -13,7 +13,7 @@ export default [
             preserveModules: true,
         },
         plugins: [
-            nodeResolve({ resolveOnly: ['@justeattakeaway/pie-icons-configs'] }),
+            nodeResolve(),
         ],
     },
     {
@@ -28,9 +28,7 @@ export default [
             preserveModules: true,
         },
         plugins: [
-            nodeResolve({
-                resolveOnly: ['@justeattakeaway/pie-icons-configs'],
-            })
+            nodeResolve(),
         ],
     },
 ];

--- a/packages/tools/pie-icons-vue/rollup.config.js
+++ b/packages/tools/pie-icons-vue/rollup.config.js
@@ -1,4 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default [
     {
@@ -14,6 +15,7 @@ export default [
         },
         plugins: [
             nodeResolve(),
+            commonjs(),
         ],
     },
     {
@@ -29,6 +31,7 @@ export default [
         },
         plugins: [
             nodeResolve(),
+            commonjs(),
         ],
     },
 ];

--- a/packages/tools/pie-icons-vue/scripts/build.js
+++ b/packages/tools/pie-icons-vue/scripts/build.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { pascalCase } from 'pascal-case';
 import fs from 'fs-extra';
 
-import pieIcons from '@justeattakeaway/pie-icons'; // eslint-disable-line import/no-unresolved
+import pieIcons from '@justeattakeaway/pie-icons';
 import { normalizeIconName } from '@justeattakeaway/pie-icons-configs'; // eslint-disable-line import/no-unresolved
 
 const componentTemplate = (name, svg) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,6 +5338,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-icons": 4.5.0
     "@justeattakeaway/pie-icons-configs": "workspace:*"
+    "@rollup/plugin-commonjs": 25.0.4
     "@vue/babel-helper-vue-jsx-merge-props": 1.4.0
     "@vue/babel-preset-jsx": 1.4.0
     "@vue/test-utils": 1.1.3
@@ -7146,6 +7147,25 @@ __metadata:
     "@types/babel__core":
       optional: true
   checksum: 220d71e4647330f252ef33d5f29700aef2e8284a0b61acfcceb47617a7f96208aa1ed16eae75619424bf08811ede5241e271a6d031f07026dee6b3a2bdcdc638
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-commonjs@npm:25.0.4":
+  version: 25.0.4
+  resolution: "@rollup/plugin-commonjs@npm:25.0.4"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    commondir: ^1.0.1
+    estree-walker: ^2.0.2
+    glob: ^8.0.3
+    is-reference: 1.2.1
+    magic-string: ^0.27.0
+  peerDependencies:
+    rollup: ^2.68.0||^3.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 073b92b765a1f8ab8db8e1aa216c1950e62f6c0c41210d10bb7530c4fc63670a16c19c0bbbf73e2752467c4468ad4c8134cf4724924388c3eed83df45630fda6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
My hypothesis is that the reason that `pie-icons` could not be resolved by the `pie-icons-vue` build is that rollup was told to only resolve `pie-icons-configs`.

I think this turned out to be true but it revealed another issue where `@vue/babel-helper-vue-jsx-merge-props` was not being loaded properly, so I needed to add the commonjs plugin.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
