### PR TITLE
fix(pie-modal): DSW-1322 Address modal footer design feedback

### DIFF
--- a/.changeset/silver-ties-warn.md
+++ b/.changeset/silver-ties-warn.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+[Changed] - The shadow effect for unpinned footer to span the whole container
+
+[Removed] - Heading shadow 
+
+[Fixed] - Footer should sit at the bottom of a fullscreen modal, regardless of the content height

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -351,7 +351,8 @@
     }
 
     // removes the scroll shadow effect if "background-attachment" isn't supported.
-    // @supports (background-attachment: local) isn't used as Safari 14 recognizes the property but it has no effect
+    // @supports (background-attachment: local) isn't used as Safari 14 recognizes the property but it has no effect.
+    // thus, "aspect-ratio" is used instead as it's only supported in Safari>=15
     @supports not (aspect-ratio: 1 / 1) {
         .c-modal-scrollContainer {
             background: none;

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -231,31 +231,6 @@
         }
     }
 
-    &[isfooterpinned] .c-modal-content,
-    & > .c-modal-scrollContainer {
-        overflow-y: auto;
-    }
-
-    & > .c-modal-scrollContainer {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-
-        // These are the shadows used to indicate scrolling above and below content
-        --bg-scroll-end: linear-gradient(rgba(255, 255, 255, 0), var(--dt-color-container-default) 70%) 0 100%;
-        --bg-scroll-bottom: radial-gradient(farthest-corner at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) 0 100%;
-
-        // Sizes of the scroll shadows
-        --bg-size-scroll-end: 100% 40px;
-        --bg-size-scroll-bottom: 100% 8px;
-
-        background: var(--bg-scroll-end), var(--bg-scroll-bottom);
-        background-repeat: no-repeat;
-        background-size: var(--bg-size-scroll-end), var(--bg-size-scroll-bottom);
-
-        background-attachment: local, scroll;
-    }
-
     & .c-modal-content {
         // Modal content Custom Props
         --modal-content-font-size: calc(var(--dt-font-size-16) * 1px);
@@ -286,6 +261,7 @@
         --spinner-animation-iteration-count: infinite;
 
         position: relative;
+        min-block-size: var(--dt-spacing-j);
 
         font-size: var(--modal-content-font-size);
         line-height: var(--modal-content-line-height);
@@ -332,6 +308,35 @@
             will-change: transform;
             opacity: 0;
         }
+    }
+
+    & > .c-modal-scrollContainer {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow-y: auto;
+
+        // These are the shadows used to indicate scrolling above and below content
+        --bg-scroll-end: linear-gradient(rgba(255, 255, 255, 0), var(--dt-color-container-default) 70%) 0 100%;
+        --bg-scroll-bottom: radial-gradient(farthest-corner at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) 0 100%;
+
+        // Sizes of the scroll shadows
+        --bg-size-scroll-end: 100% 40px;
+        --bg-size-scroll-bottom: 100% 8px;
+
+        background: var(--bg-scroll-end), var(--bg-scroll-bottom);
+        background-repeat: no-repeat;
+        background-size: var(--bg-size-scroll-end), var(--bg-size-scroll-bottom);
+
+        background-attachment: local, scroll;
+
+        .c-modal-content {
+            flex-shrink: 0;
+        }
+    }
+
+    &[isfooterpinned] .c-modal-content {
+        overflow-y: auto;
     }
 
     &[isLoading] .c-modal-content {

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -310,6 +310,10 @@
             // (and therefore hides) the shadow. This gives the effect of the shadow fading away.
             // The shadow itself does not move as you scroll.
             background-attachment: local, scroll;
+
+            @supports not (aspect-ratio: 1 / 1) {
+                background: none;
+            }
         }
 
         &:before {
@@ -342,6 +346,15 @@
 
         & .c-modal-contentInner {
             opacity: 0;
+        }
+    }
+
+    
+    // removes the scroll shadow effect if "background-attachment" isn't supported.
+    // @supports (background-attachment: local) isn't used as Safari 14 recognizes the property but it has no effect
+    @supports not (aspect-ratio: 1 / 1) {
+        .c-modal-scrollContainer {
+            background: none;
         }
     }
 }

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -310,10 +310,6 @@
             // (and therefore hides) the shadow. This gives the effect of the shadow fading away.
             // The shadow itself does not move as you scroll.
             background-attachment: local, scroll;
-
-            @supports not (aspect-ratio: 1 / 1) {
-                background: none;
-            }
         }
 
         &:before {

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -240,6 +240,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+
         // These are the shadows used to indicate scrolling above and below content
         --bg-scroll-end: linear-gradient(rgba(255, 255, 255, 0), var(--dt-color-container-default) 70%) 0 100%;
         --bg-scroll-bottom: radial-gradient(farthest-corner at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) 0 100%;

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -232,29 +232,27 @@
     }
 
     &[isfooterpinned] .c-modal-content,
-    & .c-modal-scrollContainer {
+    & > .c-modal-scrollContainer {
         overflow-y: auto;
     }
 
-    & .c-modal-scrollContainer {
+    & > .c-modal-scrollContainer {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
         // These are the shadows used to indicate scrolling above and below content
-        --bg-scroll-start: linear-gradient(var(--dt-color-container-default) 30%, rgba(255, 255, 255, 0));
         --bg-scroll-end: linear-gradient(rgba(255, 255, 255, 0), var(--dt-color-container-default) 70%) 0 100%;
-        --bg-scroll-top: radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0));
-        --bg-scroll-bottom: radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) 0 100%;
+        --bg-scroll-bottom: radial-gradient(farthest-corner at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) 0 100%;
 
         // Sizes of the scroll shadows
-        --bg-size-scroll-start: 100% 40px;
         --bg-size-scroll-end: 100% 40px;
-        --bg-size-scroll-top: 100% 16px;
-        --bg-size-scroll-bottom: 100% 16px;
+        --bg-size-scroll-bottom: 100% 8px;
 
-        background: var(--bg-scroll-start), var(--bg-scroll-end), var(--bg-scroll-top), var(--bg-scroll-bottom);
+        background: var(--bg-scroll-end), var(--bg-scroll-bottom);
         background-repeat: no-repeat;
-        background-color: var(--dt-color-container-default);
-        background-size: var(--bg-size-scroll-start), var(--bg-size-scroll-end), var(--bg-size-scroll-top), var(--bg-size-scroll-bottom);
+        background-size: var(--bg-size-scroll-end), var(--bg-size-scroll-bottom);
 
-        background-attachment: local, local, scroll, scroll;
+        background-attachment: local, scroll;
     }
 
     & .c-modal-content {
@@ -287,7 +285,6 @@
         --spinner-animation-iteration-count: infinite;
 
         position: relative;
-        min-block-size: var(--dt-spacing-j);
 
         font-size: var(--modal-content-font-size);
         line-height: var(--modal-content-line-height);
@@ -295,6 +292,7 @@
 
         padding-inline: var(--modal-content-padding-inline);
         padding-block: var(--modal-content-padding-block);
+        flex-grow: 1;
 
         &--scrollable {
             background:

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -349,7 +349,6 @@
         }
     }
 
-    
     // removes the scroll shadow effect if "background-attachment" isn't supported.
     // @supports (background-attachment: local) isn't used as Safari 14 recognizes the property but it has no effect
     @supports not (aspect-ratio: 1 / 1) {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Changed] - The shadow effect for the unpinned footer spans the whole container. ( the shadow effect for this use case isn't 100% aligned with the design, but it's the closest I managed to get to with the current implementation and was approved by @RLumleyJET)

[Removed] - Heading shadow 

[Fixed] - The footer should sit at the bottom of a fullscreen modal, regardless of the content height

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
