### PR TITLE
ci(pie-monorepo): DSW-1193 ensure all GH checks are passing

### DIFF
--- a/.changeset/ten-lies-punch.md
+++ b/.changeset/ten-lies-punch.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Added] - Github action settings to ensure the required CI jobs are passing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,3 +310,29 @@ jobs:
       os: ubuntu-latest
       node-version: 18
     secrets: inherit
+
+  check-all-jobs:
+    if: always()
+
+    needs:
+    - lint-styles
+    - lint-js
+    - build-ubuntu-node-16
+    - build-windows-node-16
+    - build-ubuntu-node-18
+    - build-windows-node-18
+    - unit-tests
+    - browser-tests-components
+    - deploy-docs
+    - deploy-storybook
+    - browser-tests-docs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Verify if the required jobs succeeded
+      uses: re-actors/alls-green@release/v1
+      with:
+        # "allowed-skips" lists jobs that are optional but should not fail
+        allowed-skips: browser-tests-components, deploy-docs, deploy-storybook, browser-tests-docs
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Add Github action settings to ensure the required CI jobs are passing

A new check will appear under the name "Build / check-all-jobs".

![image](https://github.com/justeattakeaway/pie/assets/448801/e77c0eed-7873-4f12-9b19-707e422af3eb)

In the [workflow view](https://github.com/justeattakeaway/pie/actions/runs/6507309654) you can see all the jobs "check-all-jobs" relies on:

![image](https://github.com/justeattakeaway/pie/assets/448801/b51a4183-bada-4659-a183-c8198e49d070)

In case some job fails, it will represented as usual:

<img width="855" alt="image" src="https://github.com/justeattakeaway/pie/assets/448801/8eb5325e-fdcc-474d-bee6-3734c6234b8b">

Also, as an example the workflow of failed pipeline might look like this:

![image](https://github.com/justeattakeaway/pie/assets/448801/e4c55535-98a2-4366-a554-54a8295aa75a)

![image](https://github.com/justeattakeaway/pie/assets/448801/fdd6ed83-e3c1-410d-8c62-f6d02f649666)

This is only an additional check and there's no need to change how we work.
