### PR TITLE
chore(pie-monorepo): DSW-1280 add sideEffects property to components

### DIFF
--- a/.changeset/nervous-yaks-run.md
+++ b/.changeset/nervous-yaks-run.md
@@ -1,0 +1,14 @@
+---
+"@justeattakeaway/pie-card-container": minor
+"@justeattakeaway/generator-pie-component": minor
+"@justeattakeaway/pie-cookie-banner": minor
+"@justeattakeaway/pie-toggle-switch": minor
+"@justeattakeaway/pie-icon-button": minor
+"@justeattakeaway/pie-form-label": minor
+"@justeattakeaway/pie-divider": minor
+"@justeattakeaway/pie-button": minor
+"@justeattakeaway/pie-modal": minor
+"@justeattakeaway/pie-link": minor
+---
+
+[Added] - set sideEffects package.json property to correctly communicate to bundlers such as webpack that js files in the component dist folders contain side effects and should therefore not be treeshaken when the entire library is imported. [Reference](https://cube.dev/blog/how-to-build-tree-shakeable-javascript-libraries)

--- a/packages/components/pie-button/package.json
+++ b/packages/components/pie-button/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-card-container/package.json
+++ b/packages/components/pie-card-container/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-cookie-banner/package.json
+++ b/packages/components/pie-cookie-banner/package.json
@@ -41,5 +41,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-divider/package.json
+++ b/packages/components/pie-divider/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-form-label/package.json
+++ b/packages/components/pie-form-label/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-icon-button/package.json
+++ b/packages/components/pie-icon-button/package.json
@@ -34,5 +34,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-link/package.json
+++ b/packages/components/pie-link/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-modal/package.json
+++ b/packages/components/pie-modal/package.json
@@ -44,5 +44,8 @@
   },
   "dependencies": {
     "dialog-polyfill": "0.5.6"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/components/pie-toggle-switch/package.json
+++ b/packages/components/pie-toggle-switch/package.json
@@ -33,5 +33,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }

--- a/packages/tools/generator-pie-component/src/app/templates/__package__.json
+++ b/packages/tools/generator-pie-component/src/app/templates/__package__.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  }
+  },
+  "sideEffects": [
+    "dist/*.js"
+  ]
 }


### PR DESCRIPTION
---
"@justeattakeaway/pie-card-container": minor
"@justeattakeaway/generator-pie-component": minor
"@justeattakeaway/pie-cookie-banner": minor
"@justeattakeaway/pie-toggle-switch": minor
"@justeattakeaway/pie-icon-button": minor
"@justeattakeaway/pie-form-label": minor
"@justeattakeaway/pie-divider": minor
"@justeattakeaway/pie-button": minor
"@justeattakeaway/pie-modal": minor
"@justeattakeaway/pie-link": minor
---

[Added] - set sideEffects package.json property to correctly communicate to bundlers such as webpack that js files in the component dist folders contain side effects and should therefore not be treeshaken when the entire library is imported. [Reference](https://cube.dev/blog/how-to-build-tree-shakeable-javascript-libraries)