### PR TITLE
docs(pie-modal): DSW-1317 update default modal body text on storybook

### DIFF
--- a/apps/pie-storybook/stories/pie-modal.stories.ts
+++ b/apps/pie-storybook/stories/pie-modal.stories.ts
@@ -37,7 +37,7 @@ const defaultArgs: ModalProps = {
     isLoading: false,
     size: 'medium',
     position: 'center',
-    slot: '<p>This is Lit!</p>',
+    slot: '<p>Body copy</p>',
     leadingAction: {
         text: 'Confirm',
         variant: 'primary',


### PR DESCRIPTION
This PR was supposed to be larger, containing a fix for the padding around the modal content, but I realised that I fixed that already as part of #878.

---

## Describe your changes (can list changeset entries if preferable)

- Update default body text for modal on storybook

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
