### PR TITLE
fix(pie-monorepo): DSW-1376 mark "lit/react" as an external dependency 

### DIFF
--- a/apps/examples/wc-next10/README.md
+++ b/apps/examples/wc-next10/README.md
@@ -18,7 +18,7 @@ Once this is installed, head to your `next.config.js` and transpile modules need
 ```
 const transpileModules = [
     '@justeattakeaway/pie-button',
-    '@lit-labs/react',
+    '@lit/react',
     'lit'
 ];
 

--- a/apps/examples/wc-next10/package.json
+++ b/apps/examples/wc-next10/package.json
@@ -10,14 +10,9 @@
     "lint:examples": "eslint ."
   },
   "dependencies": {
-    "@babel/core": "7.22.11",
-    "@babel/plugin-transform-runtime": "7.21.4",
-    "@babel/preset-env": "7.21.4",
-    "@babel/preset-react": "7.18.6",
     "@justeattakeaway/pie-button": "0.38.1-next.0",
     "@justeattakeaway/pie-css": "0.8.0",
-    "eslint": "8.37.0",
-    "eslint-config-next": "13.2.4",
+    "@lit/react": "1.0.2",
     "next": "10.2.3",
     "next-transpile-modules": "4.1.0",
     "react": "16.13.1",
@@ -33,9 +28,15 @@
     "hoistingLimits": "workspaces"
   },
   "devDependencies": {
+    "@babel/core": "7.22.11",
     "@babel/plugin-transform-logical-assignment-operators": "7.22.11",
     "@babel/plugin-transform-nullish-coalescing-operator": "7.22.11",
     "@babel/plugin-transform-optional-chaining": "7.23.0",
-    "babel-loader": "8"
+    "@babel/plugin-transform-runtime": "7.21.4",
+    "@babel/preset-env": "7.21.4",
+    "@babel/preset-react": "7.18.6",
+    "babel-loader": "8",
+    "eslint": "8.37.0",
+    "eslint-config-next": "13.2.4"
   }
 }

--- a/apps/examples/wc-next13/README.md
+++ b/apps/examples/wc-next13/README.md
@@ -35,7 +35,7 @@ module.exports = withLitSSR(nextConfig);
 
 #### Using Web Components in React
 
-React 18 and previous versions don't handle web components and custom elements out of the box correctly in all cases due to how React treats custom props and events (More details can be found [here](https://lit.dev/docs/frameworks/react/)). Our solution for this is to wrap the web component to include the [`@lit-labs/react`](https://lit.dev/docs/frameworks/react/) package, generating a `react` file inside the component's `dist` folder.
+React 18 and previous versions don't handle web components and custom elements out of the box correctly in all cases due to how React treats custom props and events (More details can be found [here](https://lit.dev/docs/frameworks/react/)). Our solution for this is to wrap the web component to include the [`@lit/react`](https://lit.dev/docs/frameworks/react/) package, generating a `react` file inside the component's `dist` folder.
 
 Therefore, in order to import the web component into your React application, please use:
 

--- a/apps/examples/wc-next13/package.json
+++ b/apps/examples/wc-next13/package.json
@@ -9,18 +9,21 @@
     "start": "next start",
     "lint:examples": "next lint"
   },
-  "dependencies": {
-    "@justeattakeaway/pie-button": "0.38.1-next.0",
-    "@justeattakeaway/pie-css": "0.8.0",
-    "@lit-labs/nextjs": "0.1.3",
+  "devDependencies": {
     "@types/node": "20.8.10",
     "@types/react-dom": "18.2.14",
     "eslint": "8.37.0",
     "eslint-config-next": "13.2.4",
+    "typescript": "5.2.2"
+  },
+  "dependencies": {
+    "@justeattakeaway/pie-button": "0.38.1-next.0",
+    "@justeattakeaway/pie-css": "0.8.0",
+    "@lit-labs/nextjs": "0.1.3",
+    "@lit/react": "1.0.2",
     "next": "13.2.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "5.2.2"
+    "react-dom": "18.2.0"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/apps/examples/wc-react17/package.json
+++ b/apps/examples/wc-react17/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@justeattakeaway/pie-button": "0.38.1-next.0",
     "@justeattakeaway/pie-css": "0.8.0",
+    "@lit/react": "1.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "5.0.1"

--- a/apps/examples/wc-react18/README.md
+++ b/apps/examples/wc-react18/README.md
@@ -13,7 +13,7 @@ Builds the app for production to the `build` folder.\
 
 #### Using Web Components in React
 
-React 18 and previous versions don't handle web components and custom elements out of the box correctly in all cases due to how React treats custom props and events (More details can be found [here](https://lit.dev/docs/frameworks/react/)). Our solution for this is to wrap the web component to include the `[@lit-labs/react](https://lit.dev/docs/frameworks/react/)` package, generating a `react` file inside the component's `dist` folder.
+React 18 and previous versions don't handle web components and custom elements out of the box correctly in all cases due to how React treats custom props and events (More details can be found [here](https://lit.dev/docs/frameworks/react/)). Our solution for this is to wrap the web component to include the `[@lit/react](https://lit.dev/docs/frameworks/react/)` package, generating a `react` file inside the component's `dist` folder.
 
 Therefore, in order to import the web component into your React application, please use:
 

--- a/apps/examples/wc-react18/package.json
+++ b/apps/examples/wc-react18/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@justeattakeaway/pie-button": "0.38.1-next.0",
     "@justeattakeaway/pie-css": "0.8.0",
+    "@lit/react": "1.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-scripts": "5.0.1"

--- a/configs/pie-components-config/vite.config.js
+++ b/configs/pie-components-config/vite.config.js
@@ -22,7 +22,7 @@ const sharedConfig = ({ build = {}, plugins = [], ...rest }) => defineConfig({
         },
         rollupOptions: {
             external: (id) => {
-                if (id === 'react' || /^lit/.test(id) || id === '@lit/react') {
+                if (['react', '@lit/react'].includes(id) || /^lit/.test(id)) {
                     return true;
                 }
 

--- a/configs/pie-components-config/vite.config.js
+++ b/configs/pie-components-config/vite.config.js
@@ -22,7 +22,7 @@ const sharedConfig = ({ build = {}, plugins = [], ...rest }) => defineConfig({
         },
         rollupOptions: {
             external: (id) => {
-                if (id === 'react' || /^lit/.test(id)) {
+                if (id === 'react' || /^lit/.test(id) || id === '@lit/react') {
                     return true;
                 }
 

--- a/packages/components/pie-button/README.md
+++ b/packages/components/pie-button/README.md
@@ -61,7 +61,7 @@ import '@justeattakeaway/pie-button';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieButton } from '@justeattakeaway/pie-button/dist/react';
 ```
 

--- a/packages/components/pie-card/README.md
+++ b/packages/components/pie-card/README.md
@@ -55,7 +55,7 @@ import '@justeattakeaway/pie-card';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieCard } from '@justeattakeaway/pie-card/dist/react';
 ```
 

--- a/packages/components/pie-cookie-banner/README.md
+++ b/packages/components/pie-cookie-banner/README.md
@@ -56,7 +56,7 @@ import '@justeattakeaway/pie-cookie-banner';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieCookieBanner } from '@justeattakeaway/pie-cookie-banner/dist/react';
 ```
 

--- a/packages/components/pie-divider/README.md
+++ b/packages/components/pie-divider/README.md
@@ -56,7 +56,7 @@ import '@justeattakeaway/pie-divider';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieDivider } from '@justeattakeaway/pie-divider/dist/react';
 ```
 

--- a/packages/components/pie-form-label/README.md
+++ b/packages/components/pie-form-label/README.md
@@ -55,7 +55,7 @@ import '@justeattakeaway/pie-form-label';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieFormLabel } from '@justeattakeaway/pie-form-label/dist/react';
 ```
 

--- a/packages/components/pie-icon-button/README.md
+++ b/packages/components/pie-icon-button/README.md
@@ -60,7 +60,7 @@ import '@justeattakeaway/pie-icon-button';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieIconButton } from '@justeattakeaway/pie-icon-button/dist/react';
 ```
 

--- a/packages/components/pie-link/README.md
+++ b/packages/components/pie-link/README.md
@@ -55,7 +55,7 @@ import '@justeattakeaway/pie-link';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieLink } from '@justeattakeaway/pie-link/dist/react';
 ```
 

--- a/packages/components/pie-modal/README.md
+++ b/packages/components/pie-modal/README.md
@@ -57,7 +57,7 @@ import '@justeattakeaway/pie-modal';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieModal } from '@justeattakeaway/pie-modal/dist/react';
 ```
 

--- a/packages/components/pie-notification/README.md
+++ b/packages/components/pie-notification/README.md
@@ -55,7 +55,7 @@ import '@justeattakeaway/pie-notification';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieNotification } from '@justeattakeaway/pie-notification/dist/react';
 ```
 

--- a/packages/components/pie-spinner/README.md
+++ b/packages/components/pie-spinner/README.md
@@ -55,7 +55,7 @@ import '@justeattakeaway/pie-spinner';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieSpinner } from '@justeattakeaway/pie-spinner/dist/react';
 ```
 

--- a/packages/components/pie-switch/README.md
+++ b/packages/components/pie-switch/README.md
@@ -56,7 +56,7 @@ import '@justeattakeaway/pie-switch';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { PieSwitch } from '@justeattakeaway/pie-switch/dist/react';
 ```
 

--- a/packages/tools/generator-pie-component/src/app/templates/README.md
+++ b/packages/tools/generator-pie-component/src/app/templates/README.md
@@ -55,7 +55,7 @@ import '@justeattakeaway/pie-<%= fileName %>';
 ```js
 // React
 // For React, you will need to import our React-specific component build
-// which wraps the web component using @lit-labs/react
+// which wraps the web component using @lit/react
 import { Pie<%= componentName %> } from '@justeattakeaway/pie-<%= fileName %>/dist/react';
 ```
 

--- a/packages/tools/pie-wrapper-react/CHANGELOG.md
+++ b/packages/tools/pie-wrapper-react/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- [Changed] - `@lit/react` dependency to `@lit/react` and updated any references. ([#999](https://github.com/justeattakeaway/pie/pull/999)) by [@siggerzz](https://github.com/siggerzz)
+- [Changed] - `@lit-labs/react` dependency to `@lit/react` and updated any references. ([#999](https://github.com/justeattakeaway/pie/pull/999)) by [@siggerzz](https://github.com/siggerzz)
 
 ## 0.10.2
 

--- a/packages/tools/pie-wrapper-react/CHANGELOG.md
+++ b/packages/tools/pie-wrapper-react/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- [Changed] - `@lit-labs/react` dependency to `@lit/react` and updated any references. ([#999](https://github.com/justeattakeaway/pie/pull/999)) by [@siggerzz](https://github.com/siggerzz)
+- [Changed] - `@lit/react` dependency to `@lit/react` and updated any references. ([#999](https://github.com/justeattakeaway/pie/pull/999)) by [@siggerzz](https://github.com/siggerzz)
 
 ## 0.10.2
 

--- a/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
+++ b/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
@@ -3,7 +3,7 @@
 exports[`React Wrapper should be added from mock custom elements JSON 1`] = `
 "
 import * as React from 'react';
-import { createComponent, EventName } from '@lit-labs/react';
+import { createComponent, EventName } from '@lit/react';
 import { MockComponent as MockComponentReact } from './index';
 
 export * from './defs';
@@ -24,7 +24,7 @@ export const MockComponent = createComponent({
 exports[`React Wrapper should be named the same as the component itself 1`] = `
 "
 import * as React from 'react';
-import { createComponent } from '@lit-labs/react';
+import { createComponent } from '@lit/react';
 import { ButtonComponent as ButtonComponentReact } from './index';
 
 export * from './defs';
@@ -42,7 +42,7 @@ export const ButtonComponent = createComponent({
 exports[`React Wrapper should leave the events object empty if the component contains no custom events 1`] = `
 "
 import * as React from 'react';
-import { createComponent } from '@lit-labs/react';
+import { createComponent } from '@lit/react';
 import { MockComponent as MockComponentReact } from './index';
 
 export * from './defs';

--- a/packages/tools/pie-wrapper-react/package.json
+++ b/packages/tools/pie-wrapper-react/package.json
@@ -23,7 +23,7 @@
     "@babel/core": "7.23.3",
     "@babel/preset-react": "7.18.6",
     "@custom-elements-manifest/analyzer": "0.9.0",
-    "@lit/react": "1.0.1",
+    "@lit/react": "1.0.2",
     "@types/react": "18.2.36",
     "cem-plugin-module-file-extensions": "0.0.5",
     "fs-extra": "9.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5447,23 +5447,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.38.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.38.1-next.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-spinner": 0.2.1
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-spinner": 0.2.2-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
     element-internals-polyfill: 1.3.8
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.14.1, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.14.2-next.0, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
@@ -5475,19 +5475,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.11.1, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.11.2-next.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-divider": 0.9.1
-    "@justeattakeaway/pie-icon-button": 0.21.2
-    "@justeattakeaway/pie-link": 0.11.1
-    "@justeattakeaway/pie-modal": 0.32.2
+    "@justeattakeaway/pie-divider": 0.9.2-next.0
+    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
+    "@justeattakeaway/pie-link": 0.11.2-next.0
+    "@justeattakeaway/pie-modal": 0.32.3-next.0
     "@justeattakeaway/pie-switch": 0.17.2
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
@@ -5502,31 +5502,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-divider@0.9.1, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
+"@justeattakeaway/pie-divider@0.9.2-next.0, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.8.1, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.8.2-next.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.21.2, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.21.3-next.0, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-spinner": 0.2.1
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-spinner": 0.2.2-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
@@ -5587,7 +5587,7 @@ __metadata:
     "@babel/node": 7.20.7
     "@justeattakeaway/pie-icons": 4.9.2
     "@justeattakeaway/pie-icons-configs": 4.5.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
     "@open-wc/testing": 3.2.2
     "@rollup/plugin-typescript": 11.1.5
     "@web/test-runner": 0.16.1
@@ -5617,47 +5617,47 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.11.1, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.11.2-next.0, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.32.2, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.32.3-next.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-icon-button": 0.21.2
+    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-spinner": 0.2.1
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-spinner": 0.2.2-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
     "@types/body-scroll-lock": 3.1.2
     body-scroll-lock: 3.1.5
     dialog-polyfill: 0.5.6
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-notification@0.1.1, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
+"@justeattakeaway/pie-notification@0.1.2-next.0, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-spinner@0.2.1, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
+"@justeattakeaway/pie-spinner@0.2.2-next.0, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.11.0
+    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
   languageName: unknown
   linkType: soft
 
@@ -5670,7 +5670,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-core@0.11.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
+"@justeattakeaway/pie-webc-core@0.12.0-next.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   languageName: unknown
@@ -5689,7 +5689,7 @@ __metadata:
     "@babel/core": 7.23.3
     "@babel/preset-react": 7.18.6
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@lit/react": 1.0.1
+    "@lit/react": 1.0.2
     "@types/react": 18.2.36
     cem-plugin-module-file-extensions: 0.0.5
     fs-extra: 9.1.0
@@ -5775,12 +5775,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lit/react@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@lit/react@npm:1.0.1"
+"@lit/react@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@lit/react@npm:1.0.2"
   peerDependencies:
     "@types/react": 17 || 18
-  checksum: a81dd202b9e0a379c77ea73c3822cec2a17730347767d12c090b1519d2ed602f34900a913347f17cd839c2eb8cc284d8816367d90dec4431cd78da5d477b74bd
+  checksum: 6a5c2be97d53e75b714fd6831629366e7d9d296a8756132289a49e4e4474f26b5a4bb3ef44d5d4f89a0cacfc75b305845bbbf45b0bdc356ce4a6eda0c488b7e8
   languageName: node
   linkType: hard
 
@@ -28855,18 +28855,18 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.38.0
-    "@justeattakeaway/pie-card": 0.14.1
-    "@justeattakeaway/pie-cookie-banner": 0.11.1
+    "@justeattakeaway/pie-button": 0.38.1-next.0
+    "@justeattakeaway/pie-card": 0.14.2-next.0
+    "@justeattakeaway/pie-cookie-banner": 0.11.2-next.0
     "@justeattakeaway/pie-css": 0.8.0
-    "@justeattakeaway/pie-divider": 0.9.1
-    "@justeattakeaway/pie-form-label": 0.8.1
-    "@justeattakeaway/pie-icon-button": 0.21.2
+    "@justeattakeaway/pie-divider": 0.9.2-next.0
+    "@justeattakeaway/pie-form-label": 0.8.2-next.0
+    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-link": 0.11.1
-    "@justeattakeaway/pie-modal": 0.32.2
-    "@justeattakeaway/pie-notification": 0.1.1
-    "@justeattakeaway/pie-spinner": 0.2.1
+    "@justeattakeaway/pie-link": 0.11.2-next.0
+    "@justeattakeaway/pie-modal": 0.32.3-next.0
+    "@justeattakeaway/pie-notification": 0.1.2-next.0
+    "@justeattakeaway/pie-spinner": 0.2.2-next.0
     "@justeattakeaway/pie-switch": 0.17.2
     "@storybook/addon-a11y": 7.5.1
     "@storybook/addon-essentials": 7.5.1
@@ -37747,7 +37747,7 @@ __metadata:
     "@angular/platform-browser": 15.2.0
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
     "@types/jasmine": 4.3.0
     jasmine-core: 4.5.0
@@ -37774,8 +37774,9 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.21.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
+    "@lit/react": 1.0.2
     babel-loader: 8
     eslint: 8.37.0
     eslint-config-next: 13.2.4
@@ -37790,9 +37791,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
     "@lit-labs/nextjs": 0.1.3
+    "@lit/react": 1.0.2
     "@types/node": 20.8.10
     "@types/react-dom": 18.2.14
     eslint: 8.37.0
@@ -37811,7 +37813,7 @@ __metadata:
     "@babel/plugin-transform-logical-assignment-operators": 7.22.11
     "@babel/plugin-transform-nullish-coalescing-operator": 7.22.11
     "@babel/plugin-transform-optional-chaining": 7.23.0
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
     babel-loader: 8
     core-js: 3.30.0
@@ -37826,7 +37828,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
     "@types/node": 18
     nuxt: 3.4.3
@@ -37838,8 +37840,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
+    "@lit/react": 1.0.2
     react: 17.0.2
     react-dom: 17.0.2
     react-scripts: 5.0.1
@@ -37850,8 +37853,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
+    "@lit/react": 1.0.2
     react: 18.2.0
     react-dom: 18.2.0
     react-scripts: 5.0.1
@@ -37863,11 +37867,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
-    "@justeattakeaway/pie-icon-button": 0.21.2
+    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-modal": 0.32.2
+    "@justeattakeaway/pie-modal": 0.32.3-next.0
     vite: 4.3.9
   languageName: unknown
   linkType: soft
@@ -37876,7 +37880,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.38.0
+    "@justeattakeaway/pie-button": 0.38.1-next.0
     "@justeattakeaway/pie-css": 0.8.0
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- This PR marks "@lit/react" as an external package so it isn't bundled as part of the react wrappers. 
- This is required to fix (DSW-1376) where the react-wrappers of our component will fall back to their default values when JS is disabled resulting in a rehydration error. 
- The lit team also suggested the package should be marked as `external` to avoid other edge cases. 
- the change was tested in all of our react examples and should be good to go 🥳 


the lit team also suggested to not bundle the package as that will just create duplications for consumers.
## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
