### PR TITLE
fix(pie-docs): DSW-000 fix issue where dev server was running on incorrect port for browser tests

### DIFF
--- a/.changeset/twelve-candles-carry.md
+++ b/.changeset/twelve-candles-carry.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Fixed] - Issue where `dev` script wasn't running on port 8080, causing the browser tests to fail.

--- a/apps/pie-docs/package.json
+++ b/apps/pie-docs/package.json
@@ -12,7 +12,7 @@
     "build": "DEPLOYMENT_ENVIRONMENT='production' eleventy",
     "build:dev": "DEPLOYMENT_ENVIRONMENT='development' eleventy",
     "clean": "run -T rimraf dist",
-    "dev": "npx @11ty/eleventy --serve",
+    "dev": "npx @11ty/eleventy --serve --port=8080",
     "lint:scripts": "run -T eslint .",
     "lint:scripts:fix": "run -T eslint . --fix",
     "lint:style": "run -T stylelint ./src/**/*.{css,scss}",


### PR DESCRIPTION
---
"pie-docs": patch
---

[Fixed] - Issue where `dev` script wasn't running on port 8080, causing the browser tests to fail.