### PR TITLE
fix(pie-spinner): DSW-000 rename sizes to match new design specs

### DIFF
--- a/.changeset/five-grapes-live.md
+++ b/.changeset/five-grapes-live.md
@@ -1,0 +1,10 @@
+---
+"@justeattakeaway/pie-icon-button": minor
+"@justeattakeaway/pie-spinner": minor
+"@justeattakeaway/pie-button": minor
+"@justeattakeaway/pie-modal": minor
+"pie-storybook": minor
+"pie-monorepo": minor
+---
+
+[Changed] - spinner sizes should be fully spelt out such as large not l

--- a/apps/pie-storybook/stories/pie-spinner.stories.ts
+++ b/apps/pie-storybook/stories/pie-spinner.stories.ts
@@ -27,7 +27,7 @@ const spinnerStoryMeta: SpinnerStoryMeta = {
             control: 'select',
             options: sizes,
             defaultValue: {
-                summary: 'm',
+                summary: 'medium',
             },
         },
         variant: {

--- a/packages/components/pie-button/src/index.ts
+++ b/packages/components/pie-button/src/index.ts
@@ -210,7 +210,7 @@ export class PieButton extends LitElement implements ButtonProps {
      * @private
      */
     private renderSpinner (): TemplateResult {
-        const spinnerSize = this.size.includes('small') ? 's' : 'm'; // includes("small") matches for any small size value and xsmall
+        const spinnerSize = this.size.includes('small') ? 'small' : 'medium'; // includes("small") matches for any small size value and xsmall
         const inverseVariants: Array<ButtonProps['variant']> = ['primary', 'destructive', 'outline-inverse', 'ghost-inverse'];
         const spinnerVariant = inverseVariants.includes(this.variant) ? 'inverse' : 'secondary';
 

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -39,7 +39,7 @@ export class PieIconButton extends LitElement implements IconButtonProps {
      */
     private renderSpinner (): TemplateResult {
         const { variant, size } = this;
-        const spinnerSize = size === 'xsmall' ? 's' : 'm';
+        const spinnerSize = size === 'xsmall' ? 'small' : 'medium';
         let spinnerVariant = 'brand';
         if (variant?.includes('secondary')) spinnerVariant = 'secondary';
         if (variant === 'primary' || variant === 'ghost-inverse') spinnerVariant = 'inverse';

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -343,7 +343,7 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
             <div class="c-modal-contentInner">
                 <slot></slot>
             </div>
-            ${this.isLoading ? html`<pie-spinner size="xl" variant="secondary"></pie-spinner>` : nothing}
+            ${this.isLoading ? html`<pie-spinner size="xlarge" variant="secondary"></pie-spinner>` : nothing}
         </article>
         <footer class="c-modal-footer">
             ${this.leadingAction ? this.renderLeadingAction() : nothing}

--- a/packages/components/pie-spinner/README.md
+++ b/packages/components/pie-spinner/README.md
@@ -74,7 +74,7 @@ import { PieSpinner } from '@justeattakeaway/pie-spinner/dist/react';
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| size | `String` | `m` | Size of the spinner, one of `sizes` – `xs`, `s`, `m`, `l`, `xl` |
+| size | `String` | `medium` | Size of the spinner, one of `sizes` – `xsmall`, `small`, `medium`, `large`, `xlarge` |
 | variant | `String` | `brand` | Variant of the spinner, one of `variants` – `brand`, `secondary`, `inverse` |
 | aria  | `Object`  | `undefined`  | An object representing the aria attributes such as label;
 

--- a/packages/components/pie-spinner/src/defs.ts
+++ b/packages/components/pie-spinner/src/defs.ts
@@ -1,4 +1,4 @@
-export const sizes = ['xs', 's', 'm', 'l', 'xl'] as const;
+export const sizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'] as const;
 export const variants = ['brand', 'secondary', 'inverse'] as const;
 
 export type AriaProps = {

--- a/packages/components/pie-spinner/src/index.ts
+++ b/packages/components/pie-spinner/src/index.ts
@@ -24,8 +24,8 @@ export class PieSpinner extends LitElement implements SpinnerProps {
     public aria?: AriaProps;
 
     @property()
-    @validPropertyValues(componentSelector, sizes, 'm')
-    public size?: SpinnerProps['size'] = 'm';
+    @validPropertyValues(componentSelector, sizes, 'medium')
+    public size?: SpinnerProps['size'] = 'medium';
 
     @property()
     @validPropertyValues(componentSelector, variants, 'brand')

--- a/packages/components/pie-spinner/src/spinner.scss
+++ b/packages/components/pie-spinner/src/spinner.scss
@@ -55,23 +55,23 @@
         @include spinner-base-colors('--dt-color-content-inverse');
     }
 
-    &[size='xs'] {
+    &[size='xsmall'] {
         --spinner-size: 16px;
     }
 
-    &[size='s'] {
+    &[size='small'] {
         --spinner-size: 20px;
     }
 
-    &[size='m'] {
+    &[size='medium'] {
         /* Same as default styles */
     }
 
-    &[size='l'] {
+    &[size='large'] {
         --spinner-size: 32px;
     }
 
-    &[size='xl'] {
+    &[size='xlarge'] {
         --spinner-size: 48px;
     }
 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Refactors the sizes prop values to match the button size values as requested by design for better consistency

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
