### PR TITLE
fix(pie-docs): DSW-1325 usage cards should have the same height

### DIFF
--- a/.changeset/few-suns-grin.md
+++ b/.changeset/few-suns-grin.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Changed] - Usage cards should have equal height

--- a/apps/pie-docs/src/assets/styles/components/_usage.scss
+++ b/apps/pie-docs/src/assets/styles/components/_usage.scss
@@ -20,6 +20,9 @@ $usage-bg-minHeight: 280px;
     width: 100%;
 
     figure {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
         margin: 0;
     }
 }
@@ -39,6 +42,7 @@ $usage-bg-minHeight: 280px;
     background-color: f.$color-background-subtle;
     border-radius: 0 0 f.$radius-rounded-d f.$radius-rounded-d;
     border-top: 4px solid var(--style-colour);
+    flex-grow: 1;
 
     &.c-usage-backdrop--hasImage {
         display: grid;


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

As part of the components template work, we need to ensure the usage items shortcut should have the same height. 

Before:

<img width="931" alt="Screenshot 2023-11-07 at 11 48 38" src="https://github.com/justeattakeaway/pie/assets/28605803/f9eb08fb-047e-4532-85a1-116836d05a6a">

After:

<img width="931" alt="Screenshot 2023-11-07 at 11 48 41" src="https://github.com/justeattakeaway/pie/assets/28605803/509a9e91-48e5-483b-bd77-afea769ad02b">


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
