### PR TITLE
fix(pie-modal): DSW-000 modal content doesn't span the whole height

### DIFF
--- a/.changeset/short-coins-serve.md
+++ b/.changeset/short-coins-serve.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Fixed] - modal should be full height in safari

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -62,7 +62,7 @@
 
     // The initial values for these variables apply to the medium-sized modal
     // Other sizes will update the variables as needed
-    --modal-block-size: 100%;
+    --modal-block-size: fit-content;
     --modal-inline-size: 75%;
     --modal-max-block-size: calc(100vh - calc(var(--modal-margin-block) * 2));
     --modal-max-inline-size: var(--modal-size-m);
@@ -86,10 +86,15 @@
             @media (max-width: calc($breakpoint-wide - 1px)) {
                 --modal-margin-block: var(--modal-margin-none);
                 --modal-border-radius: var(--dt-radius-rounded-none);
+                --modal-block-size: 100%;
                 --modal-inline-size: 100%;
 
                 // In this case, the modal must exceed the previous maximum width
                 --modal-max-inline-size: 100%;
+
+                > .c-modal-scrollContainer {
+                    height: 100%;
+                }
             }
         }
     }
@@ -102,6 +107,7 @@
         @media (max-width: calc($breakpoint-wide - 1px)) {
             --modal-margin-block: var(--modal-margin-none);
             --modal-border-radius: var(--dt-radius-rounded-none);
+            --modal-block-size: 100%;
             --modal-inline-size: 100%;
         }
     }
@@ -264,7 +270,7 @@
     & > .c-modal-scrollContainer {
         display: flex;
         flex-direction: column;
-        height: 100%;
+        height: auto;
         overflow-y: auto;
 
         // These are the shadows used to indicate scrolling above and below content

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -92,8 +92,9 @@
                 // In this case, the modal must exceed the previous maximum width
                 --modal-max-inline-size: 100%;
 
+                // this ensures the content container spans the full height
                 > .c-modal-scrollContainer {
-                    height: 100%;
+                    block-size: 100%;
                 }
             }
         }
@@ -270,7 +271,7 @@
     & > .c-modal-scrollContainer {
         display: flex;
         flex-direction: column;
-        height: auto;
+        block-size: auto;
         overflow-y: auto;
 
         // These are the shadows used to indicate scrolling above and below content

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -62,7 +62,7 @@
 
     // The initial values for these variables apply to the medium-sized modal
     // Other sizes will update the variables as needed
-    --modal-block-size: fit-content;
+    --modal-block-size: 100%;
     --modal-inline-size: 75%;
     --modal-max-block-size: calc(100vh - calc(var(--modal-margin-block) * 2));
     --modal-max-inline-size: var(--modal-size-m);
@@ -86,7 +86,6 @@
             @media (max-width: calc($breakpoint-wide - 1px)) {
                 --modal-margin-block: var(--modal-margin-none);
                 --modal-border-radius: var(--dt-radius-rounded-none);
-                --modal-block-size: 100%;
                 --modal-inline-size: 100%;
 
                 // In this case, the modal must exceed the previous maximum width
@@ -103,7 +102,6 @@
         @media (max-width: calc($breakpoint-wide - 1px)) {
             --modal-margin-block: var(--modal-margin-none);
             --modal-border-radius: var(--dt-radius-rounded-none);
-            --modal-block-size: 100%;
             --modal-inline-size: 100%;
         }
     }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

currently, our modal doesn't display fully in Safari when `isFooterPinned` is set to false. 

<img width="1280" alt="Screenshot 2023-11-20 at 18 42 06" src="https://github.com/justeattakeaway/pie/assets/28605803/673d6425-6c1b-4299-a3cf-241b8127989b">

This PR ensures that the modal renders the correct height while maintaining the current behavior of `isFooterPinned` and `isFullWidthBelowMid`

<img width="1280" alt="Screenshot 2023-11-20 at 19 13 08" src="https://github.com/justeattakeaway/pie/assets/28605803/bcbeca31-e8d2-424f-845a-8e08658356da">


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
