### PR TITLE
feat(pie-card-container): DSW-1161 is draggable

### DIFF
--- a/.changeset/young-trains-roll.md
+++ b/.changeset/young-trains-roll.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-card-container": minor
+"@justeattakeaway/pie-css": minor
+---
+
+[Added] - pie-css helper class and modified card container to accept draggable prop

--- a/apps/pie-storybook/stories/pie-card-container.stories.ts
+++ b/apps/pie-storybook/stories/pie-card-container.stories.ts
@@ -22,6 +22,7 @@ const defaultArgs: CardContainerProps = {
     aria: {
         linkLabel: 'Click to go to restaurant',
     },
+    isDraggable: false,
     // This is just an arbitrary example of some markup a user may pass into the card
     slot: `<div style="color: var(--card-color); font-size: calc(var(--dt-font-body-l-size) * 1px); font-family: var(--dt-font-interactive-m-family); padding: var(--dt-spacing-b);">
         <h2> Card title </h2>
@@ -78,6 +79,12 @@ const cardContainerStoryMeta: CardContainerStoryMeta = {
             description: 'The ARIA labels used for various parts of the card.',
             control: 'object',
         },
+        isDraggable: {
+            control: 'boolean',
+            defaultValue: {
+                summary: false,
+            },
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -98,6 +105,7 @@ const Template: TemplateFunction<CardContainerProps> = ({
     slot,
     aria,
     variant,
+    isDraggable,
 }) => {
     const darkMode = variant.includes('inverse');
 
@@ -109,7 +117,8 @@ const Template: TemplateFunction<CardContainerProps> = ({
             target="${target || nothing}"
             rel="${rel || nothing}"
             ?disabled="${disabled}"
-            .aria="${aria}">
+            .aria="${aria}"
+            .isDraggable="${isDraggable}">
             ${unsafeStatic(slot)}
         </pie-card-container>
     </div>

--- a/packages/components/pie-card-container/src/card-container.scss
+++ b/packages/components/pie-card-container/src/card-container.scss
@@ -99,7 +99,7 @@
     &.isDraggable {
         a,
         button {
-            @extend %has-grabCursor;
+            @extend %has-grab-cursor;
         }
     }
 }

--- a/packages/components/pie-card-container/src/card-container.scss
+++ b/packages/components/pie-card-container/src/card-container.scss
@@ -95,6 +95,13 @@
     &:focus-within {
         box-shadow: 0 0 0 2px var(--dt-color-focus-inner), 0 0 0 4px var(--dt-color-focus-outer);
     }
+
+    &.isDraggable {
+      a,
+      button {
+          @extend %has-grabCursor;
+      }
+    }
 }
 
 .c-card-container-slot {

--- a/packages/components/pie-card-container/src/card-container.scss
+++ b/packages/components/pie-card-container/src/card-container.scss
@@ -97,10 +97,10 @@
     }
 
     &.isDraggable {
-      a,
-      button {
-          @extend %has-grabCursor;
-      }
+        a,
+        button {
+            @extend %has-grabCursor;
+        }
     }
 }
 

--- a/packages/components/pie-card-container/src/defs.ts
+++ b/packages/components/pie-card-container/src/defs.ts
@@ -36,4 +36,9 @@ export interface CardContainerProps {
      * What style variant the card should be such as default or inverse.
      */
     variant: Variant;
+
+    /**
+     * Allows the consumer to set draggable css styles (grab/grabbing cursor styles).
+     */
+    isDraggable: boolean;
 }

--- a/packages/components/pie-card-container/src/index.ts
+++ b/packages/components/pie-card-container/src/index.ts
@@ -31,6 +31,9 @@ export class PieCardContainer extends LitElement implements CardContainerProps {
     @property({ type: Object })
     public aria!: AriaProps;
 
+    @property({ type: Boolean })
+    public isDraggable = false;
+
     render () {
         const {
             href,
@@ -38,12 +41,13 @@ export class PieCardContainer extends LitElement implements CardContainerProps {
             rel,
             disabled,
             variant,
+            isDraggable,
         } = this;
 
         return html`
                 <div
                     variant=${variant}
-                    class="c-card-container"
+                    class="c-card-container ${isDraggable ? 'isDraggable' : ''}"
                     data-test-id="pie-card-container"
                     ?disabled=${disabled}>
                     <a

--- a/packages/components/pie-card-container/test/component/pie-card-container.spec.ts
+++ b/packages/components/pie-card-container/test/component/pie-card-container.spec.ts
@@ -129,4 +129,47 @@ test.describe('PieCardContainer - Component tests', () => {
         // Assert
         await expect(component).toHaveAttribute('variant', variant);
     });
+
+    test.describe('Prop: `isDraggable`', () => {
+        test.describe('when set to true', () => {
+            test('should set class `isDraggable`', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieCardContainer, {
+                    props: {
+                        isDraggable: true,
+                    } as CardContainerProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                });
+
+                const component = page.locator(componentSelector);
+                const componentClass = await component.getAttribute('class');
+
+                // Assert
+                expect(componentClass).toContain('isDraggable');
+            });
+        });
+
+        test.describe('when set to false', () => {
+            test('should not set class `isDraggable`', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieCardContainer, {
+                    props: {
+                        isDraggable: false,
+                    } as CardContainerProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                });
+
+                // Act
+                const component = page.locator(componentSelector);
+                const componentClass = await component.getAttribute('class');
+
+                // Assert
+                expect(componentClass).not.toContain('isDraggable');
+            });
+        });
+    });
 });

--- a/packages/tools/pie-css/scss/helpers/_helpers.scss
+++ b/packages/tools/pie-css/scss/helpers/_helpers.scss
@@ -1,0 +1,9 @@
+// Allows a grab handle to appear.
+// Currently used in the card container component.
+%has-grabCursor {
+    cursor: grab;
+
+    &:active {
+        cursor: grabbing;
+    }
+}

--- a/packages/tools/pie-css/scss/helpers/_helpers.scss
+++ b/packages/tools/pie-css/scss/helpers/_helpers.scss
@@ -1,6 +1,6 @@
 // Allows a grab handle to appear.
 // Currently used in the card container component.
-%has-grabCursor {
+%has-grab-cursor {
     cursor: grab;
 
     &:active {

--- a/packages/tools/pie-css/scss/helpers/index.scss
+++ b/packages/tools/pie-css/scss/helpers/index.scss
@@ -1,0 +1,1 @@
+@forward './helpers';

--- a/packages/tools/pie-css/scss/index.scss
+++ b/packages/tools/pie-css/scss/index.scss
@@ -1,2 +1,3 @@
 @forward './mixins/';
 @forward './functions/';
+@forward 'helpers';


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Added] - pie-css helper class and modified card container to accept draggable prop

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
