### PR TITLE
fix(pie-link): DSW-1185 address design reviews

### DIFF
--- a/.changeset/clean-deers-arrive.md
+++ b/.changeset/clean-deers-arrive.md
@@ -3,11 +3,11 @@
 "pie-storybook": minor
 ---
 
-[Fixed] - When the `isStandalone` prop is `false`, underline can only be default and not reversed.
+[Fixed] - The `reverse` value of the `underline` prop can only be used if `isStandalone` is `true`
 
 [Fixed] - When the `isStandalone` prop is `false`, icon's cannot be shown.
 
-[Fixed] - When the link is small, he icon doesn't seem to be vertically centered with the text.
+[Fixed] - When the link is small, the icon doesn't seem to be vertically centered with the text.
 
 [Fixed] - The spacing between the text and icon should be fixed / hugging the length of the text.
 

--- a/.changeset/clean-deers-arrive.md
+++ b/.changeset/clean-deers-arrive.md
@@ -1,0 +1,15 @@
+---
+"@justeattakeaway/pie-link": minor
+"pie-storybook": minor
+---
+
+[Fixed] - When the `isStandalone` prop is `false`, underline can only be default and not reversed.
+
+[Fixed] - When the `isStandalone` prop is `false`, icon's cannot be shown.
+
+[Fixed] - When the link is small, he icon doesn't seem to be vertically centered with the text.
+
+[Fixed] - The spacing between the text and icon should be fixed / hugging the length of the text.
+
+[Fixed] - focus styles for the link component
+

--- a/.changeset/clean-deers-arrive.md
+++ b/.changeset/clean-deers-arrive.md
@@ -3,7 +3,7 @@
 "pie-storybook": minor
 ---
 
-[Fixed] - The `reverse` value of the `underline` prop can only be used if `isStandalone` is `true`
+[Fixed] - The `reverse` value of the `underline` prop can only be used if `isStandalone` is set to `true`
 
 [Fixed] - When the `isStandalone` prop is `false`, icon's cannot be shown.
 

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -55,7 +55,7 @@ const linkStoryMeta: LinkStoryMeta = {
             },
         },
         underline: {
-            description: 'Set the underline behavior of the link.',
+            description: 'Set the underline behavior of the link.<br /><br /> the `reverse` type can only be used if `isStandalone` is `true`',
             control: 'select',
             options: underlineTypes,
             defaultValue: {
@@ -63,7 +63,7 @@ const linkStoryMeta: LinkStoryMeta = {
             },
         },
         iconPlacement: {
-            description: 'Show a leading/trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.',
+            description: 'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br /> Can only be used if `isStandalone` is `true`',
             control: 'select',
             options: [undefined, ...iconPlacements],
         },

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -55,7 +55,7 @@ const linkStoryMeta: LinkStoryMeta = {
             },
         },
         underline: {
-            description: 'Set the underline behavior of the link.<br /><br /> the `reverse` type can only be used if `isStandalone` is `true`',
+            description: 'Set the underline behavior of the link.<br /><br /> The `reverse` type can only be used if `isStandalone` is `true`',
             control: 'select',
             options: underlineTypes,
             defaultValue: {
@@ -63,7 +63,7 @@ const linkStoryMeta: LinkStoryMeta = {
             },
         },
         iconPlacement: {
-            description: 'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br /> Can only be used if `isStandalone` is `true`',
+            description: 'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br />Can only be used if `isStandalone` is `true`',
             control: 'select',
             options: [undefined, ...iconPlacements],
         },

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -55,7 +55,7 @@ const linkStoryMeta: LinkStoryMeta = {
             },
         },
         underline: {
-            description: 'Set the underline behavior of the link.<br /><br /> The `reverse` type can only be used if `isStandalone` is `true`',
+            description: 'Set the underline behavior of the link.<br /><br />The `reverse` type can only be used if `isStandalone` is set to `true`',
             control: 'select',
             options: underlineTypes,
             defaultValue: {
@@ -63,7 +63,7 @@ const linkStoryMeta: LinkStoryMeta = {
             },
         },
         iconPlacement: {
-            description: 'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br />Can only be used if `isStandalone` is `true`',
+            description: 'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br />Can only be used if `isStandalone` is set to `true`',
             control: 'select',
             options: [undefined, ...iconPlacements],
         },

--- a/packages/components/pie-link/README.md
+++ b/packages/components/pie-link/README.md
@@ -62,7 +62,7 @@ import { PieLink } from '@justeattakeaway/pie-link/dist/react';
 | tag           | `String`  | `a`         | The rendered HTML element of the link, one of `tags` – `a`, `button`                        |
 | variant       | `String`  | `default`   | Variant of the link, one of `variants` – `default`, `high-visibility`, `inverse`         |
 | size          | `String`  | `medium`    | Size of the link, one of `sizes` – `medium`, `small`                                          |
-| underline          | `String`  | `default`    | The underline behavior of the link, one of `underlineTypes` – `default`, `reversed`                                          |
+| underline          | `String`  | `default`    | The underline behavior of the link, one of `underlineTypes` – `default`, `reversed`. The `reverse` type can only be used if `isStandalone` is `true`                                          |
 | href          | `String`  | `undefined` | Native html `href` attribute                                                                       |
 | rel           | `String`  | `undefined` | Native html `rel` attribute                                                                        |
 | target        | `String`  | `undefined` | Native html `target` attribute                                                                     |
@@ -70,7 +70,7 @@ import { PieLink } from '@justeattakeaway/pie-link/dist/react';
 | isBold        | `Boolean` | `false`     | If `true`, sets the link text bold                                                                 |
 | isStandalone  | `Boolean` | `false`     | If `true`, sets the link as a block element                                                        |
 | hasVisited    | `Boolean` | `false`     | If `true`, the link will apply the styles for the visited state                                    |
-| iconPlacement | `String`  | `leading`   | Icon placements of the icon slot, if provided, one of `iconPlacements` - `leading`, `trailing` |
+| iconPlacement | `String`  | `leading`   | Icon placements of the icon slot, if provided, one of `iconPlacements` - `leading`, `trailing`. Can only be used if `isStandalone` is `true` |
 | aria | `object` | `undefined` | The ARIA labels used for the link. |
 
 In your markup or JSX, you can then use these to set the properties for the `pie-link` component:

--- a/packages/components/pie-link/README.md
+++ b/packages/components/pie-link/README.md
@@ -62,7 +62,7 @@ import { PieLink } from '@justeattakeaway/pie-link/dist/react';
 | tag           | `String`  | `a`         | The rendered HTML element of the link, one of `tags` – `a`, `button`                        |
 | variant       | `String`  | `default`   | Variant of the link, one of `variants` – `default`, `high-visibility`, `inverse`         |
 | size          | `String`  | `medium`    | Size of the link, one of `sizes` – `medium`, `small`                                          |
-| underline          | `String`  | `default`    | The underline behavior of the link, one of `underlineTypes` – `default`, `reversed`. The `reverse` type can only be used if `isStandalone` is `true`                                          |
+| underline          | `String`  | `default`    | The underline behavior of the link, one of `underlineTypes` – `default`, `reversed`. The `reverse` type can only be used if `isStandalone` is set to `true`                                          |
 | href          | `String`  | `undefined` | Native html `href` attribute                                                                       |
 | rel           | `String`  | `undefined` | Native html `rel` attribute                                                                        |
 | target        | `String`  | `undefined` | Native html `target` attribute                                                                     |

--- a/packages/components/pie-link/src/defs.ts
+++ b/packages/components/pie-link/src/defs.ts
@@ -27,7 +27,8 @@ export interface LinkProps {
      */
     size: typeof sizes[number];
     /**
-     * What underline behavior the link should have such as default or reversed
+     * What underline behavior the link should have such as default or reversed.
+     * The `reversed` type can only be used if the link is a block element (isStandalone = true)
      */
     underline: typeof underlineTypes[number];
     /**
@@ -55,7 +56,8 @@ export interface LinkProps {
      */
     hasVisited: boolean;
     /**
-     * The placement of the icon slot, if provided, such as leading or trailing
+     * The placement of the icon slot, if provided, such as leading or trailing.
+     * Will only apply if the link is a block element (isStandalone = true)
      */
     iconPlacement?: typeof iconPlacements[number];
     /**

--- a/packages/components/pie-link/src/defs.ts
+++ b/packages/components/pie-link/src/defs.ts
@@ -27,7 +27,7 @@ export interface LinkProps {
      */
     size: typeof sizes[number];
     /**
-     * What underline behavior the link should have such as default or reversed.
+     * Defines what underline behavior the link should have, such as default or reversed.
      * The `reversed` type can only be used if the link is a block element (isStandalone = true)
      */
     underline: typeof underlineTypes[number];

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -73,7 +73,7 @@ export class PieLink extends LitElement implements LinkProps {
 
     /**
      * Renders the link content.
-     * Icons should render only if the link is a block element
+     * Icons should only render if the link is a block element
      * @private
      */
     private renderContent (): TemplateResult {

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -73,7 +73,7 @@ export class PieLink extends LitElement implements LinkProps {
 
     /**
      * Renders the link content.
-     * Icons should only render if the link is a block element
+     * Icons are only shown in block elements
      * @private
      */
     private renderContent (): TemplateResult {

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -73,16 +73,16 @@ export class PieLink extends LitElement implements LinkProps {
 
     /**
      * Renders the link content.
-     *
+     * Icons should render only if the link is a block element
      * @private
      */
     private renderContent (): TemplateResult {
-        const { iconPlacement } = this;
+        const { iconPlacement, isStandalone } = this;
         return html`
                 <span class="c-link-content">
-                    ${iconPlacement === 'leading' ? html`<slot name="icon"></slot>` : nothing}
+                    ${isStandalone && iconPlacement === 'leading' ? html`<slot name="icon"></slot>` : nothing}
                     <slot></slot>
-                    ${iconPlacement === 'trailing' ? html`<slot name="icon"></slot>` : nothing}
+                    ${isStandalone && iconPlacement === 'trailing' ? html`<slot name="icon"></slot>` : nothing}
                 </span>`;
     }
 

--- a/packages/components/pie-link/src/link.scss
+++ b/packages/components/pie-link/src/link.scss
@@ -104,7 +104,6 @@
 .c-link-content {
     display: flex;
     gap: var(--dt-spacing-a);
-    text-align: justify;
 }
 
 ::slotted(.c-pieIcon),

--- a/packages/components/pie-link/src/link.scss
+++ b/packages/components/pie-link/src/link.scss
@@ -31,6 +31,9 @@
     text-decoration: var(--link-text-decoration);
     cursor: pointer;
 
+    @include link-interactive-states('default');
+
+
     &[tag='a'] {
         /* Same as default styles */
     }
@@ -67,11 +70,9 @@
 
     &[underline='default'] {
         /* Same as default styles */
-
-        @include link-interactive-states('default');
     }
 
-    &[underline='reversed'] {
+    &[underline='reversed'][isStandalone] {
         --link-text-decoration: none;
 
         @include link-interactive-states('reversed');

--- a/packages/components/pie-link/src/link.scss
+++ b/packages/components/pie-link/src/link.scss
@@ -20,6 +20,7 @@
     --link-text-color: var(--dt-color-content-link);
     --link-text-decoration: var(--dt-font-style-underline);
     --link-icon-size: 16px;
+    --link-icon-offset-top: var(--dt-spacing-a);
 
     display: inline-block;
     font-family: var(--link-font-family);
@@ -57,6 +58,7 @@
     &[size='small'] {
         --link-font-size: #{p.font-size(--dt-font-size-14)};
         --link-line-height: calc(var(--dt-font-size-14-line-height) * 1px);
+        --link-icon-offset-top: 2px;
     }
 
     &[size='medium'] {
@@ -92,19 +94,22 @@
     }
 
     &:focus-visible {
-        box-shadow: 0 0 0 2px var(--dt-color-focus-outer);
+        outline: none;
+        border-radius: 2px;
+        box-shadow: 0 0 0 2px var(--dt-color-focus-inner), 0 0 0 4px var(--dt-color-focus-outer);
     }
 }
 
 .c-link-content {
     display: flex;
     gap: var(--dt-spacing-a);
+    text-align: justify;
 }
 
 ::slotted(.c-pieIcon),
 ::slotted(svg) {
     display: inline-flex;
-    margin-block-start: var(--dt-spacing-a);
+    margin-block-start: var(--link-icon-offset-top);
     height: var(--link-icon-size);
     width: var(--link-icon-size);
 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Fixed] - When the `isStandalone` prop is `false`, underline can only be default and not reversed.

[Fixed] - When the `isStandalone` prop is `false`, icon's cannot be shown.

[Fixed] - When the link is small, the icon doesn't seem to be vertically centered with the text.

[Fixed] - The spacing between the text and icon should be fixed / hugging the length of the text.

[Fixed] - focus styles for the link component

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
