### PR TITLE
ci(pie-monorepo): DSW-000 update changesets release logic from boolean to a string

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -111,7 +111,7 @@ jobs:
     #    - For 'pie-storybook', a distinct message is generated pointing to 'webc.pie.design'.
     #    - For all other packages, a generic message is generated, including links to the GitHub release and npm.
     - name: Generate Slack payload blocks
-      if: steps.changesets-main.outputs.published == true
+      if: steps.changesets-main.outputs.published == 'true'
       id: generate_payload
       run: |
         PACKAGES='${{ steps.changesets-main.outputs.publishedPackages}}'


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Minor update to change changesets published step from a boolean to a string.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
