### PR TITLE
feat(pie-link): DSW-1121 allow the link component to behave like a button

### DIFF
--- a/.changeset/calm-cobras-behave.md
+++ b/.changeset/calm-cobras-behave.md
@@ -1,0 +1,9 @@
+---
+"@justeattakeaway/pie-divider": minor
+"@justeattakeaway/pie-link": minor
+"pie-storybook": minor
+"pie-monorepo": minor
+---
+[Added] - allow the link component to behave like a button
+
+[Changed] - fixed visual tests for the link and divider components

--- a/apps/pie-storybook/package.json
+++ b/apps/pie-storybook/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@justeattakeaway/pie-button": "workspace:*",
     "@justeattakeaway/pie-css": "workspace:*",
+    "@justeattakeaway/pie-cookie-banner": "workspace:*",
     "@justeattakeaway/pie-divider": "workspace:*",
     "@justeattakeaway/pie-icon-button": "workspace:*",
     "@justeattakeaway/pie-icons-webc": "workspace:*",

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -21,7 +21,7 @@ const defaultArgs: LinkProps = {
     target: '_blank',
     isBold: false,
     isStandalone: false,
-    slot: 'This is Lit!',
+    slot: 'Link',
 };
 
 const linkStoryMeta: LinkStoryMeta = {

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -1,7 +1,8 @@
 import { html, TemplateResult, nothing } from 'lit';
 import { type StoryObj as Story } from '@storybook/web-components';
 import {
-    PieLink, LinkProps as LinkBaseProps, sizes, variants, iconPlacements,
+    PieLink, LinkProps as LinkBaseProps, sizes, variants,
+    iconPlacements, tags,
 } from '@justeattakeaway/pie-link';
 import type { StoryMeta, SlottedComponentProps } from '../types';
 
@@ -13,6 +14,7 @@ type LinkProps = SlottedComponentProps<LinkBaseProps>;
 type LinkStoryMeta = StoryMeta<LinkProps>;
 
 const defaultArgs: LinkProps = {
+    tag: 'a',
     variant: 'default',
     size: 'medium',
     href: 'https://pie.design',
@@ -26,6 +28,14 @@ const linkStoryMeta: LinkStoryMeta = {
     title: 'Link',
     component: 'pie-link',
     argTypes: {
+        tag: {
+            description: 'Set the element tag of the link.',
+            control: 'select',
+            options: tags,
+            defaultValue: {
+                summary: 'a',
+            },
+        },
         variant: {
             description: 'Set the variant of the link.',
             control: 'select',
@@ -50,14 +60,17 @@ const linkStoryMeta: LinkStoryMeta = {
         href: {
             description: 'The URL that the hyperlink should point to',
             control: 'text',
+            if: { arg: 'tag', eq: 'a' },
         },
         target: {
             description: 'Set where to display the linked URL',
             control: 'text',
+            if: { arg: 'tag', eq: 'a' },
         },
         rel: {
             description: 'Set what the relationship of the linked URL is',
             control: 'text',
+            if: { arg: 'tag', eq: 'a' },
         },
         isBold: {
             description: 'If `true`, makes the link text bold',
@@ -93,6 +106,7 @@ const linkStoryMeta: LinkStoryMeta = {
 export default linkStoryMeta;
 
 const Template = ({
+    tag,
     href,
     target,
     rel,
@@ -104,6 +118,7 @@ const Template = ({
     iconPlacement,
 }: LinkProps): TemplateResult => html`
         <pie-link
+            tag="${tag}"
             variant="${variant}"
             size="${size}"
             iconPlacement="${iconPlacement || nothing}"

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -1,8 +1,8 @@
 import { html, TemplateResult, nothing } from 'lit';
 import { type StoryObj as Story } from '@storybook/web-components';
 import {
-    PieLink, LinkProps as LinkBaseProps, sizes, variants,
-    iconPlacements, tags,
+    PieLink, LinkProps as LinkBaseProps, sizes,
+    variants, iconPlacements, tags, buttonTypes,
 } from '@justeattakeaway/pie-link';
 import type { StoryMeta, SlottedComponentProps } from '../types';
 
@@ -18,7 +18,7 @@ const defaultArgs: LinkProps = {
     variant: 'default',
     size: 'medium',
     href: 'https://pie.design',
-    target: '_target',
+    target: '_blank',
     isBold: false,
     isStandalone: false,
     slot: 'This is Lit!',
@@ -72,6 +72,15 @@ const linkStoryMeta: LinkStoryMeta = {
             control: 'text',
             if: { arg: 'tag', eq: 'a' },
         },
+        type: {
+            description: 'Set the type of the button.',
+            control: 'select',
+            options: buttonTypes,
+            defaultValue: {
+                summary: 'submit',
+            },
+            if: { arg: 'tag', eq: 'button' },
+        },
         isBold: {
             description: 'If `true`, makes the link text bold',
             control: 'boolean',
@@ -98,7 +107,7 @@ const linkStoryMeta: LinkStoryMeta = {
     parameters: {
         design: {
             type: 'figma',
-            url: '',
+            url: 'https://www.figma.com/file/pPSC73rPin4csb8DiK1CRr/Core-Web-Components-%5BDESIGNERS-DO-NOT-USE%5D?type=design&node-id=364-29974&mode=design',
         },
     },
 };
@@ -112,6 +121,7 @@ const Template = ({
     rel,
     size,
     variant,
+    type,
     isBold,
     isStandalone,
     slot,
@@ -125,6 +135,7 @@ const Template = ({
             href="${href || nothing}"
             target="${target || nothing}"
             rel="${rel || nothing}"
+            type="${type || nothing}"
             ?isBold="${isBold}"
             ?isStandalone="${isStandalone}">
             ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}

--- a/packages/components/pie-divider/test/visual/pie-divider.spec.ts
+++ b/packages/components/pie-divider/test/visual/pie-divider.spec.ts
@@ -22,7 +22,17 @@ const props: PropObject = {
     orientation: orientations,
 };
 
-const renderTestPieDivider = (propVals: WebComponentPropValues) => `<pie-divider variant="${propVals.variant}" orientation="${propVals.orientation}" />`;
+const renderTestPieDivider = (propVals: WebComponentPropValues) => {
+    const { variant, orientation } = propVals;
+    if (orientation === 'vertical') {
+        return `
+            <div style="height: 250px">
+                <pie-divider variant="${variant}" orientation="${orientation}" />
+            </div>
+        `;
+    }
+    return `<pie-divider variant="${variant}" orientation="${orientation}"></pie-divider>`;
+};
 
 const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(props);
 const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
@@ -39,11 +49,17 @@ test.beforeEach(async ({ page, mount }) => {
 componentVariants.forEach((variant) => test(`Render all prop variations for Variant: ${variant}`, async ({ page, mount }) => {
     await Promise.all(componentPropsMatrixByVariant[variant].map(async (combo: WebComponentPropValues) => {
         const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieDivider);
-        const propKeyValues = `orientation: ${testComponent.propValues.orientation}}`;
+        const propKeyValues = `orientation: ${testComponent.propValues.orientation}`;
 
         await mount(
             WebComponentTestWrapper,
-            { props: { propKeyValues, darkMode: variant === 'inverse' } },
+            {
+                props: { propKeyValues, darkMode: variant === 'inverse' },
+                slots: {
+                    component: testComponent.renderedString.trim(),
+                },
+            },
+
         );
     }));
 

--- a/packages/components/pie-link/README.md
+++ b/packages/components/pie-link/README.md
@@ -59,7 +59,7 @@ import { PieLink } from '@justeattakeaway/pie-link/dist/react';
 
 | Property      | Type        | Default       | Description                                                                                          |
 | ------------- | ----------- | ------------- | ---------------------------------------------------------------------------------------------------- |
-| tag           | `String`  | `a`         | The renderd HTML element of the link, one of `tags` – `a`, `button`                         |
+| tag           | `String`  | `a`         | The rendered HTML element of the link, one of `tags` – `a`, `button`                         |
 | variant       | `String`  | `default`   | Variant of the link, one of `variants` – `default`, `high-visibility`, `inverse`         |
 | size          | `String`  | `medium`    | Size of the link, one of `sizes` – `medium`, `small`                                          |
 | href          | `String`  | `undefined` | Native html `href` attribute                                                                       |

--- a/packages/components/pie-link/README.md
+++ b/packages/components/pie-link/README.md
@@ -57,16 +57,18 @@ import { PieLink } from '@justeattakeaway/pie-link/dist/react';
 
 ## Props
 
-| Property      | Type        | Default       | Description                                                                                    |
-| ------------- | ----------- | ------------- | ---------------------------------------------------------------------------------------------- |
-| variant       | `String`  | `default`   | Variant of the link, one of `variants` – `default `, `high-visibility `, `inverse` |
-| size          | `String`  | `medium`    | Size of the link, one of `sizes` – `medium`, `small`                                    |
-| href          | `String`  | `undefined` | Native html `href` attribute                                                                 |
-| rel           | `String`  | `undefined` | Native html `rel` attribute                                                                  |
-| target        | `String`  | `undefined` | Native html `target` attribute                                                               |
-| isBold        | `Boolean` | `false`     | If `true`, sets the link text bold                                                           |
-| isStandalone  | `Boolean` | `false`     | If `true`, sets the link as a block element                                                  |
-| iconPlacement | `String`  | `leading`   | Icon placements of the icon slot, if provided, one of `iconPlacements` - `leading`, `trailing`         |
+| Property      | Type        | Default       | Description                                                                                          |
+| ------------- | ----------- | ------------- | ---------------------------------------------------------------------------------------------------- |
+| tag           | `String`  | `a`         | The renderd HTML element of the link, one of `tags` – `a`, `button`                         |
+| variant       | `String`  | `default`   | Variant of the link, one of `variants` – `default`, `high-visibility`, `inverse`         |
+| size          | `String`  | `medium`    | Size of the link, one of `sizes` – `medium`, `small`                                          |
+| href          | `String`  | `undefined` | Native html `href` attribute                                                                       |
+| rel           | `String`  | `undefined` | Native html `rel` attribute                                                                        |
+| target        | `String`  | `undefined` | Native html `target` attribute                                                                     |
+| type          | `String`  | `submit`    | Native html `type` attribute if the tag is set to `button`                                       |
+| isBold        | `Boolean` | `false`     | If `true`, sets the link text bold                                                                 |
+| isStandalone  | `Boolean` | `false`     | If `true`, sets the link as a block element                                                        |
+| iconPlacement | `String`  | `leading`   | Icon placements of the icon slot, if provided, one of `iconPlacements` - `leading`, `trailing` |
 
 In your markup or JSX, you can then use these to set the properties for the `pie-link` component:
 
@@ -80,9 +82,9 @@ In your markup or JSX, you can then use these to set the properties for the `pie
 
 ## Slots
 
-| Slot         | Description                                                                                                                                                                                                               |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Default slot | The default slot is used to pass text into the link component.                                                                                                                                                            |
+| Slot         | Description                                                                                                                                                                                                                |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Default slot | The default slot is used to pass text into the link component.                                                                                                                                                             |
 | icon         | Used to pass in an icon to the link component. The icon placement can be controlled via the `iconPlacement` prop and we recommend using `pie-icons-webc` for defining this icon, but this can also accept an SVG icon. |
 
 ### Using `pie-icons-webc` with the `pie-link` icon slot

--- a/packages/components/pie-link/src/defs.ts
+++ b/packages/components/pie-link/src/defs.ts
@@ -1,8 +1,13 @@
 export const variants = ['default', 'high-visibility', 'inverse'] as const;
 export const sizes = ['small', 'medium'] as const;
 export const iconPlacements = ['leading', 'trailing'] as const;
+export const tags = ['a', 'button'] as const;
 
 export interface LinkProps {
+     /**
+     * What HTML element the link should be such as a or button.
+     */
+    tag: typeof tags[number];
     /**
      * What style variant the link should be such as default, high-visibility or inverse.
      */

--- a/packages/components/pie-link/src/defs.ts
+++ b/packages/components/pie-link/src/defs.ts
@@ -2,6 +2,7 @@ export const variants = ['default', 'high-visibility', 'inverse'] as const;
 export const sizes = ['small', 'medium'] as const;
 export const iconPlacements = ['leading', 'trailing'] as const;
 export const tags = ['a', 'button'] as const;
+export const buttonTypes = ['submit', 'button', 'reset', 'menu'] as const;
 
 export interface LinkProps {
      /**
@@ -19,7 +20,7 @@ export interface LinkProps {
     /**
      * The URL that the hyperlink should point to
      */
-    href: string;
+    href?: string;
     /**
      * Where to display the linked URL such as _self, _blank, _parent or _top
      */
@@ -40,5 +41,8 @@ export interface LinkProps {
      * The placement of the icon slot, if provided, such as leading or trailing
      */
     iconPlacement?: typeof iconPlacements[number];
-
+    /**
+     * What type attribute should be applied if the tag is set to button. For example submit, button or menu.
+     */
+    type?: typeof buttonTypes[number];
 }

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -1,12 +1,10 @@
-import {
-    LitElement, html, unsafeCSS, nothing,
-} from 'lit';
+import { LitElement, unsafeCSS, nothing } from 'lit';
+import { html, unsafeStatic } from 'lit/static-html.js';
 import { property } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
 import styles from './link.scss?inline';
 import {
-    LinkProps, variants, sizes, iconPlacements,
+    LinkProps, variants, sizes, iconPlacements, tags,
 } from './defs';
 
 // Valid values available to consumers
@@ -20,6 +18,10 @@ const componentSelector = 'pie-link';
  */
 
 export class PieLink extends LitElement implements LinkProps {
+    @property()
+    @validPropertyValues(componentSelector, tags, 'a')
+    public tag: LinkProps['tag'] = 'a';
+
     @property({ type: String })
     @validPropertyValues(componentSelector, variants, 'default')
     public variant: LinkProps['variant'] = 'default';
@@ -49,27 +51,38 @@ export class PieLink extends LitElement implements LinkProps {
 
     render () {
         const {
-            variant, size, iconPlacement, href, target, rel, isBold, isStandalone,
+            tag,
+            variant,
+            size,
+            iconPlacement,
+            isBold,
+            isStandalone,
+            href,
+            target,
+            rel,
         } = this;
 
+        const element = unsafeStatic(tag);
+        const isButton = tag === 'button';
+
         return html`
-            <a
+            <${element}  
                 data-test-id="pie-link"
                 class="c-link"
+                tag="${tag}"
                 variant=${variant}
                 size=${size}
-                href=${ifDefined(href)}
-                target=${ifDefined(target)}
-                rel=${ifDefined(rel)}
                 ?isBold=${isBold}
-                ?isStandalone=${isStandalone}>
+                ?isStandalone=${isStandalone}
+                href=${!isButton && href ? href : nothing}
+                target=${!isButton && target ? target : nothing}
+                rel=${!rel && rel ? target : nothing}>
                     <div class="c-link-content">
-                      ${iconPlacement === 'leading' ? html`<slot name="icon"></slot>` : nothing}
-                      <slot></slot>
-                      ${iconPlacement === 'trailing' ? html`<slot name="icon"></slot>` : nothing}
+                        ${iconPlacement === 'leading' ? html`<slot name="icon"></slot>` : nothing}
+                        <slot></slot>
+                        ${iconPlacement === 'trailing' ? html`<slot name="icon"></slot>` : nothing}
                     </div>
-                </div>
-            </a>`;
+            </${element}>`;
     }
 
     // Renders a `CSSResult` generated from SCSS by Vite

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -4,7 +4,7 @@ import { property } from 'lit/decorators.js';
 import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
 import styles from './link.scss?inline';
 import {
-    LinkProps, variants, sizes, iconPlacements, tags,
+    LinkProps, variants, sizes, iconPlacements, tags, buttonTypes,
 } from './defs';
 
 // Valid values available to consumers
@@ -35,7 +35,7 @@ export class PieLink extends LitElement implements LinkProps {
     public iconPlacement: LinkProps['iconPlacement'] = 'leading';
 
     @property({ type: String, reflect: true })
-    public href!: string;
+    public href?: string;
 
     @property({ type: String, reflect: true })
     public target?: string;
@@ -49,6 +49,10 @@ export class PieLink extends LitElement implements LinkProps {
     @property({ type: Boolean })
     public isStandalone = false;
 
+    @property()
+    @validPropertyValues(componentSelector, buttonTypes, 'submit')
+    public type: LinkProps['type'] = 'submit';
+
     render () {
         const {
             tag,
@@ -60,6 +64,7 @@ export class PieLink extends LitElement implements LinkProps {
             href,
             target,
             rel,
+            type,
         } = this;
 
         const element = unsafeStatic(tag);
@@ -76,12 +81,13 @@ export class PieLink extends LitElement implements LinkProps {
                 ?isStandalone=${isStandalone}
                 href=${!isButton && href ? href : nothing}
                 target=${!isButton && target ? target : nothing}
-                rel=${!rel && rel ? target : nothing}>
-                    <div class="c-link-content">
+                rel=${!isButton && rel ? rel : nothing}
+                type=${isButton && type ? type : nothing}>
+                    <span class="c-link-content">
                         ${iconPlacement === 'leading' ? html`<slot name="icon"></slot>` : nothing}
                         <slot></slot>
                         ${iconPlacement === 'trailing' ? html`<slot name="icon"></slot>` : nothing}
-                    </div>
+                    </span>
             </${element}>`;
     }
 

--- a/packages/components/pie-link/src/link.scss
+++ b/packages/components/pie-link/src/link.scss
@@ -18,6 +18,18 @@
     text-decoration: var(--link-text-decoration);
     cursor: pointer;
 
+    &[tag='a'] {
+        /* Same as default styles */
+    }
+
+    &[tag='button'] {
+        outline: none;
+        border: none;
+        user-select: none;
+        background: transparent;
+        padding: 0;
+    }
+
     &[variant='default'] {
         /* Same as default styles */
     }

--- a/packages/components/pie-link/src/link.scss
+++ b/packages/components/pie-link/src/link.scss
@@ -69,6 +69,6 @@
 ::slotted(svg) {
     display: inline-flex;
     margin-block-start: var(--dt-spacing-a);
-    height: var(--btn-icon-size);
-    width: var(--btn-icon-size);
+    height: var(--link-icon-size);
+    width: var(--link-icon-size);
 }

--- a/packages/components/pie-link/test/component/pie-link.spec.ts
+++ b/packages/components/pie-link/test/component/pie-link.spec.ts
@@ -4,13 +4,18 @@ import { PieLink, LinkProps } from '@/index';
 
 const componentSelector = '[data-test-id="pie-link"]';
 
-const props: LinkProps = {
-    href: '#',
-    target: '_blank',
+const props: Partial<LinkProps> = {
+    // common props
     variant: 'default',
     size: 'medium',
     isBold: false,
     isStandalone: false,
+    // valid anchor props
+    href: '#',
+    target: '_blank',
+    rel: 'nofollow',
+    // valid button props
+    type: 'submit',
 };
 
 test.describe('PieLink - Component tests', () => {
@@ -26,7 +31,47 @@ test.describe('PieLink - Component tests', () => {
 
         // Assert
         await expect(link).toBeVisible();
+    });
+
+    test('should render as anchor when tag="a"', async ({ mount, page }) => {
+        // Arrange
+        await mount(PieLink, {
+            props: {
+                ...props,
+                tag: 'a',
+            },
+            slots: { default: 'Anchor Link!' },
+        });
+
+        // Act
+        const link = page.locator(`a${componentSelector}`);
+
+        // Assert
+        await expect(link).toBeVisible();
         await expect(link).toHaveAttribute('href', '#');
         await expect(link).toHaveAttribute('target', '_blank');
+        await expect(link).toHaveAttribute('rel', 'nofollow');
+        await expect(link).not.toHaveAttribute('type', 'submit');
+    });
+
+    test('should render as button when tag="button"', async ({ mount, page }) => {
+        // Arrange
+        await mount(PieLink, {
+            props: {
+                ...props,
+                tag: 'button',
+            },
+            slots: { default: 'Button Link!' },
+        });
+
+        // Act
+        const buttonLink = page.locator(`button${componentSelector}`);
+
+        // Assert
+        await expect(buttonLink).toBeVisible();
+        await expect(buttonLink).toHaveAttribute('type', 'submit');
+        await expect(buttonLink).not.toHaveAttribute('href', '#');
+        await expect(buttonLink).not.toHaveAttribute('target', '_blank');
+        await expect(buttonLink).not.toHaveAttribute('rel', 'nofollow');
     });
 });

--- a/packages/components/pie-link/test/visual/pie-link.spec.ts
+++ b/packages/components/pie-link/test/visual/pie-link.spec.ts
@@ -13,19 +13,24 @@ import {
 import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
-import { variants, sizes, iconPlacements } from '@/defs';
+import {
+    variants, sizes, iconPlacements, tags,
+} from '@/defs';
 import { PieLink } from '@/index';
 
 const props: PropObject = {
+    tag: tags,
     variant: variants,
     size: sizes,
     href: 'pie.design',
-    target: '_blank',
     isBold: [true, false],
     isStandalone: [true, false],
+    iconPlacement: [undefined, ...iconPlacements],
 };
 
-const renderTestPieLink = (propVals: WebComponentPropValues) => `<pie-link variant="${propVals.variant}" size="${propVals.size}" href="${propVals.href}" target="${propVals.target}" ${propVals.isBold ? 'isBold' : ''} ${propVals.isStandalone ? 'isStandalone' : ''} />`;
+const icon = '<svg slot="icon" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--plusCircle"><path d="M8.656 4.596H7.344v2.748H4.596v1.312h2.748v2.748h1.312V8.656h2.748V7.344H8.656V4.596Z"></path><path d="M12.795 3.205a6.781 6.781 0 1 0 0 9.625 6.79 6.79 0 0 0 0-9.625Zm-.927 8.662a5.469 5.469 0 1 1-7.734-7.735 5.469 5.469 0 0 1 7.734 7.736Z"></path></svg>';
+
+const renderTestPieLink = (propVals: WebComponentPropValues) => `<pie-link tag="${propVals.tag}" variant="${propVals.variant}" size="${propVals.size}" iconPlacement="${propVals.iconPlacement}" href="${propVals.href}" ${propVals.isBold ? 'isBold' : ''} ${propVals.isStandalone ? 'isStandalone' : ''}>${propVals.iconPlacement ? icon : ''} Link</pie-link>`;
 
 const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(props);
 const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
@@ -42,37 +47,18 @@ test.beforeEach(async ({ page, mount }) => {
 componentVariants.forEach((variant) => test(`Render all prop variations for Variant: ${variant}`, async ({ page, mount }) => {
     await Promise.all(componentPropsMatrixByVariant[variant].map(async (combo: WebComponentPropValues) => {
         const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieLink);
-        const propKeyValues = `size: ${testComponent.propValues.size}, isBold: ${testComponent.propValues.isBold}, isStandalone: ${testComponent.propValues.isStandalone}, href: ${testComponent.propValues.href}, target: ${testComponent.propValues.target}, target: ${testComponent.propValues.target}`;
+        const propKeyValues = `tag: ${testComponent.propValues.tag}, size: ${testComponent.propValues.size}, iconPlacement: ${testComponent.propValues.iconPlacement}, isBold: ${testComponent.propValues.isBold}, isStandalone: ${testComponent.propValues.isStandalone}, href: ${testComponent.propValues.href}`;
 
         await mount(
             WebComponentTestWrapper,
-            { props: { propKeyValues, darkMode: variant === 'inverse' } },
+            {
+                props: { propKeyValues, darkMode: variant === 'inverse' },
+                slots: {
+                    component: testComponent.renderedString.trim(),
+                },
+            },
         );
     }));
 
     await percySnapshot(page, `PIE Link - Variant: ${variant}`);
 }));
-
-const icon = '<svg slot="icon" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--plusCircle"><path d="M8.656 4.596H7.344v2.748H4.596v1.312h2.748v2.748h1.312V8.656h2.748V7.344H8.656V4.596Z"></path><path d="M12.795 3.205a6.781 6.781 0 1 0 0 9.625 6.79 6.79 0 0 0 0-9.625Zm-.927 8.662a5.469 5.469 0 1 1-7.734-7.735 5.469 5.469 0 0 1 7.734 7.736Z"></path></svg>';
-
-test('Render icon slot variations', async ({ page, mount }) => {
-    iconPlacements.forEach(async (iconPlacement) => {
-        const href = 'pie.design';
-        const propKeyValues = `href: ${href} , iconPlacement: ${iconPlacement}`;
-
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues },
-                slots: {
-                    component: `<pie-link href="${href}" iconPlacement="${iconPlacement}" >
-                                    ${icon}
-                                    Hello, Pie Link!
-                                </pie-link>`,
-                },
-            },
-        );
-    });
-
-    await percySnapshot(page, 'PIE Link Leading/Trailing Icon Variations');
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,7 +5454,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@workspace:*, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
@@ -27462,6 +27462,7 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeattakeaway/pie-button": "workspace:*"
+    "@justeattakeaway/pie-cookie-banner": "workspace:*"
     "@justeattakeaway/pie-css": "workspace:*"
     "@justeattakeaway/pie-divider": "workspace:*"
     "@justeattakeaway/pie-icon-button": "workspace:*"
@@ -32037,15 +32038,6 @@ __metadata:
   bin:
     sigstore: bin/sigstore.js
   checksum: 9886278224da4f25cc4823ff961d04addc81b71fd2310cfe019bcd8094590cafaa0d78a648cf665b1fb3ba13388ace4c970cba563572a967e8aa0c26067a402b
-  languageName: node
-  linkType: hard
-
-"simple-update-notifier@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "simple-update-notifier@npm:2.0.0"
-  dependencies:
-    semver: ^7.5.3
-  checksum: 9ba00d38ce6a29682f64a46213834e4eb01634c2f52c813a9a7b8873ca49cdbb703696f3290f3b27dc067de6d9418b0b84bef22c3eb074acf352529b2d6c27fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Added] - allow the link component to behave like a button

[Changed] - fixed visual tests for the link and divider components

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
