### PR TITLE
fix(pie-form-label): DSW-1274 address form label design feedback

### DIFF
--- a/.changeset/twenty-cats-burn.md
+++ b/.changeset/twenty-cats-burn.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-form-label": minor
+---
+[Fixed] - If the optional wraps onto a second line and there is no label to the left, there should be no additional padding.
+
+[Fixed] - When in RTL, the optional tag should be positioned to the left of the label.

--- a/packages/components/pie-form-label/src/form-label.scss
+++ b/packages/components/pie-form-label/src/form-label.scss
@@ -22,8 +22,8 @@
     font-weight: var(--dt-font-weight-regular);
 }
 
-.c-formLabel-optional {
-    margin-inline-start: var(--dt-spacing-b);
+.c-formLabel-leading {
+    margin-inline-end: var(--dt-spacing-b);
 }
 
 .c-formLabel-trailing {

--- a/packages/components/pie-form-label/src/form-label.scss
+++ b/packages/components/pie-form-label/src/form-label.scss
@@ -8,6 +8,7 @@
 
     display: flex;
     justify-content: space-between;
+    align-items: flex-end;
     gap: var(--dt-spacing-d);
     color: var(--form-label-color);
     font-size: var(--form-label-font-size);

--- a/packages/components/pie-form-label/src/index.ts
+++ b/packages/components/pie-form-label/src/index.ts
@@ -1,7 +1,7 @@
 import {
-    LitElement, html, nothing, unsafeCSS,
+    LitElement, TemplateResult, html, nothing, unsafeCSS,
 } from 'lit';
-import { defineCustomElement } from '@justeattakeaway/pie-webc-core';
+import { RtlMixin, defineCustomElement } from '@justeattakeaway/pie-webc-core';
 import { property } from 'lit/decorators.js';
 import styles from './form-label.scss?inline';
 import { FormLabelProps } from './defs';
@@ -14,7 +14,7 @@ const componentSelector = 'pie-form-label';
 /**
  * @tagname pie-form-label
  */
-export class PieFormLabel extends LitElement implements FormLabelProps {
+export class PieFormLabel extends RtlMixin(LitElement) implements FormLabelProps {
     @property({ type: String, reflect: true })
     public for?: string;
 
@@ -24,10 +24,16 @@ export class PieFormLabel extends LitElement implements FormLabelProps {
     @property({ type: String })
     public trailing?: string;
 
+    private _renderOptionalLabel (): TemplateResult | typeof nothing {
+        const { optional } = this;
+
+        return optional ? html`<span class="c-formLabel-optional">${optional}</span>` : nothing;
+    }
+
     render () {
         const {
-            optional,
             trailing,
+            isRTL,
         } = this;
 
         return html`
@@ -36,8 +42,9 @@ export class PieFormLabel extends LitElement implements FormLabelProps {
                 class="c-formLabel"
                 for=${this.for}>
                     <div>
-                        <slot></slot>
-                        ${optional ? html`<span class="c-formLabel-optional">${optional}</span>` : nothing}
+                        ${isRTL ? this._renderOptionalLabel() : nothing}
+                        <span class="c-formLabel-leading"><slot></slot></span>
+                        ${!isRTL ? this._renderOptionalLabel() : nothing}
                     </div>
                     ${trailing ? html`<span class="c-formLabel-trailing">${trailing}</span>` : nothing}
             </label>`;


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] - If the optional wraps onto a second line and there is no label to the left, there should be no additional padding.

[Fixed] - When in RTL, the optional tag should be positioned to the left of the label.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
