### PR TITLE
feat(pie-form-label): DSW-1188 build form label

### DIFF
--- a/.changeset/stale-beans-fix.md
+++ b/.changeset/stale-beans-fix.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-form-label": minor
+"@justeattakeaway/pie-link": minor
+"pie-storybook": minor
+---
+
+[Added] - Build the Pie Form Label web component

--- a/apps/pie-storybook/stories/pie-form-label.stories.ts
+++ b/apps/pie-storybook/stories/pie-form-label.stories.ts
@@ -1,20 +1,52 @@
-import { html } from 'lit';
-import { PieFormLabel, FormLabelProps } from '@justeattakeaway/pie-form-label';
-import { type StoryMeta } from '../types';
-import { createStory } from '../utilities';
+import { html, nothing } from 'lit';
+import { PieFormLabel, FormLabelProps as FormLabelPropsBase } from '@justeattakeaway/pie-form-label';
+import { SlottedComponentProps, type StoryMeta } from '../types';
+import { createStory, type TemplateFunction } from '../utilities';
 
 // This prevents storybook from tree shaking the components
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const keptReferences = [PieFormLabel];
 
+type FormLabelProps = SlottedComponentProps<FormLabelPropsBase>;
 type FormLabelStoryMeta = StoryMeta<FormLabelProps>;
 
-const defaultArgs: FormLabelProps = {};
+const defaultArgs: FormLabelProps = {
+    for: 'form-label',
+    slot: 'Label',
+    optional: 'Optional',
+    trailing: 'X of X',
+};
 
 const formLabelStoryMeta: FormLabelStoryMeta = {
     title: 'Form Label',
     component: 'pie-form-label',
-    argTypes: {},
+    argTypes: {
+        for: {
+            description: 'The native HTML `for` attribute',
+            control: 'text',
+        },
+        slot: {
+            description: 'The default slot is used to pass the label text into the component.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        optional: {
+            description: 'Optional is used to pass an optional text next to the main label.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        trailing: {
+            description: 'Trailing is used to pass a trailing text into the component.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+    },
     args: defaultArgs,
     parameters: {
         design: {
@@ -26,10 +58,17 @@ const formLabelStoryMeta: FormLabelStoryMeta = {
 
 export default formLabelStoryMeta;
 
-// TODO: remove the eslint-disable rule when props are added
-// eslint-disable-next-line no-empty-pattern
-const Template = ({}: FormLabelProps) => html`
-  <pie-form-label></pie-form-label>
-`;
+const Template: TemplateFunction<FormLabelProps> = ({
+    slot,
+    optional,
+    trailing,
+    ...props
+}) => html`
+        <pie-form-label
+            for="${props.for}"
+            optional="${optional || nothing}"
+            trailing="${trailing || nothing}">
+                ${slot}
+        </pie-form-label>`;
 
 export const Default = createStory<FormLabelProps>(Template, defaultArgs)();

--- a/packages/components/pie-form-label/README.md
+++ b/packages/components/pie-form-label/README.md
@@ -59,16 +59,18 @@ import { PieFormLabel } from '@justeattakeaway/pie-form-label/dist/react';
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| - | - | - | - |
+| for | `String` | `undefined` | Native html `for` attribute |
+| optional | `String` | `undefined` | Sets an optional text to be placed next to the main label |
+| trailing | `String` | `undefined` | Sets a trailing text at the end of the label component  |
 
 In your markup or JSX, you can then use these to set the properties for the `pie-form-label` component:
 
 ```html
 <!-- Native HTML -->
-<pie-form-label></pie-form-label>
+<pie-form-label>Label</pie-form-label>
 
 <!-- JSX -->
-<PieFormLabel></PieFormLabel>
+<PieFormLabel>Label</PieFormLabel>
 ```
 
 ## Testing

--- a/packages/components/pie-form-label/src/defs.ts
+++ b/packages/components/pie-form-label/src/defs.ts
@@ -1,3 +1,14 @@
-// TODO - please remove the eslint disable comment below when you add props to this interface
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FormLabelProps {}
+export interface FormLabelProps {
+    /**
+    * The native for HTML attribute.
+    */
+    for?: string;
+    /**
+    * Optional text to be placed next to the main label.
+    */
+    optional?: string;
+    /**
+    * What the trailing text of the label should be.
+    */
+    trailing?: string;
+}

--- a/packages/components/pie-form-label/src/defs.ts
+++ b/packages/components/pie-form-label/src/defs.ts
@@ -8,7 +8,7 @@ export interface FormLabelProps {
     */
     optional?: string;
     /**
-    * What the trailing text of the label should be.
+    * What the trailing text of the label component should be.
     */
     trailing?: string;
 }

--- a/packages/components/pie-form-label/src/form-label.scss
+++ b/packages/components/pie-form-label/src/form-label.scss
@@ -1,10 +1,5 @@
 @use '@justeattakeaway/pie-css/scss' as p;
 
-*,
-*:before,
-*:after {
-    box-sizing: border-box;
-}
 
 .pie-form-label {
     --form-label-font-size: #{p.font-size(--dt-font-size-14)};

--- a/packages/components/pie-form-label/src/form-label.scss
+++ b/packages/components/pie-form-label/src/form-label.scss
@@ -1,1 +1,40 @@
 @use '@justeattakeaway/pie-css/scss' as p;
+
+*,
+*:before,
+*:after {
+    box-sizing: border-box;
+}
+
+.pie-form-label {
+    --form-label-font-size: #{p.font-size(--dt-font-size-14)};
+    --form-label-line-height: calc(var(--dt-font-size-14-line-height) * 1px);
+    --form-label-font-weight: var(--dt-font-weight-bold);
+    --form-label-color: var(--dt-color-content-default);
+    --form-label-offset: var(--dt-spacing-a);
+
+    display: flex;
+    justify-content: space-between;
+    gap: var(--dt-spacing-d);
+    width: 100%;
+    color: var(--form-label-color);
+    font-size: var(--form-label-font-size);
+    line-height: var(--form-label-line-height);
+    font-weight: var(--form-label-font-weight);
+    margin-block-end: var(--form-label-offset);
+}
+
+.pie-form-label-optional,
+.pie-form-label-trailing {
+    color: var(--dt-color-content-subdued);
+    font-weight: var(--dt-font-weight-regular);
+}
+
+.pie-form-label-optional {
+    margin-inline-start: var(--dt-spacing-b);
+}
+
+.pie-form-label-trailing {
+    flex-shrink: 0;
+    white-space: var(--dt-spacing-d);
+}

--- a/packages/components/pie-form-label/src/form-label.scss
+++ b/packages/components/pie-form-label/src/form-label.scss
@@ -1,6 +1,6 @@
 @use '@justeattakeaway/pie-css/scss' as p;
 
-.pie-form-label {
+.c-formLabel {
     --form-label-font-size: #{p.font-size(--dt-font-size-14)};
     --form-label-line-height: calc(var(--dt-font-size-14-line-height) * 1px);
     --form-label-font-weight: var(--dt-font-weight-bold);
@@ -9,7 +9,6 @@
     display: flex;
     justify-content: space-between;
     gap: var(--dt-spacing-d);
-    width: 100%;
     color: var(--form-label-color);
     font-size: var(--form-label-font-size);
     line-height: var(--form-label-line-height);
@@ -17,17 +16,17 @@
     margin-block-end: var(--dt-spacing-a);
 }
 
-.pie-form-label-optional,
-.pie-form-label-trailing {
+.c-formLabel-optional,
+.c-formLabel-trailing {
     color: var(--dt-color-content-subdued);
     font-weight: var(--dt-font-weight-regular);
 }
 
-.pie-form-label-optional {
+.c-formLabel-optional {
     margin-inline-start: var(--dt-spacing-b);
 }
 
-.pie-form-label-trailing {
+.c-formLabel-trailing {
     flex-shrink: 0;
     white-space: var(--dt-spacing-d);
 }

--- a/packages/components/pie-form-label/src/form-label.scss
+++ b/packages/components/pie-form-label/src/form-label.scss
@@ -1,12 +1,10 @@
 @use '@justeattakeaway/pie-css/scss' as p;
 
-
 .pie-form-label {
     --form-label-font-size: #{p.font-size(--dt-font-size-14)};
     --form-label-line-height: calc(var(--dt-font-size-14-line-height) * 1px);
     --form-label-font-weight: var(--dt-font-weight-bold);
     --form-label-color: var(--dt-color-content-default);
-    --form-label-offset: var(--dt-spacing-a);
 
     display: flex;
     justify-content: space-between;
@@ -16,7 +14,7 @@
     font-size: var(--form-label-font-size);
     line-height: var(--form-label-line-height);
     font-weight: var(--form-label-font-weight);
-    margin-block-end: var(--form-label-offset);
+    margin-block-end: var(--dt-spacing-a);
 }
 
 .pie-form-label-optional,

--- a/packages/components/pie-form-label/src/index.ts
+++ b/packages/components/pie-form-label/src/index.ts
@@ -29,13 +29,13 @@ export class PieFormLabel extends LitElement implements FormLabelProps {
         return html`
             <label
                 data-test-id="pie-form-label"
-                class="pie-form-label"
+                class="c-formLabel"
                 for=${this.for}>
                     <div>
                         <slot></slot>
-                        ${optional ? html`<span class="pie-form-label-optional">${optional}</span>` : nothing}
+                        ${optional ? html`<span class="c-formLabel-optional">${optional}</span>` : nothing}
                     </div>
-                    ${trailing ? html`<span class="pie-form-label-trailing">${trailing}</span>` : nothing}
+                    ${trailing ? html`<span class="c-formLabel-trailing">${trailing}</span>` : nothing}
             </label>`;
     }
 

--- a/packages/components/pie-form-label/src/index.ts
+++ b/packages/components/pie-form-label/src/index.ts
@@ -1,5 +1,7 @@
-import { LitElement, html, unsafeCSS } from 'lit';
-
+import {
+    LitElement, html, nothing, unsafeCSS,
+} from 'lit';
+import { property } from 'lit/decorators.js';
 import styles from './form-label.scss?inline';
 import { FormLabelProps } from './defs';
 
@@ -9,8 +11,32 @@ export * from './defs';
 const componentSelector = 'pie-form-label';
 
 export class PieFormLabel extends LitElement implements FormLabelProps {
+    @property({ type: String, reflect: true })
+    public for?: string;
+
+    @property({ type: String })
+    public optional?: string;
+
+    @property({ type: String })
+    public trailing?: string;
+
     render () {
-        return html`<h1 data-test-id="pie-form-label">Hello world!</h1>`;
+        const {
+            optional,
+            trailing,
+        } = this;
+
+        return html`
+            <label
+                data-test-id="pie-form-label"
+                class="pie-form-label"
+                for=${this.for}>
+                    <div>
+                        <slot></slot>
+                        ${optional ? html`<span class="pie-form-label-optional">${optional}</span>` : nothing}
+                    </div>
+                    ${trailing ? html`<span class="pie-form-label-trailing">${trailing}</span>` : nothing}
+            </label>`;
     }
 
     // Renders a `CSSResult` generated from SCSS by Vite

--- a/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
@@ -8,7 +8,16 @@ test.describe('PieFormLabel - Component tests', () => {
     test('should render successfully', async ({ mount, page }) => {
         // Arrange
         await mount(PieFormLabel, {
-            props: {} as FormLabelProps,
+            // TODO: remove @ts-ignore when https://github.com/sand4rt/playwright-ct-web/issues/27 is fixed
+            // @ts-ignore
+            props: {
+                for: 'form-label',
+                optional: 'Optional',
+                trailing: 'X out X',
+            } as FormLabelProps,
+            slots: {
+                default: 'Label',
+            },
         });
 
         // Act

--- a/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
@@ -8,8 +8,7 @@ test.describe('PieFormLabel - Component tests', () => {
     test('should render successfully', async ({ mount, page }) => {
         // Arrange
         await mount(PieFormLabel, {
-            // TODO: remove @ts-ignore when https://github.com/sand4rt/playwright-ct-web/issues/27 is fixed
-            // @ts-ignore
+            // Note: the ts issue in props should be fixed with this https://github.com/sand4rt/playwright-ct-web/issues/27
             props: {
                 for: 'form-label',
                 optional: 'Optional',

--- a/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
@@ -8,7 +8,7 @@ test.describe('PieFormLabel - Component tests', () => {
     test('should render successfully', async ({ mount, page }) => {
         // Arrange
         await mount(PieFormLabel, {
-            // Note: the ts issue in props should be fixed with this https://github.com/sand4rt/playwright-ct-web/issues/27
+            // Note: the props ts issue should be fixed with https://github.com/sand4rt/playwright-ct-web/issues/27
             props: {
                 for: 'form-label',
                 optional: 'Optional',

--- a/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/component/pie-form-label.spec.ts
@@ -1,5 +1,5 @@
 
-import { test, expect } from '@sand4rt/experimental-ct-web';
+import { test, expect, MountOptions } from '@sand4rt/experimental-ct-web';
 import { PieFormLabel, FormLabelProps } from '@/index';
 
 const componentSelector = '[data-test-id="pie-form-label"]';
@@ -8,12 +8,11 @@ test.describe('PieFormLabel - Component tests', () => {
     test('should render successfully', async ({ mount, page }) => {
         // Arrange
         await mount(PieFormLabel, {
-            // Note: the props ts issue should be fixed with https://github.com/sand4rt/playwright-ct-web/issues/27
             props: {
                 for: 'form-label',
                 optional: 'Optional',
                 trailing: 'X out X',
-            } as FormLabelProps,
+            } as MountOptions<Record<string, never>, PieFormLabel>['props'] & FormLabelProps,
             slots: {
                 default: 'Label',
             },

--- a/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
@@ -1,14 +1,34 @@
 
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
-import { PieFormLabel, FormLabelProps } from '@/index';
+import {
+    WebComponentTestWrapper,
+} from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
+import type {
+    PropObject, WebComponentPropValues, WebComponentTestInput,
+} from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
+import {
+    createTestWebComponent,
+} from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
+import { FormLabelProps } from '@/defs';
 
-test.describe('PieFormLabel - Visual tests`', () => {
-    test('should display the PieFormLabel component successfully', async ({ page, mount }) => {
-        await mount(PieFormLabel, {
-            props: {} as FormLabelProps,
+const renderTestPieDivider = (propVals: WebComponentPropValues) => `<pie-form-label optional="${propVals.optional}" trailing="${propVals.trailing}"></pie-form-label>`;
+
+const props: FormLabelProps = {
+    optional: 'Optional',
+    trailing: 'X out of X',
+};
+
+test.describe('Pie Form Label - Visual tests`', () => {
+    test('should display the Pie Form Label component successfully', async ({ page, mount }) => {
+        const testComponent: WebComponentTestInput = createTestWebComponent(props, renderTestPieDivider);
+
+        await mount(WebComponentTestWrapper, {
+            slots: {
+                component: testComponent.renderedString.trim(),
+            },
         });
 
-        await percySnapshot(page, 'PieFormLabel - Visual Test');
+        await percySnapshot(page, 'Pie Form Label - Visual Test');
     });
 });

--- a/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
@@ -10,20 +10,31 @@ import type {
 import {
     createTestWebComponent,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
+import { PieFormLabel } from '@/index';
 import { FormLabelProps } from '@/defs';
 
-const renderTestPieDivider = (propVals: WebComponentPropValues) => `<pie-form-label optional="${propVals.optional}" trailing="${propVals.trailing}"></pie-form-label>`;
+const renderTestPieDivider = (propVals: WebComponentPropValues) => `<pie-form-label optional="${propVals.optional}" trailing="${propVals.trailing}">Label</pie-form-label>`;
 
 const props: FormLabelProps = {
     optional: 'Optional',
     trailing: 'X out of X',
 };
 
+test.beforeEach(async ({ page, mount }) => {
+    await mount(PieFormLabel, {});
+    await page.evaluate(() => {
+        const element : Element | null = document.querySelector('pie-form-label');
+        element?.remove();
+    });
+});
+
 test.describe('Pie Form Label - Visual tests`', () => {
     test('should display the Pie Form Label component successfully', async ({ page, mount }) => {
         const testComponent: WebComponentTestInput = createTestWebComponent(props, renderTestPieDivider);
+        const propKeyValues = `optional: ${testComponent.propValues.optional}, trailing: ${testComponent.propValues.trailing}`;
 
         await mount(WebComponentTestWrapper, {
+            props: { propKeyValues },
             slots: {
                 component: testComponent.renderedString.trim(),
             },

--- a/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
@@ -5,7 +5,7 @@ import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import type {
-    PropObject, WebComponentPropValues, WebComponentTestInput,
+    WebComponentPropValues, WebComponentTestInput,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
 import {
     createTestWebComponent,

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -5,8 +5,14 @@ import { property } from 'lit/decorators.js';
 import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
 import styles from './link.scss?inline';
 import {
-    LinkProps, variants, sizes, iconPlacements,
-    tags, buttonTypes, underlineTypes, type AriaProps,
+    LinkProps,
+    variants,
+    sizes,
+    iconPlacements,
+    tags,
+    buttonTypes,
+    underlineTypes,
+    type AriaProps,
 } from './defs';
 
 // Valid values available to consumers


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Added] - Build the Pie Form Label component

📓 as a result of [ this discussion](https://github.com/justeattakeaway/pie/discussions/782), we agreed to pass the optional / trailing labels as named slots to the component, however, that didn't seem to be doable during implementation as slots aren't moved in the DOM tree, but they're rendered as if they were children of the `<slot>` so when the parent element (label) is a flex container, optional and trailing slots won't be considered 'flex children' as they aren't a direct child. 

Besides, marking them as a slot will require end users to set the html element alongside the slot such as 
```
<pie-form-label>
Label
<span slot='trailing'> X out X </span>
</pie-form-label>
```
and that's going to be tricky to validate since we only want to accept text, so it's easier to lock it down as a prop and avoid the overhead of validating HTML elements, figuring out how to ensure the passed markup is positioned correctly in the component layout etc.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
