### PR TITLE
fix(pie-toggle-switch): DSW-1196 safari bug issue

### DIFF
--- a/.changeset/young-snakes-begin.md
+++ b/.changeset/young-snakes-begin.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-toggle-switch": minor
+---
+
+[Fixed] Safari bug with toggle placement

--- a/packages/components/pie-toggle-switch/src/toggle-switch.scss
+++ b/packages/components/pie-toggle-switch/src/toggle-switch.scss
@@ -142,6 +142,7 @@
         left: initial;
         right: 2px;
     }
+
     .c-toggleSwitch-input:checked + .c-toggleSwitch-control {
         @include toggle-switch-transition(transform);
         transform: translateX(calc(-1 * var(--toggle-switch-translation)));

--- a/packages/components/pie-toggle-switch/src/toggle-switch.scss
+++ b/packages/components/pie-toggle-switch/src/toggle-switch.scss
@@ -38,6 +38,7 @@
     --toggle-switch-radius: var(--dt-radius-rounded-e);
     --toggle-switch-translation: calc(var(--toggle-switch-width) - var(--toggle-switch-control-size) - 2 * var(--toggle-switch-padding));
 
+    position: relative;
     display: flex;
     width: var(--toggle-switch-width);
     height: var(--toggle-switch-height);
@@ -96,6 +97,8 @@
 }
 
 .c-toggleSwitch-control {
+    position: absolute;
+    left: 2px;
     @include toggle-switch-transition(transform);
     width: var(--toggle-switch-control-size);
     height: var(--toggle-switch-control-size);
@@ -134,6 +137,11 @@
 }
 
 :host([dir='rtl']) {
+    .c-toggleSwitch-control {
+        position: absolute;
+        left: initial;
+        right: 2px;
+    }
     .c-toggleSwitch-input:checked + .c-toggleSwitch-control {
         @include toggle-switch-transition(transform);
         transform: translateX(calc(-1 * var(--toggle-switch-translation)));


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### Safari
![Screenshot 2023-09-07 at 13 15 39](https://github.com/justeattakeaway/pie/assets/2299779/86e06d2e-ce2c-4bf5-8cf3-ae48813ea97f)
![Screenshot 2023-09-07 at 13 16 16](https://github.com/justeattakeaway/pie/assets/2299779/e891dd5a-13cb-4433-8e17-66ac09ddd36b)
![Screenshot 2023-09-07 at 13 17 16](https://github.com/justeattakeaway/pie/assets/2299779/bb2b8e3f-a7a4-4fdc-bff7-21a64589b5f2)

### Chrome
![Screenshot 2023-09-07 at 13 26 07](https://github.com/justeattakeaway/pie/assets/2299779/85efde68-d395-4b99-b1d7-6f7bc0f7a7c7)
![Screenshot 2023-09-07 at 13 26 18](https://github.com/justeattakeaway/pie/assets/2299779/9d78e911-948f-405a-bae3-d9927efd2fd8)
![Screenshot 2023-09-07 at 13 27 19](https://github.com/justeattakeaway/pie/assets/2299779/4d1209e2-a0db-4f21-a392-31e0b5b30aef)

![Screenshot 2023-09-07 at 13 30 31](https://github.com/justeattakeaway/pie/assets/2299779/e7e5004f-9a7c-4a19-b8e4-bb6d3e078136)




### Firefox



## Author Checklist (complete before requesting a review)

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
