### PR TITLE
chore(pie-icons-webc): DSW-000 move test package deps to devdependencies

### DIFF
--- a/.changeset/rich-sloths-judge.md
+++ b/.changeset/rich-sloths-judge.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-webc": patch
+---
+
+[Changed] - Moved test packages from dependencies to dev dependencies to prevent consumers from needing to install them

--- a/packages/tools/pie-icons-webc/package.json
+++ b/packages/tools/pie-icons-webc/package.json
@@ -59,7 +59,9 @@
     "@justeattakeaway/pie-icons": "4.9.2",
     "@justeattakeaway/pie-icons-configs": "4.5.0",
     "@justeattakeaway/pie-webc-core": "0.11.0",
+    "@open-wc/testing": "3.2.0",
     "@rollup/plugin-typescript": "11.1.5",
+    "@web/test-runner": "0.16.1",
     "just-kebab-case": "4.2.0",
     "just-pascal-case": "3.2.0",
     "lit": "2.7.5",
@@ -69,10 +71,6 @@
   },
   "volta": {
     "extends": "../../../package.json"
-  },
-  "dependencies": {
-    "@open-wc/testing": "3.2.0",
-    "@web/test-runner": "0.16.1"
   },
   "peerDependencies": {
     "lit": "2.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,7 +5119,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/generator-pie-component@0.11.0, @justeattakeaway/generator-pie-component@workspace:packages/tools/generator-pie-component":
+"@justeattakeaway/generator-pie-component@0.12.0, @justeattakeaway/generator-pie-component@workspace:packages/tools/generator-pie-component":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/generator-pie-component@workspace:packages/tools/generator-pie-component"
   dependencies:
@@ -5137,24 +5137,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.32.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.33.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@justeat/pie-design-tokens": 5.8.2
     "@justeattakeaway/pie-components-config": 0.4.0
     "@justeattakeaway/pie-css": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
     element-internals-polyfill: 1.3.8
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card-container@0.10.0, @justeattakeaway/pie-card-container@workspace:packages/components/pie-card-container":
+"@justeattakeaway/pie-card-container@0.11.0, @justeattakeaway/pie-card-container@workspace:packages/components/pie-card-container":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card-container@workspace:packages/components/pie-card-container"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
   languageName: unknown
   linkType: soft
 
@@ -5164,18 +5164,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.6.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.7.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@justeat/pie-design-tokens": 5.8.2
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-icon-button": 0.17.0
-    "@justeattakeaway/pie-link": 0.9.0
-    "@justeattakeaway/pie-modal": 0.27.0
-    "@justeattakeaway/pie-toggle-switch": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-icon-button": 0.18.0
+    "@justeattakeaway/pie-link": 0.10.0
+    "@justeattakeaway/pie-modal": 0.28.0
+    "@justeattakeaway/pie-toggle-switch": 0.14.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
   languageName: unknown
   linkType: soft
 
@@ -5190,30 +5190,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-divider@0.7.0, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
+"@justeattakeaway/pie-divider@0.8.0, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.4.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.5.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.17.0, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.18.0, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 0.10.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-icons-webc": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
   peerDependencies:
     "@justeat/pie-design-tokens": ^5.8.2
   languageName: unknown
@@ -5268,7 +5268,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-webc@0.10.0, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
+"@justeattakeaway/pie-icons-webc@0.11.0, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
@@ -5276,7 +5276,7 @@ __metadata:
     "@babel/node": 7.20.7
     "@justeattakeaway/pie-icons": 4.9.2
     "@justeattakeaway/pie-icons-configs": 4.5.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
     "@open-wc/testing": 3.2.0
     "@rollup/plugin-typescript": 11.1.5
     "@web/test-runner": 0.16.1
@@ -5306,25 +5306,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.9.0, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.10.0, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.27.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.28.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@justeat/pie-design-tokens": 5.8.2
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-icon-button": 0.17.0
-    "@justeattakeaway/pie-icons-webc": 0.10.0
-    "@justeattakeaway/pie-webc-core": 0.10.0
+    "@justeattakeaway/pie-icon-button": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.11.0
     "@types/body-scroll-lock": 3.1.0
     dialog-polyfill: 0.5.6
   peerDependencies:
@@ -5332,16 +5332,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-toggle-switch@0.13.0, @justeattakeaway/pie-toggle-switch@workspace:packages/components/pie-toggle-switch":
+"@justeattakeaway/pie-toggle-switch@0.14.0, @justeattakeaway/pie-toggle-switch@workspace:packages/components/pie-toggle-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-toggle-switch@workspace:packages/components/pie-toggle-switch"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.4.0
-    "@justeattakeaway/pie-icons-webc": 0.10.0
+    "@justeattakeaway/pie-icons-webc": 0.11.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-core@0.10.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
+"@justeattakeaway/pie-webc-core@0.11.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   languageName: unknown
@@ -27542,7 +27542,7 @@ __metadata:
     "@justeat/fozzie": 11.0.1
     "@justeat/pie-design-tokens": 5.8.2
     "@justeattakeaway/browserslist-config-pie": 0.2.0
-    "@justeattakeaway/generator-pie-component": 0.11.0
+    "@justeattakeaway/generator-pie-component": 0.12.0
     "@justeattakeaway/pie-icons": 4.9.2
     "@justeattakeaway/pie-webc-testing": 0.6.0
     "@justeattakeaway/stylelint-config-pie": 0.5.0
@@ -27598,17 +27598,17 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 5.8.2
-    "@justeattakeaway/pie-button": 0.32.0
-    "@justeattakeaway/pie-card-container": 0.10.0
-    "@justeattakeaway/pie-cookie-banner": 0.6.0
+    "@justeattakeaway/pie-button": 0.33.0
+    "@justeattakeaway/pie-card-container": 0.11.0
+    "@justeattakeaway/pie-cookie-banner": 0.7.0
     "@justeattakeaway/pie-css": 0.6.0
-    "@justeattakeaway/pie-divider": 0.7.0
-    "@justeattakeaway/pie-form-label": 0.4.0
-    "@justeattakeaway/pie-icon-button": 0.17.0
-    "@justeattakeaway/pie-icons-webc": 0.10.0
-    "@justeattakeaway/pie-link": 0.9.0
-    "@justeattakeaway/pie-modal": 0.27.0
-    "@justeattakeaway/pie-toggle-switch": 0.13.0
+    "@justeattakeaway/pie-divider": 0.8.0
+    "@justeattakeaway/pie-form-label": 0.5.0
+    "@justeattakeaway/pie-icon-button": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.11.0
+    "@justeattakeaway/pie-link": 0.10.0
+    "@justeattakeaway/pie-modal": 0.28.0
+    "@justeattakeaway/pie-toggle-switch": 0.14.0
     "@storybook/addon-a11y": 7.4.0
     "@storybook/addon-designs": 7.0.5
     "@storybook/addon-docs": 7.4.0
@@ -36292,7 +36292,7 @@ __metadata:
     "@angular/platform-browser": 15.2.0
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     "@types/jasmine": 4.3.0
     jasmine-core: 4.5.0
@@ -36316,7 +36316,7 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.21.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     eslint: 8.37.0
     eslint-config-next: 13.2.4
@@ -36331,7 +36331,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     "@lit-labs/nextjs": 0.1.1
     "@lit-labs/react": 1.1.1
@@ -36350,7 +36350,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt2@workspace:apps/examples/wc-nuxt2"
   dependencies:
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -36364,7 +36364,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     "@types/node": 18
     nuxt: 3.4.3
@@ -36376,7 +36376,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     react: 17.0.2
     react-dom: 17.0.2
@@ -36388,7 +36388,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     react: 18.2.0
     react-dom: 18.2.0
@@ -36401,11 +36401,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.8.2
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
-    "@justeattakeaway/pie-icon-button": 0.17.0
-    "@justeattakeaway/pie-icons-webc": 0.10.0
-    "@justeattakeaway/pie-modal": 0.27.0
+    "@justeattakeaway/pie-icon-button": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.11.0
+    "@justeattakeaway/pie-modal": 0.28.0
     body-scroll-lock: 3.1.5
     vite: 4.3.9
   languageName: unknown
@@ -36415,7 +36415,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.32.0
+    "@justeattakeaway/pie-button": 0.33.0
     "@justeattakeaway/pie-css": 0.6.0
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0


### PR DESCRIPTION
Move two test package dependencies from dependencies to dev dependencies - otherwise this causes consumers to need to install these two packages when using the icons