### PR TITLE
cosmetic(pie-modal): DSW-000 use narrow/wide font sizes for the modal heading

### DIFF
--- a/.changeset/strong-pens-wave.md
+++ b/.changeset/strong-pens-wave.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Changed] - Use different font sizes for the modal heading at narrow and wide breakpoints

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -40,7 +40,7 @@
 
     // We need to override the icon sizes at different screen sizes regardless of size prop passed in
     pie-icon-button {
-        @media (max-width: $breakpoint-wide) {
+        @media (max-width: calc($breakpoint-wide - 1px)) {
             --btn-dimension: 40px;
         }
     }
@@ -172,8 +172,8 @@
     }
 
     & .c-modal-heading {
-        --modal-header-font-size: calc(var(--dt-font-heading-m-size--wide) * 1px);
-        --modal-header-font-line-height: calc(var(--dt-font-heading-m-line-height--wide) * 1px);
+        --modal-header-font-size: calc(var(--dt-font-heading-m-size--narrow) * 1px);
+        --modal-header-font-line-height: calc(var(--dt-font-heading-m-line-height--narrow) * 1px);
         --modal-header-font-weight: var(--dt-font-heading-m-weight);
 
         font-size: var(--modal-header-font-size);
@@ -186,6 +186,8 @@
         margin-block: 14px; // This is deliberately not a custom property
 
         @media (min-width: $breakpoint-wide) {
+            --modal-header-font-size: calc(var(--dt-font-heading-m-size--wide) * 1px);
+            --modal-header-font-line-height: calc(var(--dt-font-heading-m-line-height--wide) * 1px);
             margin-inline: var(--dt-spacing-e);
             margin-block: 20px; // This is deliberately not a custom property
         }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Modal heading should be 20px for narrow and 24px for wide. Also updated line heights.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If it is a component change, I have reviewed the Storybook preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
