### PR TITLE
ci(pie-monorepo): DSW-000 add outputs keyword to prevent changesets job failure when pushing Slack notification.

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -111,7 +111,7 @@ jobs:
     #    - For 'pie-storybook', a distinct message is generated pointing to 'webc.pie.design'.
     #    - For all other packages, a generic message is generated, including links to the GitHub release and npm.
     - name: Generate Slack payload blocks
-      if: steps.changesets-main.published == true
+      if: steps.changesets-main.outputs.published == true
       id: generate_payload
       run: |
         PACKAGES='${{ steps.changesets-main.outputs.publishedPackages}}'

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -114,7 +114,7 @@ jobs:
       if: steps.changesets-main.published == true
       id: generate_payload
       run: |
-        PACKAGES='${{ steps.changesets-main.publishedPackages}}'
+        PACKAGES='${{ steps.changesets-main.outputs.publishedPackages}}'
         PRIORITIZED_PACKAGES=$(echo $PACKAGES | jq -c '[.[] | select(.name == "pie-docs" or .name == "pie-storybook")]')
         REST_PACKAGES=$(echo $PACKAGES | jq -c '[.[] | select((.name != "pie-docs" and .name != "pie-storybook") and (.name | startswith("wc-") | not) and .name != "pie-monorepo")]')
     


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
I didn't realise the `.outputs` was needed on the line where we grab the array of published packages. Sorry!

Link to changeset docs - https://github.com/changesets/action#outputs

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
