### PR TITLE
feat(pie-webc-core): DSW-1306 extend validProperty decorator to support comma separated values

### DIFF
--- a/apps/pie-storybook/stories/pie-card-container.stories.ts
+++ b/apps/pie-storybook/stories/pie-card-container.stories.ts
@@ -2,7 +2,7 @@ import { nothing } from 'lit';
 import { html } from 'lit/static-html.js';
 import {
     PieCardContainer, CardContainerProps as CardContainerPropsBase,
-    variants, interactionTypes, padding,
+    variants, interactionTypes,
 } from '@justeattakeaway/pie-card-container';
 import type { StoryMeta, SlottedComponentProps } from '../types';
 import { createStory, type TemplateFunction, staticSlot } from '../utilities';
@@ -24,7 +24,6 @@ const defaultArgs: CardContainerProps = {
     aria: {
         label: 'Click to go to restaurant',
     },
-    padding: '',
     isDraggable: false,
     // This is just an arbitrary example of some markup a user may pass into the card
     slot: `<div style="color: var(--card-color); font-size: calc(var(--dt-font-body-l-size) * 1px); font-family: var(--dt-font-interactive-m-family); padding: var(--dt-spacing-b);">
@@ -61,11 +60,11 @@ const cardContainerStoryMeta: CardContainerStoryMeta = {
             },
         },
         padding: {
-            description: 'Set the padding of the card.',
+            description: `Set the padding of the card. <br /> Can be either a single value or two values separated by a comma. 
+            <br />Setting a single value adds padding to all sides, whereas setting two values will set "paddingX, paddingY" such as 'a' or 'a,b'`,
             control: {
                 type: 'text',
             },
-            options: padding,
         },
         disabled: {
             description: 'If `true`, disables the card.',
@@ -99,6 +98,7 @@ const cardContainerStoryMeta: CardContainerStoryMeta = {
         },
         isDraggable: {
             control: 'boolean',
+            description: 'If `true`, the card cursor will be draggable.',
             defaultValue: {
                 summary: false,
             },

--- a/packages/components/pie-card-container/src/defs.ts
+++ b/packages/components/pie-card-container/src/defs.ts
@@ -1,9 +1,8 @@
 export const variants = ['default', 'outline', 'inverse', 'outline-inverse'] as const;
 export const interactionTypes = ['anchor', 'button', 'none'] as const;
-export const padding = ['a', 'b', 'c', 'd', 'e', 'f', 'g'] as const;
+export const paddingValues = ['a', 'b', 'c', 'd', 'e', 'f', 'g'] as const;
 
-export type Variant = typeof variants[number];
-export type PaddingValue = typeof padding[number];
+export type PaddingValue = typeof paddingValues[number];
 
 export type AriaProps = {
     label?: string;
@@ -38,7 +37,7 @@ export interface CardContainerProps {
     /**
      * What style variant the card should be such as default or inverse.
      */
-    variant: Variant;
+    variant: typeof variants[number];
 
     /**
      * Allows the consumer to set draggable css styles (grab/grabbing cursor styles).
@@ -52,8 +51,8 @@ export interface CardContainerProps {
 
     /**
      * Sets the padding of the card container. Can be either a single value or two values
-     * separated by commas. Setting a single value adds padding to all sides of the card,
-     * whereas setting two values will set the "topBottom, leftRight" padding. e.g `'a'` or `'a, b'`
+     * separated by a comma. Setting a single value adds padding to all sides,
+     * whereas setting two values will set the "paddingX, paddingY" such as`'a'` or `'a,b'`
      */
-    padding?: PaddingValue | PaddingValue[];
+    padding?: PaddingValue | `${PaddingValue},${PaddingValue}`;
 }

--- a/packages/components/pie-card-container/src/index.ts
+++ b/packages/components/pie-card-container/src/index.ts
@@ -5,7 +5,10 @@ import { property } from 'lit/decorators.js';
 import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
 import styles from './card-container.scss?inline';
 import {
-    CardContainerProps, type AriaProps, type PaddingValue, variants, interactionTypes,
+    CardContainerProps,
+    variants,
+    interactionTypes,
+    paddingValues,
 } from './defs';
 
 // Valid values available to consumers
@@ -35,18 +38,14 @@ export class PieCardContainer extends LitElement implements CardContainerProps {
     public disabled = false;
 
     @property({ type: Object })
-    public aria!: AriaProps;
+    public aria: CardContainerProps['aria'];
 
     @property({ type: Boolean })
     public isDraggable = false;
 
-    /**
-     * Todo: We need to validate the user input at the moment
-     * the `validPropertyValues` won't work for this property so it
-     * is being looked at here: DSW-1306
-     */
     @property({ type: String })
-    public padding?: PaddingValue;
+    @validPropertyValues(componentSelector, paddingValues, undefined)
+    public padding?: CardContainerProps['padding'];
 
     /**
      * Renders the card as an anchor element.

--- a/packages/components/pie-webc-core/src/decorators/test/valid-property-values.spec.ts
+++ b/packages/components/pie-webc-core/src/decorators/test/valid-property-values.spec.ts
@@ -26,6 +26,9 @@ describe('validPropertyValues', () => {
         @validPropertyValues('mock-component', ['red', 'green', 'blue'], 'red')
             color = 'red';
 
+        @validPropertyValues('mock-component', ['a', 'b'], undefined)
+            padding?: string;
+
         private _requestUpdateArgs = {};
 
         requestUpdate (propertyKey: string, oldValue: unknown) {
@@ -37,54 +40,110 @@ describe('validPropertyValues', () => {
         }
     }
 
-    it('should allow value to be updated with a valid value', () => {
+    describe('With single value', () => {
+        it('should allow value to be updated with a valid value', () => {
         // Arrange
-        const mockComponent = new MockComponent();
+            const mockComponent = new MockComponent();
 
-        // Act
-        mockComponent.color = 'green';
+            // Act
+            mockComponent.color = 'green';
 
-        // Assert
-        expect(mockComponent.color).toBe('green');
-        expect(consoleErrorSpy).not.toHaveBeenCalled();
+            // Assert
+            expect(mockComponent.color).toBe('green');
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should fallback to the default value if an invalid value is assigned', () => {
+        // Arrange
+            const mockComponent = new MockComponent();
+
+            // Act
+            mockComponent.color = 'yellow';
+
+            // Assert
+            expect(mockComponent.color).toBe('red');
+            expect(consoleErrorSpy).toHaveBeenCalled();
+        });
+
+        it('should log an error message if an invalid value is assigned', () => {
+        // Arrange
+            const mockComponent = new MockComponent();
+
+            // Act
+            mockComponent.color = 'yellow';
+
+            // Assert
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '<mock-component> Invalid value "yellow" provided for property "color".',
+                'Must be one of: red | green | blue.',
+                'Falling back to default value: "red"',
+            );
+        });
+
+        it('should call requestUpdate when the property is set', () => {
+        // Arrange
+            const mockComponent = new MockComponent();
+
+            // Act
+            mockComponent.color = 'yellow';
+
+            // Assert
+            expect(mockComponent.color).toBe('red');
+            expect(mockComponent.requestUpdateCalledWith()).toStrictEqual({ propertyKey: 'color', oldValue: 'red' });
+        });
     });
 
-    it('should fallback to the default value if an invalid value is assigned', () => {
+    describe('With comma separated values', () => {
+        it('should allow value to be updated with a valid value', () => {
         // Arrange
-        const mockComponent = new MockComponent();
+            const mockComponent = new MockComponent();
 
-        // Act
-        mockComponent.color = 'yellow';
+            // Act
+            mockComponent.padding = 'a,b';
 
-        // Assert
-        expect(mockComponent.color).toBe('red');
-        expect(consoleErrorSpy).toHaveBeenCalled();
-    });
+            // Assert
+            expect(mockComponent.padding).toBe('a,b');
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
 
-    it('should log an error message if an invalid value is assigned', () => {
+        it('should fallback to the default value if an invalid value is assigned', () => {
         // Arrange
-        const mockComponent = new MockComponent();
+            const mockComponent = new MockComponent();
 
-        // Act
-        mockComponent.color = 'yellow';
+            // Act
+            mockComponent.padding = 'c,d';
 
-        // Assert
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            '<mock-component> Invalid value "yellow" provided for property "color".',
-            'Must be one of: red | green | blue.',
-            'Falling back to default value: "red"',
-        );
-    });
+            // Assert
+            expect(mockComponent.padding).toBe(undefined);
+            expect(consoleErrorSpy).toHaveBeenCalled();
+        });
 
-    it('should call requestUpdate when the property is set', () => {
+        it('should log an error message if an invalid value is assigned', () => {
         // Arrange
-        const mockComponent = new MockComponent();
+            const mockComponent = new MockComponent();
 
-        // Act
-        mockComponent.color = 'yellow';
+            // Act
+            mockComponent.padding = 'c,d';
 
-        // Assert
-        expect(mockComponent.color).toBe('red');
-        expect(mockComponent.requestUpdateCalledWith()).toStrictEqual({ propertyKey: 'color', oldValue: 'red' });
+            // Assert
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '<mock-component> Invalid value "c,d" provided for property "padding".',
+                'Must be a combination of values separated with a comma: a | b.',
+                'Falling back to default value: "undefined"',
+            );
+        });
+
+        it('should call requestUpdate when the property is set', () => {
+        // Arrange
+            const mockComponent = new MockComponent();
+
+            // Act
+            mockComponent.padding = 'c,d';
+
+            // Assert
+            expect(mockComponent.padding).toBe(undefined);
+            expect(mockComponent.requestUpdateCalledWith()).toStrictEqual({ propertyKey: 'padding', oldValue: undefined });
+        });
     });
 });
+

--- a/packages/components/pie-webc-core/src/decorators/valid-property-values.ts
+++ b/packages/components/pie-webc-core/src/decorators/valid-property-values.ts
@@ -1,6 +1,7 @@
 /**
  * A decorator for specifying a list of valid values for a property.
  * If this property's setter is called with an invalid value, an error is logged and the default value will be assigned instead.
+ * The decorator supports single values or a string of comma separated values
  * @param validValues - The array of valid values
  * @param defaultValue - The value to fall back on
  * @returns  - The decorator function
@@ -13,12 +14,20 @@ export const validPropertyValues = <T>(componentName: string, validValues: reado
             return this[privatePropertyKey];
         },
         set (value: T): void {
+            let isValid;
             const oldValue = this[privatePropertyKey];
+            const isCommaSeparatedValue = typeof value === 'string' && value.includes(',');
 
-            if (!validValues.includes(value)) {
+            if (isCommaSeparatedValue) {
+                isValid = value.trim().split(',').every((i) => validValues.includes(i as T));
+            } else {
+                isValid = validValues.includes(value);
+            }
+
+            if (!isValid) {
                 console.error(
                         `<${componentName}> Invalid value "${value}" provided for property "${propertyKey}".`,
-                        `Must be one of: ${validValues.join(' | ')}.`,
+                        `Must be ${isCommaSeparatedValue ? 'a combination of values separated with a comma' : 'one of'}: ${validValues.join(' | ')}.`,
                         `Falling back to default value: "${defaultValue}"`,
                 );
                 this[privatePropertyKey] = defaultValue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5184,7 +5184,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 0.8.1
+    "@justeattakeaway/pie-icons-webc": 0.9.0
     "@justeattakeaway/pie-webc-core": 0.9.1
   peerDependencies:
     "@justeat/pie-design-tokens": ^5.8.2
@@ -5240,7 +5240,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-webc@0.8.1, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
+"@justeattakeaway/pie-icons-webc@0.9.0, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
@@ -5295,7 +5295,7 @@ __metadata:
     "@justeattakeaway/pie-button": 0.30.0
     "@justeattakeaway/pie-components-config": 0.4.0
     "@justeattakeaway/pie-icon-button": 0.16.0
-    "@justeattakeaway/pie-icons-webc": 0.8.1
+    "@justeattakeaway/pie-icons-webc": 0.9.0
     "@justeattakeaway/pie-webc-core": 0.9.1
     "@types/body-scroll-lock": 3.1.0
     dialog-polyfill: 0.5.6
@@ -5309,7 +5309,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-toggle-switch@workspace:packages/components/pie-toggle-switch"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-icons-webc": 0.8.1
+    "@justeattakeaway/pie-icons-webc": 0.9.0
   languageName: unknown
   linkType: soft
 
@@ -27576,7 +27576,7 @@ __metadata:
     "@justeattakeaway/pie-divider": 0.6.0
     "@justeattakeaway/pie-form-label": 0.3.0
     "@justeattakeaway/pie-icon-button": 0.16.0
-    "@justeattakeaway/pie-icons-webc": 0.8.1
+    "@justeattakeaway/pie-icons-webc": 0.9.0
     "@justeattakeaway/pie-link": 0.7.0
     "@justeattakeaway/pie-modal": 0.25.0
     "@justeattakeaway/pie-toggle-switch": 0.12.0
@@ -36375,7 +36375,7 @@ __metadata:
     "@justeattakeaway/pie-button": 0.30.0
     "@justeattakeaway/pie-css": 0.5.1
     "@justeattakeaway/pie-icon-button": 0.16.0
-    "@justeattakeaway/pie-icons-webc": 0.8.1
+    "@justeattakeaway/pie-icons-webc": 0.9.0
     "@justeattakeaway/pie-modal": 0.25.0
     body-scroll-lock: 3.1.5
     vite: 4.3.9


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- I tried to wrap the validator so it gets used as an extension within the pie-card-container component but the actual value isn't passed to the decorator, instead, it's referenced as an instance field using the `this` keyword. 
- I extended the validator to accept comma-separated values, but I'm wondering if it's easier to just update our `paddingValues` array in `defs.ts` of the card to include every possible padding combination instead of modifying the decorator such as [here](https://stackoverflow.com/questions/43241174/javascript-generating-all-combinations-of-elements-in-a-single-array-in-pairs). this way we don't need to touch the decorator and be robust/clear about the valid values. 


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
