### PR TITLE
feat(pie-docs): DSW-1325 support a variant prop to contentImage

### DIFF
--- a/.changeset/polite-taxis-check.md
+++ b/.changeset/polite-taxis-check.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Added] - varaint prop to contentImage

--- a/apps/pie-docs/src/_11ty/shortcodes/contentPageImage.js
+++ b/apps/pie-docs/src/_11ty/shortcodes/contentPageImage.js
@@ -21,6 +21,7 @@ const createCaption = (config) => (config.caption
  * @param {string} config.mobileSrc - the image src path for an optimised mobile image if required
  * @param {string} config.context - a contextual string to use to in-built class names. Defaults to "contentPage".
  * @param {string} config.caption - A string to use as the image caption. This can be raw text or markdown (which will be transformed into HTML).
+ * @param {string} config.variant - Sets the variant of the shortcut. Valid values are default, secondary and inverse. Defaults to "default"
  * @returns {string} a <figure> element containing the image(s) provided with the config settings applied.
  */
 // eslint-disable-next-line func-names
@@ -30,6 +31,7 @@ module.exports = function (config) {
     const isImageFullContainerWidth = !config.width;
     const imageStyles = !isImageFullContainerWidth ? `style="--img-width: ${config.width};"` : ''; // If image isn't full width, set it to required width
     const imageAlt = `alt="${config.alt || ''}"`;
+    const variant = config.variant || 'default';
     const figureClasses = [
         contextClass,
         'c-contentImage',
@@ -46,7 +48,7 @@ module.exports = function (config) {
     const mobileImageMaxWidth = '600px';
 
     return `<figure class="${figureClasses.join(' ')}">
-        <div class="c-contentImage-backdrop">
+        <div class="c-contentImage-backdrop c-contentImage-${variant}">
           <picture>
             ${config.mobileSrc ? `<source ${imageStyles} media="(max-width: ${mobileImageMaxWidth})" srcset="${config.mobileSrc}">` : ''}
             <img src="${config.src}" ${imageStyles} ${imageAlt}>

--- a/apps/pie-docs/src/__tests__/_11ty/shortcodes/__snapshots__/contentPageImage.test.js.snap
+++ b/apps/pie-docs/src/__tests__/_11ty/shortcodes/__snapshots__/contentPageImage.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`contentPageImage.js creates the expected markup for the given config settings 1`] = `
 "<figure class=\\"c-someContainer-img c-contentImage c-contentImage--hasBackdrop\\">
-        <div class=\\"c-contentImage-backdrop\\">
+        <div class=\\"c-contentImage-backdrop c-contentImage-default\\">
           <picture>
             <source style=\\"--img-width: 200px;\\" media=\\"(max-width: 600px)\\" srcset=\\"some/path/to/mobile/image\\">
             <img src=\\"some/path/to/image\\" style=\\"--img-width: 200px;\\" alt=\\"foo bar\\">
@@ -14,7 +14,7 @@ exports[`contentPageImage.js creates the expected markup for the given config se
 
 exports[`contentPageImage.js creates the expected markup for the given config settings 2`] = `
 "<figure class=\\"c-contentPage-img c-contentImage c-contentImage--fullWidth\\">
-        <div class=\\"c-contentImage-backdrop\\">
+        <div class=\\"c-contentImage-backdrop c-contentImage-default\\">
           <picture>
             
             <img src=\\"some/path/to/image\\"  alt=\\"\\">

--- a/apps/pie-docs/src/__tests__/_11ty/shortcodes/__snapshots__/shortcode-utilities.test.js.snap
+++ b/apps/pie-docs/src/__tests__/_11ty/shortcodes/__snapshots__/shortcode-utilities.test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`deindentHTML flattens an indented HTML string to a single line 1`] = `"<div>          <p>Foo Bar Baz</p>        </div>"`;
 
-exports[`deindentHTML flattens the result of a real shortcode 1`] = `"<figure class=\\"c-bar-img c-contentImage c-contentImage--fullWidth\\">        <div class=\\"c-contentImage-backdrop\\">          <picture>                        <img src=\\"../some/path\\"  alt=\\"foo\\">          </picture>        </div>              </figure>"`;
+exports[`deindentHTML flattens the result of a real shortcode 1`] = `"<figure class=\\"c-bar-img c-contentImage c-contentImage--fullWidth\\">        <div class=\\"c-contentImage-backdrop c-contentImage-default\\">          <picture>                        <img src=\\"../some/path\\"  alt=\\"foo\\">          </picture>        </div>              </figure>"`;

--- a/apps/pie-docs/src/assets/styles/components/_contentImage.scss
+++ b/apps/pie-docs/src/assets/styles/components/_contentImage.scss
@@ -43,8 +43,21 @@ $contentImage-height-l--mobile:           400px;
     justify-content: center;
     height: 100%;
     padding: f.spacing(h) f.spacing(d);
-    background-color: f.$color-background-subtle;
+    background-color: f.$color-container-subtle;
     border-radius: f.$radius-rounded-d;
+
+    &.c-contentImage-default {
+        // Same as default styles
+    }
+
+    &.c-contentImage-secondary {
+        background-color: f.$color-container-default;
+        border: 1px solid f.$color-border-strong;
+    }
+
+    &.c-contentImage-inverse {
+        background-color: f.$color-container-inverse;
+    }
 }
 
 .c-contentImage {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

as part of the components templet work, we need to extend the `contentImage` shortcut to support different variants as shown in the screenshot 

<img width="460" alt="Screenshot 2023-11-07 at 10 12 43" src="https://github.com/justeattakeaway/pie/assets/28605803/9e2395be-7d93-4b5a-849d-f35f098ed758">

<img width="460" alt="Screenshot 2023-11-07 at 10 12 37" src="https://github.com/justeattakeaway/pie/assets/28605803/b7de2032-19c1-4575-a923-c8b60d153033">


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
