### PR TITLE
feat(pie-storybook): DWS-000 added documentation page for button vari…

### DIFF
--- a/.changeset/lucky-grapes-call.md
+++ b/.changeset/lucky-grapes-call.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - Documentation page for button variants with code snippets

--- a/apps/pie-storybook/.storybook/main.ts
+++ b/apps/pie-storybook/.storybook/main.ts
@@ -3,7 +3,7 @@ import type { StorybookConfig } from '@storybook/web-components-vite';
 const config: StorybookConfig = {
     stories: [
         "../stories/**/*.mdx",
-        "../stories/**/*.stories.@(js|ts)"
+        "../stories/**/*.stories.@(js|ts|tsx)"
     ],
     addons: [
         "@storybook/addon-a11y",

--- a/apps/pie-storybook/.storybook/preview.ts
+++ b/apps/pie-storybook/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import '@justeattakeaway/pie-css';
+import './styles/docs.scss';
 
 import { WritingDirection } from '../decorators';
 import { type StoryBackgrounds } from '../types/StoryOptions';

--- a/apps/pie-storybook/.storybook/styles/_fozzie-config.scss
+++ b/apps/pie-storybook/.storybook/styles/_fozzie-config.scss
@@ -1,0 +1,8 @@
+/**
+ * Fozzie Config:
+ * =================================
+ * Fozzie config forwards styles from the core Fozzie framework, configured for this project
+ */
+
+ @forward '@justeat/fozzie/src/scss/fozzie';
+ 

--- a/apps/pie-storybook/.storybook/styles/_fozzie-config.scss
+++ b/apps/pie-storybook/.storybook/styles/_fozzie-config.scss
@@ -4,5 +4,4 @@
  * Fozzie config forwards styles from the core Fozzie framework, configured for this project
  */
 
- @forward '@justeat/fozzie/src/scss/fozzie';
- 
+@forward '@justeat/fozzie/src/scss/fozzie';

--- a/apps/pie-storybook/.storybook/styles/docs.scss
+++ b/apps/pie-storybook/.storybook/styles/docs.scss
@@ -1,0 +1,6 @@
+// for styling storybook documentation pages
+@use './fozzie-config' as f;
+
+.docs-story:has([id*=inverse]) {
+    background-color: f.$color-background-dark;
+}

--- a/apps/pie-storybook/stories/pie-button-docs/variants.mdx
+++ b/apps/pie-storybook/stories/pie-button-docs/variants.mdx
@@ -2,30 +2,65 @@ import * as ButtonStories from '../pie-button.stories.tsx'
 import { Meta, Canvas } from '@storybook/blocks';
 
 <Meta of={ButtonStories} />
+
 ### Primary
+
 The primary button should be prominent, limited to one per page. It should be reserved for the most critical action.
-<Canvas of={ButtonStories.Primary} style={{backgroundColor: 'black'}}/>
+
+<Canvas of={ButtonStories.Primary} />
+
+
 ### Secondary
+
 Secondary buttons are supplementary options for non-essential actions on a web page.
+
 <Canvas of={ButtonStories.Secondary} />
+
+
 ### Outline
+
 Outline buttons are designed to provide increased emphasis compared to ghost buttons.
+
 <Canvas of={ButtonStories.Outline} />
+
+
 ### Ghost
+
 Ghost buttons are commonly employed for actions that are less crucial. They are ideal for repetitive actions, such as an edit button on a recurring card.
+
 <Canvas of={ButtonStories.Ghost} />
+
+
 ### Destructive
+
 Destructive buttons are used for high impact deletions that can result in permanent and undesired consequences. They should be limited to one per page.
+
 <Canvas of={ButtonStories.Destructive} />
+
+
 ### Destructive Ghost
+
 Destructive ghost buttons are employed for lower impact destructive actions, with no direct consequences and require confirmation. 
+
 <Canvas of={ButtonStories.DestructiveGhost} />
+
+
 ### Inverse
+
 Inverse buttons are specifically designed to be used on backgrounds with colours or images, and it's recommended to limit their usage to just one per page. They are reserved for the most critical actions, such as "Next," "Save," "Submit," etc.
-<Canvas of={ButtonStories.Inverse} class={"inverse-button"} class="hey" />
+
+<Canvas of={ButtonStories.Inverse} />
+
+
 ### Ghost Inverse
+
 Ghost Inverse buttons are intended for utilisation on backgrounds with colours or images, and are usually reserved for actions of lesser significance. They can be used independently or in conjunction with a primary button. Ghost Inverse buttons are ideal for repetitive actions, such as an edit button on a repeating card.
+
 <Canvas of={ButtonStories.GhostInverse} />
+
+
 ### Outline Inverse
+
+
 Inverse buttons are specifically designed to be used on backgrounds with colours or images, and it's recommended to limit their usage to just one per page. They are reserved for the most critical actions, such as "Next," "Save," "Submit," etc.
 <Canvas of={ButtonStories.OutlineInverse} />

--- a/apps/pie-storybook/stories/pie-button-docs/variants.mdx
+++ b/apps/pie-storybook/stories/pie-button-docs/variants.mdx
@@ -1,0 +1,31 @@
+import * as ButtonStories from '../pie-button.stories.tsx'
+import { Meta, Canvas } from '@storybook/blocks';
+
+<Meta of={ButtonStories} />
+### Primary
+The primary button should be prominent, limited to one per page. It should be reserved for the most critical action.
+<Canvas of={ButtonStories.Primary} style={{backgroundColor: 'black'}}/>
+### Secondary
+Secondary buttons are supplementary options for non-essential actions on a web page.
+<Canvas of={ButtonStories.Secondary} />
+### Outline
+Outline buttons are designed to provide increased emphasis compared to ghost buttons.
+<Canvas of={ButtonStories.Outline} />
+### Ghost
+Ghost buttons are commonly employed for actions that are less crucial. They are ideal for repetitive actions, such as an edit button on a recurring card.
+<Canvas of={ButtonStories.Ghost} />
+### Destructive
+Destructive buttons are used for high impact deletions that can result in permanent and undesired consequences. They should be limited to one per page.
+<Canvas of={ButtonStories.Destructive} />
+### Destructive Ghost
+Destructive ghost buttons are employed for lower impact destructive actions, with no direct consequences and require confirmation. 
+<Canvas of={ButtonStories.DestructiveGhost} />
+### Inverse
+Inverse buttons are specifically designed to be used on backgrounds with colours or images, and it's recommended to limit their usage to just one per page. They are reserved for the most critical actions, such as "Next," "Save," "Submit," etc.
+<Canvas of={ButtonStories.Inverse} class={"inverse-button"} class="hey" />
+### Ghost Inverse
+Ghost Inverse buttons are intended for utilisation on backgrounds with colours or images, and are usually reserved for actions of lesser significance. They can be used independently or in conjunction with a primary button. Ghost Inverse buttons are ideal for repetitive actions, such as an edit button on a repeating card.
+<Canvas of={ButtonStories.GhostInverse} />
+### Outline Inverse
+Inverse buttons are specifically designed to be used on backgrounds with colours or images, and it's recommended to limit their usage to just one per page. They are reserved for the most critical actions, such as "Next," "Save," "Submit," etc.
+<Canvas of={ButtonStories.OutlineInverse} />

--- a/apps/pie-storybook/stories/pie-button.stories.tsx
+++ b/apps/pie-storybook/stories/pie-button.stories.tsx
@@ -170,24 +170,24 @@ const Template: TemplateFunction<ButtonProps> = ({
     formnovalidate,
     formtarget,
 }) => html`
-        <pie-button
-            size="${size}"
-            variant="${variant}"
-            type="${type}"
-            iconPlacement="${iconPlacement || nothing}"
-            ?disabled="${disabled}"
-            ?isLoading="${isLoading}"
-            ?isFullWidth="${isFullWidth}"
-            name=${name || nothing}
-            value=${value || nothing}
-            formaction=${formaction || nothing}
-            formenctype=${formenctype || nothing}
-            formmethod=${formmethod || nothing}
-            formtarget=${formtarget || nothing}
-            ?formnovalidate="${formnovalidate}">
-            ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}
-            ${slot}
-        </pie-button>`;
+<pie-button
+    size="${size}"
+    variant="${variant}"
+    type="${type}"
+    iconPlacement="${iconPlacement || nothing}"
+    ?disabled="${disabled}"
+    ?isLoading="${isLoading}"
+    ?isFullWidth="${isFullWidth}"
+    name=${name || nothing}
+    value=${value || nothing}
+    formaction=${formaction || nothing}
+    formenctype=${formenctype || nothing}
+    formmethod=${formmethod || nothing}
+    formtarget=${formtarget || nothing}
+    ?formnovalidate="${formnovalidate}">
+    ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}
+    ${slot}
+</pie-button>`;
 
 const FormTemplate: TemplateFunction<ButtonProps> = (props: ButtonProps) => html`
 <p id="formLog" style="display: none; font-size: 2rem; color: var(--dt-color-support-positive);"></p>

--- a/apps/pie-storybook/stories/pie-button.stories.tsx
+++ b/apps/pie-storybook/stories/pie-button.stories.tsx
@@ -185,8 +185,7 @@ const Template: TemplateFunction<ButtonProps> = ({
     formmethod=${formmethod || nothing}
     formtarget=${formtarget || nothing}
     ?formnovalidate="${formnovalidate}">
-    ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}
-    ${slot}
+    ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}${slot}
 </pie-button>`;
 
 const FormTemplate: TemplateFunction<ButtonProps> = (props: ButtonProps) => html`


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Added] - Documentation page for button variants with code snippets

In order to embed code snippets of the different variants in our pie design system, we need to create a docs page. Storybook does provide autodocs out of the box, but a bespoke page gave more flexibility in terms of adding content and separating the variant code snippets from the stories.

Tested in local branch with code button template:

https://github.com/justeattakeaway/pie/assets/49618712/644a09ee-6061-42df-b6b7-d8d62202b091

https://pr982-storybook.pie.design/?path=/docs/button--variants

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
