### PR TITLE
chore(pie-monorepo): DSW-1110 update ds token package

### DIFF
--- a/.changeset/empty-panthers-drop.md
+++ b/.changeset/empty-panthers-drop.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Changed] - Upgraded `@justeat/pie-design-tokens` to `5.7.0`

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -12,7 +12,7 @@
     "vite": "4.3.9"
   },
   "dependencies": {
-    "@justeat/pie-design-tokens": "5.5.0",
+    "@justeat/pie-design-tokens": "5.7.0",
     "@justeattakeaway/pie-button": "0.26.0",
     "@justeattakeaway/pie-css": "0.3.0",
     "@justeattakeaway/pie-icon-button": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@commitlint/cli": "17.5.1",
     "@commitlint/config-conventional": "17.4.4",
     "@justeat/browserslist-config-fozzie": "1.x",
-    "@justeat/pie-design-tokens": "5.6.2",
+    "@justeat/pie-design-tokens": "5.7.0",
     "@justeattakeaway/generator-pie-component": "workspace:*",
     "@justeattakeaway/pie-webc-testing": "workspace:*",
     "@justeattakeaway/stylelint-config-pie": "workspace:*",

--- a/packages/tools/pie-css/test/css/__snapshots__/css.spec.ts.snap
+++ b/packages/tools/pie-css/test/css/__snapshots__/css.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`index.css > should render the expected CSS content 1`] = `
-":root, ::backdrop {
+":root {
     /* Global tokens - Color */
     --dt-color-aubergine-10: #e7d6e7;
     --dt-color-aubergine-80: #452844;
@@ -662,7 +662,7 @@ exports[`index.css > should render the expected CSS content 1`] = `
     --dt-elevation-dark-inverse-04: var(--dt-elevation-box-shadow-04);
     --dt-elevation-dark-inverse-05: var(--dt-elevation-box-shadow-05);
 }
-:root, ::backdrop {
+:root {
     --dt-color-aubergine-10-h: 300;
     --dt-color-aubergine-10-s: 26.2%;
     --dt-color-aubergine-10-l: 87.3%;

--- a/packages/tools/pie-icons-vue/.eslintrc.cjs
+++ b/packages/tools/pie-icons-vue/.eslintrc.cjs
@@ -10,6 +10,7 @@ module.exports = {
         ...vue3.rules,
         'vue/sort-keys': 'off',
         'import/no-extraneous-dependencies': 'off',
+        'import/no-unresolved': 'off',
     },
     parserOptions: {
         parser: '@babel/eslint-parser',

--- a/packages/tools/pie-icons-vue/scripts/build.js
+++ b/packages/tools/pie-icons-vue/scripts/build.js
@@ -3,7 +3,7 @@ import { pascalCase } from 'pascal-case';
 import fs from 'fs-extra';
 
 import pieIcons from '@justeattakeaway/pie-icons';
-import { normalizeIconName } from '@justeattakeaway/pie-icons-configs'; // eslint-disable-line import/no-unresolved
+import { normalizeIconName } from '@justeattakeaway/pie-icons-configs';
 
 const componentTemplate = (name, svg) => {
     const isLargeIcon = name.endsWith('Large');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5396,14 +5396,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeat/pie-design-tokens@npm:5.6.2":
-  version: 5.6.2
-  resolution: "@justeat/pie-design-tokens@npm:5.6.2"
+"@justeat/pie-design-tokens@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@justeat/pie-design-tokens@npm:5.7.0"
   dependencies:
     jsonc-parser: 3.2.0
     lodash.merge: 4.6.2
     mkdirp: 1.0.4
-  checksum: 30624ad70c8e51792e377722a72393e949a5444ab730e58c93777163e314553c40bd1e120b80d1edba6405607dfa7ce3f821447c280ea2a118383d9c7072bcd1
+  checksum: 860da946c0e50f247face85bb610c46e09d64f157466da04c14e2c2425f0958492fd98a3da75153d00fcc3dc2a4d2fdd688568613fd5c8a5f83c0647b08a8574
   languageName: node
   linkType: hard
 
@@ -27413,7 +27413,7 @@ __metadata:
     "@commitlint/config-conventional": 17.4.4
     "@justeat/browserslist-config-fozzie": 1.x
     "@justeat/fozzie": 11.0.0
-    "@justeat/pie-design-tokens": 5.6.2
+    "@justeat/pie-design-tokens": 5.7.0
     "@justeattakeaway/generator-pie-component": "workspace:*"
     "@justeattakeaway/pie-webc-testing": "workspace:*"
     "@justeattakeaway/stylelint-config-pie": "workspace:*"
@@ -36163,7 +36163,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
-    "@justeat/pie-design-tokens": 5.5.0
+    "@justeat/pie-design-tokens": 5.7.0
     "@justeattakeaway/pie-button": 0.26.0
     "@justeattakeaway/pie-css": 0.3.0
     "@justeattakeaway/pie-icon-button": 0.14.0


### PR DESCRIPTION
---
"pie-monorepo": minor
---

[Changed] - Upgraded `@justeat/pie-design-tokens` to `5.7.0`



**Notes:**
- I have verified the Next13 example app displays the design tokens correctly in Safari 14 on Mac OS and iOS using Browserstack.

- I have verified the modal in Storybook displays the design tokens correctly in Safari 14 on Mac OS and iOS using Browserstack.