### PR TITLE
fix(pie-toggle-switch): DSW-1220 safari ios bug

### DIFF
--- a/.changeset/curvy-terms-move.md
+++ b/.changeset/curvy-terms-move.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-toggle-switch": minor
+---
+
+[Fixed] Safari ios checkbox disabled visual issue

--- a/packages/components/pie-toggle-switch/src/toggle-switch.scss
+++ b/packages/components/pie-toggle-switch/src/toggle-switch.scss
@@ -95,7 +95,7 @@
     margin: 0;
 
     &:disabled {
-       background-color: transparent;
+        background-color: transparent;
     }
 }
 

--- a/packages/components/pie-toggle-switch/src/toggle-switch.scss
+++ b/packages/components/pie-toggle-switch/src/toggle-switch.scss
@@ -85,7 +85,6 @@
 
     &[isDisabled] {
         background-color: var(--toggle-switch-bg-color--disabled);
-
         cursor: not-allowed;
         pointer-events: none;
     }
@@ -94,6 +93,10 @@
 .c-toggleSwitch-input {
     appearance: none;
     margin: 0;
+
+    &:disabled {
+       background-color: transparent;
+    }
 }
 
 .c-toggleSwitch-control {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] Safari ios checkbox disabled visual issue

<img width="1954" alt="Screenshot 2023-09-11 at 16 29 05" src="https://github.com/justeattakeaway/pie/assets/2299779/e7d6e44f-2a19-46bb-91cd-f599c78b0132">
<img width="1037" alt="Screenshot 2023-09-11 at 16 29 38" src="https://github.com/justeattakeaway/pie/assets/2299779/ce58926b-31b3-41c6-81b1-3cd8816fd818">





## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
