### PR TITLE
refactor(pie-button): DSW-1108 updated button, icon-button and divider

### DIFF
--- a/.changeset/warm-pillows-own.md
+++ b/.changeset/warm-pillows-own.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-testing": minor
+---
+
+[Added] - Added Percy breakpoints for screenshot widths

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import { PieButton } from '@/index';
 import { sizes, variants } from '@/defs';
 
@@ -63,7 +64,7 @@ componentVariants.forEach((variant) => test(`Render all prop variations for Vari
         );
     }));
 
-    await percySnapshot(page, `PIE Button - Variant: ${variant}`);
+    await percySnapshot(page, `PIE Button - Variant: ${variant}`, percyWidths);
 }));
 
 // TODO: Currently setting the slot to use a straight up SVG
@@ -110,5 +111,5 @@ test('Render icon slot variations', async ({ page, mount }) => {
         }));
     });
 
-    await percySnapshot(page, 'PIE Button Leading/Trailing Icon Variations');
+    await percySnapshot(page, 'PIE Button Leading/Trailing Icon Variations', percyWidths);
 });

--- a/packages/components/pie-divider/test/visual/pie-divider.spec.ts
+++ b/packages/components/pie-divider/test/visual/pie-divider.spec.ts
@@ -13,6 +13,7 @@ import {
 import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import { variants, orientations } from '@/defs';
 import { PieDivider } from '@/index';
 
@@ -46,5 +47,5 @@ componentVariants.forEach((variant) => test(`Render all prop variations for Vari
         );
     }));
 
-    await percySnapshot(page, `PIE Divider - Variant: ${variant}`);
+    await percySnapshot(page, `PIE Divider - Variant: ${variant}`, percyWidths);
 }));

--- a/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
+++ b/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import { PieIconButton } from '@/index';
 
 import { sizes, variants } from '@/defs';
@@ -66,5 +67,5 @@ componentVariants.forEach((variant) => test(`Render all prop variations for Vari
         );
     }));
 
-    await percySnapshot(page, `PIE Icon Button - Variant: ${variant}`);
+    await percySnapshot(page, `PIE Icon Button - Variant: ${variant}`, percyWidths);
 }));

--- a/packages/components/pie-webc-testing/src/percy/breakpoints.ts
+++ b/packages/components/pie-webc-testing/src/percy/breakpoints.ts
@@ -1,0 +1,3 @@
+export const percyWidths = {
+    widths: [375],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -32040,6 +32040,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-update-notifier@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "simple-update-notifier@npm:2.0.0"
+  dependencies:
+    semver: ^7.5.3
+  checksum: 9ba00d38ce6a29682f64a46213834e4eb01634c2f52c813a9a7b8873ca49cdbb703696f3290f3b27dc067de6d9418b0b84bef22c3eb074acf352529b2d6c27fd
+  languageName: node
+  linkType: hard
+
 "sirv@npm:^1.0.7":
   version: 1.0.19
   resolution: "sirv@npm:1.0.19"


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- [Added] - Percy Breakpoints to `pie-webc-testing` for limiting percy screenshot widths for use across multiple components.
- Screenshots limited to 375px.
- [Updated] - `pie-button`, `pie-icon-button` & `pie-divider` to use the new percy widths.

![Screenshot 2023-08-22 at 12 46 32](https://github.com/justeattakeaway/pie/assets/18608779/11e72b4d-5c5b-43a5-b2e0-94512be8bcdf)
![Screenshot 2023-08-22 at 12 46 23](https://github.com/justeattakeaway/pie/assets/18608779/543d62aa-8843-4e2f-8710-ae47b91bcdbd)
![Screenshot 2023-08-22 at 12 46 05](https://github.com/justeattakeaway/pie/assets/18608779/7f365881-d5c3-4b56-b7f5-2a78099ad339)



## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
