### PR TITLE
fix(pie-storybook): DSW-000 ensure icons are bundled as part of link story

### DIFF
--- a/.changeset/blue-carrots-wonder.md
+++ b/.changeset/blue-carrots-wonder.md
@@ -1,0 +1,6 @@
+---
+"pie-storybook": minor
+"pie-monorepo": minor
+---
+
+[Fixed] icons in pie link stories aren't shown if the story url is directly visited

--- a/.changeset/blue-carrots-wonder.md
+++ b/.changeset/blue-carrots-wonder.md
@@ -3,4 +3,4 @@
 "pie-monorepo": minor
 ---
 
-[Fixed] icons in pie link stories aren't shown if the story url is directly visited
+[Fixed] - icons in pie link stories aren't shown if the story url is directly visited

--- a/.changeset/silly-cherries-move.md
+++ b/.changeset/silly-cherries-move.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-switch": minor
+"pie-storybook": minor
+"pie-monorepo": minor
+---
+
+[Fixed] - add webc-core as a dep in the switch component

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -7,6 +7,7 @@ import {
     iconPlacements, tags, buttonTypes, underlineTypes,
 } from '@justeattakeaway/pie-link';
 /* eslint-enable import/no-duplicates */
+import '@justeattakeaway/pie-icons-webc/IconPlusCircle';
 
 import type { StoryMeta, SlottedComponentProps } from '../types';
 import { createStory, type TemplateFunction } from '../utilities';
@@ -154,7 +155,7 @@ const Template : TemplateFunction<LinkProps> = ({
             tag="${tag}"
             variant="${variant}"
             size="${size}"
-            underline="${underline}"
+            underline="${underline || nothing}"
             iconPlacement="${iconPlacement || nothing}"
             href="${href || nothing}"
             target="${target || nothing}"

--- a/packages/components/pie-switch/package.json
+++ b/packages/components/pie-switch/package.json
@@ -31,6 +31,7 @@
     "@justeattakeaway/pie-components-config": "0.6.0"
   },
   "dependencies": {
+    "@justeattakeaway/pie-webc-core": "0.12.0",
     "@justeattakeaway/pie-icons-webc": "0.11.1"
   },
   "volta": {

--- a/packages/components/pie-switch/package.json
+++ b/packages/components/pie-switch/package.json
@@ -31,8 +31,8 @@
     "@justeattakeaway/pie-components-config": "0.6.0"
   },
   "dependencies": {
-    "@justeattakeaway/pie-webc-core": "0.12.0",
-    "@justeattakeaway/pie-icons-webc": "0.11.1"
+    "@justeattakeaway/pie-icons-webc": "0.11.1",
+    "@justeattakeaway/pie-webc-core": "0.12.0"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5701,6 +5701,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
     "@justeattakeaway/pie-icons-webc": 0.11.1
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5468,23 +5468,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.39.1-next.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.39.1, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-spinner": 0.2.2-next.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-spinner": 0.2.2
+    "@justeattakeaway/pie-webc-core": 0.12.0
     element-internals-polyfill: 1.3.8
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.14.2-next.0, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.14.2, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
@@ -5496,19 +5496,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.11.4-next.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.11.4, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-divider": 0.9.2-next.0
-    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
-    "@justeattakeaway/pie-link": 0.11.2-next.0
-    "@justeattakeaway/pie-modal": 0.33.1-next.0
+    "@justeattakeaway/pie-divider": 0.9.2
+    "@justeattakeaway/pie-icon-button": 0.21.3
+    "@justeattakeaway/pie-link": 0.11.2
+    "@justeattakeaway/pie-modal": 0.33.1
     "@justeattakeaway/pie-switch": 0.17.2
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
@@ -5523,35 +5523,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-divider@0.9.2-next.0, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
+"@justeattakeaway/pie-divider@0.9.2, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.8.2-next.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.8.2, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.21.3-next.0, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.21.3, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-spinner": 0.2.2-next.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-spinner": 0.2.2
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-configs@4.5.0, @justeattakeaway/pie-icons-configs@workspace:packages/tools/pie-icons-configs":
+"@justeattakeaway/pie-icons-configs@4.5.1, @justeattakeaway/pie-icons-configs@workspace:packages/tools/pie-icons-configs":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-configs@workspace:packages/tools/pie-icons-configs"
   languageName: unknown
@@ -5564,8 +5564,8 @@ __metadata:
     "@babel/core": 7.23.3
     "@babel/node": 7.20.7
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-icons": 4.9.2
-    "@justeattakeaway/pie-icons-configs": 4.5.0
+    "@justeattakeaway/pie-icons": 4.9.3
+    "@justeattakeaway/pie-icons-configs": 4.5.1
     "@svgr/core": 6.4.0
     pascal-case: 3.1.2
     react: 18.2.0
@@ -5581,8 +5581,8 @@ __metadata:
   resolution: "@justeattakeaway/pie-icons-vue@workspace:packages/tools/pie-icons-vue"
   dependencies:
     "@babel/core": 7.23.3
-    "@justeattakeaway/pie-icons": 4.9.2
-    "@justeattakeaway/pie-icons-configs": 4.5.0
+    "@justeattakeaway/pie-icons": 4.9.3
+    "@justeattakeaway/pie-icons-configs": 4.5.1
     "@rollup/plugin-commonjs": 25.0.7
     "@vue/babel-helper-vue-jsx-merge-props": 1.4.0
     "@vue/babel-preset-jsx": 1.4.0
@@ -5606,9 +5606,9 @@ __metadata:
   dependencies:
     "@babel/core": 7.23.3
     "@babel/node": 7.20.7
-    "@justeattakeaway/pie-icons": 4.9.2
-    "@justeattakeaway/pie-icons-configs": 4.5.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-icons": 4.9.3
+    "@justeattakeaway/pie-icons-configs": 4.5.1
+    "@justeattakeaway/pie-webc-core": 0.12.0
     "@open-wc/testing": 4.0.0
     "@rollup/plugin-typescript": 11.1.5
     "@web/test-runner": 0.16.1
@@ -5623,7 +5623,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons@4.9.2, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
+"@justeattakeaway/pie-icons@4.9.3, @justeattakeaway/pie-icons@workspace:packages/tools/pie-icons":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons@workspace:packages/tools/pie-icons"
   dependencies:
@@ -5638,47 +5638,60 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.11.2-next.0, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-icons@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@justeattakeaway/pie-icons@npm:4.9.2"
+  dependencies:
+    cheerio: 1.0.0-rc.12
+    classnames: 2.3.2
+    html-minifier-terser: 7.2.0
+    prettier: 2.8.7
+    svgo: 3.0.2
+  checksum: b5cee36778d5eca344a12d6017919751c00495f22d88463195c294088516fbcb258296c25b8d4639ca79eab10c9f12264cad5eff02319a67410bb6d5339cc00e
+  languageName: node
+  linkType: hard
+
+"@justeattakeaway/pie-link@0.11.2, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.33.1-next.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.33.1, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
+    "@justeattakeaway/pie-icon-button": 0.21.3
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-spinner": 0.2.2-next.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-spinner": 0.2.2
+    "@justeattakeaway/pie-webc-core": 0.12.0
     "@types/body-scroll-lock": 3.1.2
     body-scroll-lock: 3.1.5
     dialog-polyfill: 0.5.6
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-notification@0.1.2-next.0, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
+"@justeattakeaway/pie-notification@0.1.2, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-spinner@0.2.2-next.0, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
+"@justeattakeaway/pie-spinner@0.2.2, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0-next.0
+    "@justeattakeaway/pie-webc-core": 0.12.0
   languageName: unknown
   linkType: soft
 
@@ -5691,7 +5704,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-core@0.12.0-next.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
+"@justeattakeaway/pie-webc-core@0.12.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   languageName: unknown
@@ -28990,7 +29003,7 @@ __metadata:
     "@justeat/pie-design-tokens": 5.9.0
     "@justeattakeaway/browserslist-config-pie": 0.2.0
     "@justeattakeaway/generator-pie-component": 0.15.0
-    "@justeattakeaway/pie-icons": 4.9.2
+    "@justeattakeaway/pie-icons": 4.9.3
     "@justeattakeaway/pie-webc-testing": 0.6.0
     "@justeattakeaway/stylelint-config-pie": 0.5.0
     "@percy/cli": 1.26.3
@@ -29044,18 +29057,18 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.39.1-next.0
-    "@justeattakeaway/pie-card": 0.14.2-next.0
-    "@justeattakeaway/pie-cookie-banner": 0.11.4-next.0
+    "@justeattakeaway/pie-button": 0.39.1
+    "@justeattakeaway/pie-card": 0.14.2
+    "@justeattakeaway/pie-cookie-banner": 0.11.4
     "@justeattakeaway/pie-css": 0.8.0
-    "@justeattakeaway/pie-divider": 0.9.2-next.0
-    "@justeattakeaway/pie-form-label": 0.8.2-next.0
-    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
+    "@justeattakeaway/pie-divider": 0.9.2
+    "@justeattakeaway/pie-form-label": 0.8.2
+    "@justeattakeaway/pie-icon-button": 0.21.3
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-link": 0.11.2-next.0
-    "@justeattakeaway/pie-modal": 0.33.1-next.0
-    "@justeattakeaway/pie-notification": 0.1.2-next.0
-    "@justeattakeaway/pie-spinner": 0.2.2-next.0
+    "@justeattakeaway/pie-link": 0.11.2
+    "@justeattakeaway/pie-modal": 0.33.1
+    "@justeattakeaway/pie-notification": 0.1.2
+    "@justeattakeaway/pie-spinner": 0.2.2
     "@justeattakeaway/pie-switch": 0.17.2
     "@storybook/addon-a11y": 7.5.1
     "@storybook/addon-designs": 7.0.5
@@ -37995,7 +38008,7 @@ __metadata:
     "@angular/platform-browser": 15.2.0
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@types/jasmine": 4.3.0
     jasmine-core: 4.5.0
@@ -38022,7 +38035,7 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.21.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit/react": 1.0.2
     babel-loader: 8
@@ -38039,7 +38052,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit-labs/nextjs": 0.1.3
     "@lit/react": 1.0.2
@@ -38061,7 +38074,7 @@ __metadata:
     "@babel/plugin-transform-logical-assignment-operators": 7.22.11
     "@babel/plugin-transform-nullish-coalescing-operator": 7.22.11
     "@babel/plugin-transform-optional-chaining": 7.23.0
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     babel-loader: 8
     core-js: 3.30.0
@@ -38076,7 +38089,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@types/node": 18
     nuxt: 3.4.3
@@ -38088,7 +38101,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit/react": 1.0.2
     react: 17.0.2
@@ -38101,7 +38114,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit/react": 1.0.2
     react: 18.2.0
@@ -38115,11 +38128,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
-    "@justeattakeaway/pie-icon-button": 0.21.3-next.0
+    "@justeattakeaway/pie-icon-button": 0.21.3
     "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-modal": 0.33.1-next.0
+    "@justeattakeaway/pie-modal": 0.33.1
     vite: 4.3.9
   languageName: unknown
   linkType: soft
@@ -38128,7 +38141,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.39.1-next.0
+    "@justeattakeaway/pie-button": 0.39.1
     "@justeattakeaway/pie-css": 0.8.0
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Fixes an issue where `pie-link` stories don't display icons when the page is refreshed. 
- a type error because of an invalid value passed to "underline"

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
