### PR TITLE
ci(pie-monorepo): DSW-000 use commitMessageAction to provide default ticket number

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,11 @@
     ":dependencyDashboard"
   ],
   "prConcurrentLimit": 3,
+  "commitMessageAction": "DSW-000 update",
   "major": false,
   "packageRules": [
     {
-      "commitMessagePrefix": "chore(pie-monorepo): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-monorepo)",
       "description": "Group babel devDependencies from package.json within pie-monorepo",
       "matchFiles": ["./package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -20,7 +21,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-monorepo): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-monorepo)",
       "description": "Group JET devDependencies / dependencies from package.json within pie-monorepo",
       "matchFiles": ["./package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -31,7 +32,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-monorepo): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-monorepo)",
       "description": "Group playwright / other testing related devDependencies from package.json within pie-monorepo",
       "matchFiles": ["./package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -42,7 +43,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-monorepo): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-monorepo)",
       "description": "Group jest devDependencies from package.json within pie-monorepo",
       "matchFiles": ["./package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -53,7 +54,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-monorepo): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-monorepo)",
       "description": "Group postcss devDependencies from package.json within pie-monorepo",
       "matchFiles": ["./package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -64,7 +65,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-monorepo): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-monorepo)",
       "description": "Group stylelint devDependencies from package.json within pie-docs",
       "matchFiles": ["./package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -75,7 +76,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-docs): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-docs)",
       "description": "Group eleventy devDependencies from package.json within pie-docs",
       "matchFiles": ["apps/pie-docs/package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -86,7 +87,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-docs): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-docs)",
       "description": "Group devdependencies / dependencies from package.json within pie-docs",
       "matchFiles": ["apps/pie-docs/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -97,7 +98,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-storybook): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-storybook)",
       "description": "Group storybook devDependencies / dependencies from package.json within pie-storybook",
       "matchFiles": ["apps/pie-storybook/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -108,7 +109,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(pie-storybook): DSW-000 ",
+      "commitMessagePrefix": "chore(pie-storybook)",
       "description": "Group react devDependencies from package.json within pie-storybook",
       "matchFiles": ["apps/pie-storybook/package.json"],
       "matchDepTypes": ["devDependencies"],
@@ -119,7 +120,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-angular12): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-angular12)",
       "description": "Group dependencies from package.json within wc-angular12",
       "matchFiles": ["apps/examples/wc-angular12/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -129,7 +130,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-next10): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-next10)",
       "description": "Group dependencies from package.json within wc-next10",
       "matchFiles": ["apps/examples/wc-next10/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -139,7 +140,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-next13): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-next13)",
       "description": "Group dependencies from package.json within wc-next13",
       "matchFiles": ["apps/examples/wc-next13/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -149,7 +150,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-nuxt2): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-nuxt2)",
       "description": "Group dependencies from package.json within wc-nuxt2",
       "matchFiles": ["apps/examples/wc-nuxt2/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -159,7 +160,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-nuxt3): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-nuxt3)",
       "description": "Group dependencies from package.json within wc-nuxt3",
       "matchFiles": ["apps/examples/wc-nuxt3/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -169,7 +170,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-react17): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-react17)",
       "description": "Group dependencies from package.json within wc-react17",
       "matchFiles": ["apps/examples/wc-react17/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -179,7 +180,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-react18): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-react18)",
       "description": "Group dependencies from package.json within wc-react18",
       "matchFiles": ["apps/examples/wc-react18/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -189,7 +190,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-vanilla): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-vanilla)",
       "description": "Group dependencies from package.json within wc-vanilla",
       "matchFiles": ["apps/examples/wc-vanilla/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],
@@ -199,7 +200,7 @@
       "enabled": true
     },
     {
-      "commitMessagePrefix": "chore(wc-vue3): DSW-000 ",
+      "commitMessagePrefix": "chore(wc-vue3)",
       "description": "Group dependencies from package.json within wc-vue3",
       "matchFiles": ["apps/examples/wc-vue3/package.json"],
       "matchDepTypes": ["devDependencies", "dependencies"],


### PR DESCRIPTION
Currently renovate does not correctly add a ticket number to its PRs which means that we have to manually add it once it has been approved prior to merging. This can be a little tedious especially if the PR rebases and you need to change it again.

## Describe your changes (can list changeset entries if preferable)
- Trying to use [`commitMessageAction`](https://docs.renovatebot.com/configuration-options/#commitmessageaction) to shoehorn the ticket number into the commit message.
- All of the PRs that I have seen have used "update" as the action so hard-coding that as part of the new action _shouldn't_ be an issue.
- I'm removing DSW-000 from the other templates because they never seem to work.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
