### PR TITLE
feat(pie-docs): DSW-000 add a neutral variant to the notification shortcut

### DIFF
--- a/.changeset/pink-guests-teach.md
+++ b/.changeset/pink-guests-teach.md
@@ -1,0 +1,6 @@
+---
+"pie-docs": minor
+---
+
+[Added] - Extended the notification shortcut to support a neutral variant
+[Changed] - Refactored some margin values to use css logical properties 

--- a/apps/pie-docs/src/_11ty/shortcodes/notification.js
+++ b/apps/pie-docs/src/_11ty/shortcodes/notification.js
@@ -42,6 +42,7 @@ const notificationSettings = {
  * @param {string} config.title - The title of the Notification
  * @param {string} config.message - The message within the Notification. This can be raw text or markdown (which will be transformed into HTML).
  * @param {string} config.context - a contextual string to use to in-built class names. Defaults to "contentPage".
+ * @param {string} config.iconName - The name of the icon to use for the Notification".
  * @returns {string}
  */
 // eslint-disable-next-line func-names

--- a/apps/pie-docs/src/_11ty/shortcodes/notification.js
+++ b/apps/pie-docs/src/_11ty/shortcodes/notification.js
@@ -9,6 +9,10 @@ const getNotificationColour = (tokenName) => {
 };
 
 const notificationSettings = {
+    neutral: {
+        iconFill: 'content-default',
+        bgColour: 'container-subtle',
+    },
     error: {
         iconFill: 'support-error',
         bgColour: 'support-error-02',
@@ -46,7 +50,7 @@ module.exports = function (config) {
     const contextClass = `c-${context}-notification`;
     const iconFill = getNotificationColour(notificationSettings[config.type].iconFill);
     const svg = pieIconsSvg({
-        name: notificationSettings[config.type].iconName,
+        name: config.iconName ?? notificationSettings[config.type].iconName,
         attrs: {
             height: 24,
             width: 24,

--- a/apps/pie-docs/src/assets/styles/base/_layout.scss
+++ b/apps/pie-docs/src/assets/styles/base/_layout.scss
@@ -128,11 +128,11 @@
         > h3 + h4,
         > p + .c-contentPage-img,
         > .c-contentPage-img + p {
-            margin-top: f.spacing(e);
+            margin-block-start: f.spacing(e);
         }
 
         > p + h2 {
-            margin-top: f.spacing(h);
+            margin-block-start: f.spacing(h);
         }
 
         > ul + h3,
@@ -144,21 +144,21 @@
         > .c-contentPage-img + h4,
         > .c-contentPage-notification + h3,
         & .c-contentPage-notification {
-            margin-top: f.spacing(f);
+            margin-block-start: f.spacing(f);
         }
 
         .c-contentPage-notification + .c-contentPage-notification {
-            margin-top: f.spacing(b);
+            margin-block-start: f.spacing(b);
         }
     }
 
     hr {
-        margin-top: f.spacing(h);
-        margin-bottom: f.spacing(h);
+        margin-block-start: f.spacing(h);
+        margin-block-end: f.spacing(h);
 
         @include f.media('>=wide') {
-            margin-top: f.spacing(i);
-            margin-bottom: f.spacing(i);
+            margin-block-start: f.spacing(i);
+            margin-block-bottom: f.spacing(i);
         }
     }
 }

--- a/apps/pie-docs/src/assets/styles/base/_layout.scss
+++ b/apps/pie-docs/src/assets/styles/base/_layout.scss
@@ -158,7 +158,7 @@
 
         @include f.media('>=wide') {
             margin-block-start: f.spacing(i);
-            margin-block-bottom: f.spacing(i);
+            margin-block-end: f.spacing(i);
         }
     }
 }

--- a/apps/pie-docs/src/assets/styles/base/_layout.scss
+++ b/apps/pie-docs/src/assets/styles/base/_layout.scss
@@ -146,6 +146,10 @@
         & .c-contentPage-notification {
             margin-top: f.spacing(f);
         }
+
+        .c-contentPage-notification + .c-contentPage-notification {
+            margin-top: f.spacing(b);
+        }
     }
 
     hr {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

As part of the components template designs, we need to support the following variant for the notification shortcut, thus, this PR extends the notification shortcut to support that. We also need the shortcut to support a custom icon passed to it so the interface is extended to do so as well

![image](https://github.com/justeattakeaway/pie/assets/28605803/c5e890b8-2a2c-4194-b227-6b510fbaad78)

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
