### PR TITLE
feat(pie-monorepo): DSW-1030 protect against duplicate registration errors in components

### DIFF
--- a/.changeset/dull-guests-worry.md
+++ b/.changeset/dull-guests-worry.md
@@ -2,4 +2,4 @@
 "@justeattakeaway/generator-pie-component": minor
 ---
 
-[Changed] - Update component index.ts template to include @tagname js doc comment above class
+[Changed] - Update component index.ts template to include @tagname js doc comment above class and new defineCustomElement function to define the component

--- a/.changeset/dull-guests-worry.md
+++ b/.changeset/dull-guests-worry.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/generator-pie-component": minor
+---
+
+[Changed] - Update component index.ts template to include @tagname js doc comment above class

--- a/.changeset/gorgeous-dingos-warn.md
+++ b/.changeset/gorgeous-dingos-warn.md
@@ -2,4 +2,4 @@
 "@justeattakeaway/pie-icons-webc": minor
 ---
 
-[Added] - jsdoc @tagname comment to generated icon typescript classes
+[Added] - jsdoc @tagname comment to generated icon typescript classes and new defineCustomElement function to define the components

--- a/.changeset/gorgeous-dingos-warn.md
+++ b/.changeset/gorgeous-dingos-warn.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-webc": minor
+---
+
+[Added] - jsdoc @tagname comment to generated icon typescript classes

--- a/.changeset/many-scissors-look.md
+++ b/.changeset/many-scissors-look.md
@@ -1,0 +1,13 @@
+---
+"@justeattakeaway/pie-card-container": minor
+"@justeattakeaway/pie-cookie-banner": minor
+"@justeattakeaway/pie-toggle-switch": minor
+"@justeattakeaway/pie-icon-button": minor
+"@justeattakeaway/pie-form-label": minor
+"@justeattakeaway/pie-divider": minor
+"@justeattakeaway/pie-button": minor
+"@justeattakeaway/pie-modal": minor
+"@justeattakeaway/pie-link": minor
+---
+
+[Added] - @tagname jsdoc comment to top of component class

--- a/.changeset/many-scissors-look.md
+++ b/.changeset/many-scissors-look.md
@@ -10,4 +10,4 @@
 "@justeattakeaway/pie-link": minor
 ---
 
-[Added] - @tagname jsdoc comment to top of component class
+[Added] - @tagname jsdoc comment to top of component class and use new defineCustomElement function to define the components

--- a/.changeset/rude-ghosts-peel.md
+++ b/.changeset/rude-ghosts-peel.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+---
+
+[Added] - defineCustomElement helper function to protect against duplicate component registration errors

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -2,7 +2,7 @@ import {
     LitElement, html, unsafeCSS, nothing,
 } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValues, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import {
     ButtonProps, sizes, types, variants, iconPlacements,
 } from './defs';
@@ -182,7 +182,8 @@ export class PieButton extends LitElement implements ButtonProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieButton);
+// customElements.define(componentSelector, PieButton);
+defineCustomElement(componentSelector, PieButton);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -15,6 +15,7 @@ export * from './defs';
 const componentSelector = 'pie-button';
 
 /**
+ * @tagname pie-button
  * @slot icon - The icon slot
  * @slot - Default slot
  */
@@ -182,7 +183,6 @@ export class PieButton extends LitElement implements ButtonProps {
     static styles = unsafeCSS(styles);
 }
 
-// customElements.define(componentSelector, PieButton);
 defineCustomElement(componentSelector, PieButton);
 
 declare global {

--- a/packages/components/pie-card-container/src/index.ts
+++ b/packages/components/pie-card-container/src/index.ts
@@ -16,6 +16,9 @@ export * from './defs';
 
 const componentSelector = 'pie-card-container';
 
+/**
+ * @tagname pie-card-container
+ */
 export class PieCardContainer extends LitElement implements CardContainerProps {
     @property()
     @validPropertyValues(componentSelector, interactionTypes, 'none')

--- a/packages/components/pie-card-container/src/index.ts
+++ b/packages/components/pie-card-container/src/index.ts
@@ -2,7 +2,7 @@ import {
     html, LitElement, unsafeCSS, nothing, TemplateResult,
 } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValues, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import styles from './card-container.scss?inline';
 import {
     variants,
@@ -153,7 +153,7 @@ export class PieCardContainer extends LitElement implements CardContainerProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieCardContainer);
+defineCustomElement(componentSelector, PieCardContainer);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-cookie-banner/src/index.ts
+++ b/packages/components/pie-cookie-banner/src/index.ts
@@ -22,6 +22,7 @@ export * from './defs';
 const componentSelector = 'pie-cookie-banner';
 
 /**
+ * @tagname pie-cookie-banner
  * @event {CustomEvent} pie-cookie-banner-accept-all - when all cookies are accepted.
  * @event {CustomEvent} pie-cookie-banner-necessary-only - when all only necessary cookies are accepted.
  * @event {CustomEvent} pie-cookie-banner-manage-prefs - when a user clicks manage preferences.
@@ -153,9 +154,9 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
                     <h3 class="c-cookieBanner-subheading">${title}</h3>
                      ${description ? html`<p class="c-cookieBanner-description">${description}</p>` : nothing}
                  </div>
-                <pie-toggle-switch 
+                <pie-toggle-switch
                     id="${id}"
-                    ?isChecked="${isChecked}" 
+                    ?isChecked="${isChecked}"
                     ?isDisabled="${isDisabled}"
                     @pie-toggle-switch-changed="${this._handleToggleStates}"/>
                 </div>
@@ -168,8 +169,8 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
      */
     private renderModalContent (): TemplateResult {
         return html`
-            <p class="c-cookieBanner-description">You can find all the information in the 
-                <pie-link href="#" size="small" target="_blank">Cookie Statement</pie-link> and 
+            <p class="c-cookieBanner-description">You can find all the information in the
+                <pie-link href="#" size="small" target="_blank">Cookie Statement</pie-link> and
                 <pie-link href="#" size="small" target="_blank">Cookie technology list</pie-link>.
             </p>
             ${repeat(

--- a/packages/components/pie-cookie-banner/src/index.ts
+++ b/packages/components/pie-cookie-banner/src/index.ts
@@ -1,6 +1,7 @@
 import {
     LitElement, html, unsafeCSS, TemplateResult, nothing,
 } from 'lit';
+import { defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import { state, queryAll } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { PieToggleSwitch } from '@justeattakeaway/pie-toggle-switch';
@@ -243,7 +244,7 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieCookieBanner);
+defineCustomElement(componentSelector, PieCookieBanner);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-divider/src/index.ts
+++ b/packages/components/pie-divider/src/index.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValues, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import styles from './divider.scss?inline';
 import { DividerProps, variants, orientations } from './defs';
 
@@ -38,7 +38,7 @@ export class PieDivider extends LitElement implements DividerProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieDivider);
+defineCustomElement(componentSelector, PieDivider);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-divider/src/index.ts
+++ b/packages/components/pie-divider/src/index.ts
@@ -9,6 +9,9 @@ export * from './defs';
 
 const componentSelector = 'pie-divider';
 
+/**
+ * @tagname pie-divider
+ */
 export class PieDivider extends LitElement implements DividerProps {
     @property({ type: String })
     @validPropertyValues(componentSelector, variants, 'default')

--- a/packages/components/pie-form-label/src/index.ts
+++ b/packages/components/pie-form-label/src/index.ts
@@ -1,6 +1,7 @@
 import {
     LitElement, html, nothing, unsafeCSS,
 } from 'lit';
+import { defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import { property } from 'lit/decorators.js';
 import styles from './form-label.scss?inline';
 import { FormLabelProps } from './defs';
@@ -46,7 +47,7 @@ export class PieFormLabel extends LitElement implements FormLabelProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieFormLabel);
+defineCustomElement(componentSelector, PieFormLabel);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-form-label/src/index.ts
+++ b/packages/components/pie-form-label/src/index.ts
@@ -10,6 +10,9 @@ export * from './defs';
 
 const componentSelector = 'pie-form-label';
 
+/**
+ * @tagname pie-form-label
+ */
 export class PieFormLabel extends LitElement implements FormLabelProps {
     @property({ type: String, reflect: true })
     public for?: string;

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -12,6 +12,9 @@ export * from './defs';
 
 const componentSelector = 'pie-icon-button';
 
+/**
+ * @tagname pie-icon-button
+ */
 export class PieIconButton extends LitElement implements IconButtonProps {
     @property()
     @validPropertyValues(componentSelector, sizes, 'medium')

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValues, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 
 import styles from './iconButton.scss?inline';
 import {
@@ -47,7 +47,7 @@ export class PieIconButton extends LitElement implements IconButtonProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieIconButton);
+defineCustomElement(componentSelector, PieIconButton);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -21,6 +21,7 @@ export * from './defs';
 const componentSelector = 'pie-link';
 
 /**
+ * @tagname pie-link
  * @slot icon - The icon slot
  * @slot - Default slot
  */

--- a/packages/components/pie-link/src/index.ts
+++ b/packages/components/pie-link/src/index.ts
@@ -2,7 +2,7 @@ import {
     html, LitElement, unsafeCSS, nothing, TemplateResult,
 } from 'lit';
 import { property } from 'lit/decorators.js';
-import { validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { validPropertyValues, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import styles from './link.scss?inline';
 import {
     LinkProps,
@@ -145,7 +145,7 @@ export class PieLink extends LitElement implements LinkProps {
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, PieLink);
+defineCustomElement(componentSelector, PieLink);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -33,6 +33,7 @@ export * from './defs';
 const componentSelector = 'pie-modal';
 
 /**
+ * @tagname pie-modal
  * @event {CustomEvent} pie-modal-open - when the modal is opened.
  * @event {CustomEvent} pie-modal-close - when the modal is closed.
  * @event {CustomEvent} pie-modal-back - when the modal back button is clicked.

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -4,7 +4,7 @@ import {
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { property, query } from 'lit/decorators.js';
 import {
-    requiredProperty, RtlMixin, validPropertyValues,
+    requiredProperty, RtlMixin, validPropertyValues, defineCustomElement,
 } from '@justeattakeaway/pie-webc-core';
 import '@justeattakeaway/pie-icons-webc/IconClose';
 import '@justeattakeaway/pie-icons-webc/IconChevronLeft';
@@ -453,7 +453,7 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     };
 }
 
-customElements.define(componentSelector, PieModal);
+defineCustomElement(componentSelector, PieModal);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-toggle-switch/src/index.ts
+++ b/packages/components/pie-toggle-switch/src/index.ts
@@ -2,7 +2,7 @@ import {
     LitElement, html, unsafeCSS, nothing, TemplateResult,
 } from 'lit';
 import { property } from 'lit/decorators.js';
-import { RtlMixin, validPropertyValues } from '@justeattakeaway/pie-webc-core';
+import { RtlMixin, validPropertyValues, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import styles from './toggle-switch.scss?inline';
 import {
     ToggleSwitchProps, ON_TOGGLE_SWITCH_CHANGED_EVENT, AriaProps, labelPlacements,
@@ -116,7 +116,7 @@ export class PieToggleSwitch extends RtlMixin(LitElement) implements ToggleSwitc
     }
 }
 
-customElements.define(componentSelector, PieToggleSwitch);
+defineCustomElement(componentSelector, PieToggleSwitch);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/components/pie-toggle-switch/src/index.ts
+++ b/packages/components/pie-toggle-switch/src/index.ts
@@ -15,6 +15,7 @@ export * from './defs';
 const componentSelector = 'pie-toggle-switch';
 
 /**
+ * @tagname pie-toggle-switch
  * @event {CustomEvent} pie-toggle-switch-changed - when the toggle switch checked state is changed.
  */
 
@@ -84,9 +85,9 @@ export class PieToggleSwitch extends RtlMixin(LitElement) implements ToggleSwitc
         const toggleSwitchId = 'toggle-switch-description';
 
         return html`
-            <div 
-                class="c-toggleSwitch-wrapper" 
-                ?isRTL=${isRTL} 
+            <div
+                class="c-toggleSwitch-wrapper"
+                ?isRTL=${isRTL}
                 ?isDisabled=${isDisabled}>
                 ${labelPlacement === 'leading' ? this.renderToggleSwitchLabel() : nothing}
                 <label

--- a/packages/components/pie-webc-core/src/functions/defineCustomElement.ts
+++ b/packages/components/pie-webc-core/src/functions/defineCustomElement.ts
@@ -1,10 +1,9 @@
 import { LitElement } from 'lit';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ClassThatExtendsLitElement = new (...args: unknown[]) => LitElement;
 
 /**
- * Defines a custom web component, ensuring that the component is only defined once in the Custom Element Registry.
+ * Defines a web component, ensuring that the component is only defined once in the Custom Element Registry.
  *
  * If the component has already been defined with the same name, a warning is logged to the console.
  *
@@ -13,8 +12,11 @@ type ClassThatExtendsLitElement = new (...args: unknown[]) => LitElement;
  *
  * @example
  *
+ * ```javascript
  * import { css, html, LitElement } from 'lit';
  *
+ * // IMPORTANT: Add the following JSDoc comment above your class setting the `@tagname` to the selector you want to use. - This is mandatory.
+ * // "@tagname my-component"
  * class MyComponent extends LitElement {
  *   static styles = css`
  *     :host {
@@ -32,6 +34,9 @@ type ClassThatExtendsLitElement = new (...args: unknown[]) => LitElement;
  * }
  *
  * defineCustomElement('my-component', MyComponent);
+ * ```
+ *
+ * NOTE: The inclusion of the `@tagname` JSDoc comment above your class is essential for correct functionality. Ensure it matches the tag you're registering.
  *
  * @returns {void}
  */

--- a/packages/components/pie-webc-core/src/functions/defineCustomElement.ts
+++ b/packages/components/pie-webc-core/src/functions/defineCustomElement.ts
@@ -1,0 +1,44 @@
+import { LitElement } from 'lit';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ClassThatExtendsLitElement = new (...args: unknown[]) => LitElement;
+
+/**
+ * Defines a custom web component, ensuring that the component is only defined once in the Custom Element Registry.
+ *
+ * If the component has already been defined with the same name, a warning is logged to the console.
+ *
+ * @param {string} elementSelector - The selector of the custom element. Must be a valid custom element selector, containing a dash. I.e. 'my-component'
+ * @param {ClassThatExtendsLitElement} elementClass - The class that defines the custom element, extending LitElement.
+ *
+ * @example
+ *
+ * import { css, html, LitElement } from 'lit';
+ *
+ * class MyComponent extends LitElement {
+ *   static styles = css`
+ *     :host {
+ *       display: block;
+ *       padding: 16px;
+ *       color: var(--my-component-text-color, black);
+ *     }
+ *   `;
+ *
+ *   render() {
+ *     return html`
+ *       <p>My custom element content goes here!</p>
+ *     `;
+ *   }
+ * }
+ *
+ * defineCustomElement('my-component', MyComponent);
+ *
+ * @returns {void}
+ */
+export function defineCustomElement (elementSelector: string, elementClass: ClassThatExtendsLitElement): void {
+    if (!customElements.get(elementSelector)) {
+        customElements.define(elementSelector, elementClass);
+    } else {
+        console.warn(`PIE Web Component: "${elementSelector}" has already been defined. Please ensure the component is only being defined once in your application.`);
+    }
+}

--- a/packages/components/pie-webc-core/src/functions/index.ts
+++ b/packages/components/pie-webc-core/src/functions/index.ts
@@ -1,0 +1,1 @@
+export * from './defineCustomElement';

--- a/packages/components/pie-webc-core/src/functions/test/defineCustomElement.spec.ts
+++ b/packages/components/pie-webc-core/src/functions/test/defineCustomElement.spec.ts
@@ -1,0 +1,84 @@
+/* eslint-disable max-classes-per-file */
+import { LitElement } from 'lit';
+import {
+    vi, expect, it,
+} from 'vitest';
+import { defineCustomElement } from '../defineCustomElement';
+
+it('should call console.warn when a component is defined twice', () => {
+    // Arrange
+    class MockComponentA extends LitElement {
+        // eslint-disable-next-line no-useless-constructor
+        constructor () {
+            super();
+        }
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn');
+    const errorSpy = vi.spyOn(console, 'error');
+
+    // Act
+    defineCustomElement('mock-component-a', MockComponentA);
+    defineCustomElement('mock-component-a', MockComponentA);
+
+    // Assert
+    const [[warning]] = warnSpy.mock.calls;
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warning).toMatch('PIE Web Component: "mock-component-a" has already been defined. Please ensure the component is only being defined once in your application.');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(customElements.get('mock-component-a')).toBe(MockComponentA);
+});
+
+it('should define the component without warnings when called once', () => {
+    // Arrange
+    class MockComponentB extends LitElement {
+        // eslint-disable-next-line no-useless-constructor
+        constructor () {
+            super();
+        }
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn');
+    const errorSpy = vi.spyOn(console, 'error');
+
+    // Act
+    defineCustomElement('mock-component-b', MockComponentB);
+
+    // Assert
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(customElements.get('mock-component-b')).toBe(MockComponentB);
+});
+
+it('should warn when defining the same component name with a different class', () => {
+    // Arrange
+    class MockComponentC extends LitElement {
+        // eslint-disable-next-line no-useless-constructor
+        constructor () {
+            super();
+        }
+    }
+
+    class MockComponentD extends LitElement {
+        // eslint-disable-next-line no-useless-constructor
+        constructor () {
+            super();
+        }
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn');
+    const errorSpy = vi.spyOn(console, 'error');
+
+    // Act
+    defineCustomElement('mock-component-c', MockComponentC);
+    defineCustomElement('mock-component-c', MockComponentD);
+
+    // Assert
+    const [[warning]] = warnSpy.mock.calls;
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warning).toMatch('PIE Web Component: "mock-component-c" has already been defined. Please ensure the component is only being defined once in your application.');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(customElements.get('mock-component-c')).toBe(MockComponentC);
+});

--- a/packages/components/pie-webc-core/src/index.ts
+++ b/packages/components/pie-webc-core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './mixins';
 export * from './decorators';
+export * from './functions';

--- a/packages/tools/generator-pie-component/src/app/templates/src/index.ts
+++ b/packages/tools/generator-pie-component/src/app/templates/src/index.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit';
-<% if (needsRTL) { %>import { RtlMixin } from '@justeattakeaway/pie-webc-core';<% } %>
+<% if (needsRTL) { %>import { RtlMixin, defineCustomElement } from '@justeattakeaway/pie-webc-core';<% } %>
+<% if (!needsRTL) { %>import { defineCustomElement } from '@justeattakeaway/pie-webc-core';<% } %>
 import styles from './<%= fileName %>.scss?inline';
 import { <%= componentName %>Props } from './defs';
 
@@ -8,6 +9,9 @@ export * from './defs';
 
 const componentSelector = 'pie-<%= fileName %>';
 
+/**
+ * @tagname pie-<%= fileName %>
+ */
 <% if (needsRTL) { %>export class Pie<%= componentName %> extends RtlMixin(LitElement) implements <%= componentName %>Props {<% }
 else { %>export class Pie<%= componentName %> extends LitElement implements <%= componentName %>Props {<% } %>
     render () {
@@ -18,7 +22,7 @@ else { %>export class Pie<%= componentName %> extends LitElement implements <%= 
     static styles = unsafeCSS(styles);
 }
 
-customElements.define(componentSelector, Pie<%= componentName %>);
+defineCustomElement(componentSelector, Pie<%= componentName %>);
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/tools/pie-icons-webc/build.js
+++ b/packages/tools/pie-icons-webc/build.js
@@ -21,6 +21,7 @@ const componentTemplate = (name, svg) => {
     return `import {
     html, LitElement, TemplateResult, css, PropertyValues
 } from 'lit';
+import { defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import { property, query } from 'lit/decorators.js';
 import { getSvgProps, ${sizeType} } from '@justeattakeaway/pie-icons-configs';
 
@@ -31,6 +32,9 @@ interface IconProps {
 
 const componentSelector = '${kebabCase(name)}';
 
+/**
+ * @tagname ${kebabCase(name)}
+ */
 export class ${name} extends LitElement implements IconProps {
     // The following styles make sure that the icon will be sized correctly
     static styles = css\`
@@ -76,9 +80,7 @@ export class ${name} extends LitElement implements IconProps {
     }
 }
 
-if (customElements.get(componentSelector) === undefined) {
-    customElements.define(componentSelector, ${name});
-}
+defineCustomElement(componentSelector, ${name});
 
 declare global {
     interface HTMLElementTagNameMap {


### PR DESCRIPTION
---
"@justeattakeaway/pie-webc-core": minor
---

[Added] - defineCustomElement helper function to protect against duplicate component registration errors

---
"@justeattakeaway/pie-icons-webc": minor
---

[Added] - jsdoc @tagname comment to generated icon typescript classes

---
"@justeattakeaway/pie-card-container": minor
"@justeattakeaway/pie-cookie-banner": minor
"@justeattakeaway/pie-toggle-switch": minor
"@justeattakeaway/pie-icon-button": minor
"@justeattakeaway/pie-form-label": minor
"@justeattakeaway/pie-divider": minor
"@justeattakeaway/pie-button": minor
"@justeattakeaway/pie-modal": minor
"@justeattakeaway/pie-link": minor
---

[Added] - @tagname jsdoc comment to top of component class