### PR TITLE
chore(pie-storybook): DSW-1397 remove extraneous storybook dependencies

### DIFF
--- a/.changeset/five-buses-sing.md
+++ b/.changeset/five-buses-sing.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-cookie-banner": patch
+"pie-storybook": patch
+---
+
+[Changed] - `hasPrimaryActionsOnly` prop description to be less tied to the copy
+[Removed] - explicit dependencies on the storybook actions and docs addons because these come through the essentials package

--- a/apps/pie-storybook/package.json
+++ b/apps/pie-storybook/package.json
@@ -29,9 +29,7 @@
   },
   "devDependencies": {
     "@storybook/addon-a11y": "7.5.1",
-    "@storybook/addon-actions": "7.5.1",
     "@storybook/addon-designs": "7.0.5",
-    "@storybook/addon-docs": "7.5.1",
     "@storybook/addon-essentials": "7.5.1",
     "@storybook/addon-links": "7.5.1",
     "@storybook/addons": "7.5.1",

--- a/apps/pie-storybook/stories/pie-cookie-banner.stories.ts
+++ b/apps/pie-storybook/stories/pie-cookie-banner.stories.ts
@@ -32,7 +32,7 @@ const cookieBannerStoryMeta: CookieBannerStoryMeta = {
     component: 'pie-cookie-banner',
     argTypes: {
         hasPrimaryActionsOnly: {
-            description: 'When true, sets the "Necessary only" button variant to "primary".',
+            description: 'When true, sets the variant to "primary" for the button which accepts necessary cookies only.',
             control: 'boolean',
         },
     },

--- a/packages/components/pie-cookie-banner/README.md
+++ b/packages/components/pie-cookie-banner/README.md
@@ -86,7 +86,7 @@ yarn dev --filter=pie-storybook
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| hasPrimaryActionsOnly | `Boolean` | `false` | When true, sets the "Necessary only" button variant to "primary". |
+| hasPrimaryActionsOnly | `Boolean` | `false` | When true, sets the variant to "primary" for the button which accepts necessary cookies only. |
 
 In your markup or JSX, you can then use these to set the properties for the `pie-cookie-banner` component:
 

--- a/packages/components/pie-cookie-banner/src/defs.ts
+++ b/packages/components/pie-cookie-banner/src/defs.ts
@@ -1,6 +1,6 @@
 export interface CookieBannerProps {
     /**
-     * When true, sets the "Necessary only" button variant to "primary".
+     * When true, sets the variant to "primary" for the button which accepts necessary cookies only.
      */
     hasPrimaryActionsOnly: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5164,7 +5164,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.7.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.8.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
@@ -5173,7 +5173,7 @@ __metadata:
     "@justeattakeaway/pie-components-config": 0.4.0
     "@justeattakeaway/pie-icon-button": 0.18.0
     "@justeattakeaway/pie-link": 0.10.0
-    "@justeattakeaway/pie-modal": 0.28.0
+    "@justeattakeaway/pie-modal": 0.29.0
     "@justeattakeaway/pie-toggle-switch": 0.14.0
     "@justeattakeaway/pie-webc-core": 0.11.0
   languageName: unknown
@@ -5199,7 +5199,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.5.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.6.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
@@ -5315,7 +5315,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.28.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.29.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
@@ -27586,19 +27586,17 @@ __metadata:
     "@justeat/pie-design-tokens": 5.8.2
     "@justeattakeaway/pie-button": 0.34.0
     "@justeattakeaway/pie-card-container": 0.11.0
-    "@justeattakeaway/pie-cookie-banner": 0.7.0
+    "@justeattakeaway/pie-cookie-banner": 0.8.0
     "@justeattakeaway/pie-css": 0.6.0
     "@justeattakeaway/pie-divider": 0.8.0
-    "@justeattakeaway/pie-form-label": 0.5.0
+    "@justeattakeaway/pie-form-label": 0.6.0
     "@justeattakeaway/pie-icon-button": 0.18.0
     "@justeattakeaway/pie-icons-webc": 0.11.1
     "@justeattakeaway/pie-link": 0.10.0
-    "@justeattakeaway/pie-modal": 0.28.0
+    "@justeattakeaway/pie-modal": 0.29.0
     "@justeattakeaway/pie-toggle-switch": 0.14.0
     "@storybook/addon-a11y": 7.5.1
-    "@storybook/addon-actions": 7.5.1
     "@storybook/addon-designs": 7.0.5
-    "@storybook/addon-docs": 7.5.1
     "@storybook/addon-essentials": 7.5.1
     "@storybook/addon-links": 7.5.1
     "@storybook/addons": 7.5.1
@@ -36372,7 +36370,7 @@ __metadata:
     "@justeattakeaway/pie-css": 0.6.0
     "@justeattakeaway/pie-icon-button": 0.18.0
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-modal": 0.28.0
+    "@justeattakeaway/pie-modal": 0.29.0
     body-scroll-lock: 3.1.5
     vite: 4.3.9
   languageName: unknown


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- [Changed] - `hasPrimaryActionsOnly` prop description to be less tied to the copy
- [Removed] - explicit dependencies on the storybook actions and docs addons because these come through the essentials package

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
