### PR TITLE
fix(pie-modal): DSW-1449 fixed multiple modals from opening when more than one exist

### DIFF
--- a/.changeset/lovely-jobs-joke.md
+++ b/.changeset/lovely-jobs-joke.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Fixed] - Multiple modals from opening when more than one exist

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -36,6 +36,10 @@ export * from './defs';
 
 const componentSelector = 'pie-modal';
 
+export interface ModalEventDetail {
+    targetModal: PieModal;
+}
+
 /**
  * @tagname pie-modal
  * @event {CustomEvent} pie-modal-open - when the modal is opened.
@@ -105,15 +109,15 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     connectedCallback () : void {
         super.connectedCallback();
         this.addEventListener('click', (event) => this._handleDialogLightDismiss(event));
-        document.addEventListener(ON_MODAL_OPEN_EVENT, this._handleModalOpened.bind(this));
-        document.addEventListener(ON_MODAL_CLOSE_EVENT, this._handleModalClosed.bind(this));
-        document.addEventListener(ON_MODAL_BACK_EVENT, this._handleModalClosed.bind(this));
+        document.addEventListener(ON_MODAL_OPEN_EVENT, (event) => this._handleModalOpened(<CustomEvent<any>>event));
+        document.addEventListener(ON_MODAL_CLOSE_EVENT, (event) => this._handleModalClosed(<CustomEvent<any>>event));
+        document.addEventListener(ON_MODAL_BACK_EVENT, (event) => this._handleModalClosed(<CustomEvent<any>>event));
     }
 
     disconnectedCallback () : void {
-        document.removeEventListener(ON_MODAL_OPEN_EVENT, this._handleModalOpened.bind(this));
-        document.removeEventListener(ON_MODAL_CLOSE_EVENT, this._handleModalClosed.bind(this));
-        document.removeEventListener(ON_MODAL_BACK_EVENT, this._handleModalClosed.bind(this));
+        document.removeEventListener(ON_MODAL_OPEN_EVENT, (event) => this._handleModalOpened(<CustomEvent<any>>event));
+        document.removeEventListener(ON_MODAL_CLOSE_EVENT, (event) => this._handleModalClosed(<CustomEvent<any>>event));
+        document.removeEventListener(ON_MODAL_BACK_EVENT, (event) => this._handleModalClosed(<CustomEvent<any>>event));
         super.disconnectedCallback();
     }
 
@@ -140,32 +144,41 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     /**
      * Opens the dialog element and disables page scrolling
      */
-    private _handleModalOpened () : void {
-        const modalScrollContainer = this._dialog?.querySelector('.c-modal-scrollContainer');
+    private _handleModalOpened (event: CustomEvent): void {
+        const { targetModal } = event.detail;
 
-        if (modalScrollContainer) {
-            disableBodyScroll(modalScrollContainer);
-        }
+        if (targetModal === this) {
+            const modalScrollContainer = this._dialog?.querySelector('.c-modal-scrollContainer');
 
-        if (this._dialog?.hasAttribute('open') || !this._dialog?.isConnected) {
-            return;
+            if (modalScrollContainer) {
+                disableBodyScroll(modalScrollContainer);
+            }
+
+            if (this._dialog?.hasAttribute('open') || !this._dialog?.isConnected) {
+                return;
+            }
+
+            // The ::backdrop pseudoelement is only shown if the modal is opened via JS
+            this._dialog?.showModal();
         }
-        // The ::backdrop pseudoelement is only shown if the modal is opened via JS
-        this._dialog?.showModal();
     }
 
     /**
      * Closes the dialog element and re-enables page scrolling
      */
-    private _handleModalClosed () : void {
-        const modalScrollContainer = this._dialog?.querySelector('.c-modal-scrollContainer');
+    private _handleModalClosed (event: CustomEvent): void {
+        const { targetModal } = event.detail;
 
-        if (modalScrollContainer) {
-            enableBodyScroll(modalScrollContainer);
+        if (targetModal === this) {
+            const modalScrollContainer = this._dialog?.querySelector('.c-modal-scrollContainer');
+
+            if (modalScrollContainer) {
+                enableBodyScroll(modalScrollContainer);
+            }
+
+            this._dialog?.close();
+            this._returnFocus();
         }
-
-        this._dialog?.close();
-        this._returnFocus();
     }
 
     /**
@@ -448,14 +461,15 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
      *
      * @param {string} eventType
      */
-    private _dispatchModalCustomEvent = (eventType: string) : void => {
-        const event = new CustomEvent(eventType, {
+    private _dispatchModalCustomEvent (eventType: string): void {
+        const event = new CustomEvent<ModalEventDetail>(eventType, {
             bubbles: true,
             composed: true,
+            detail: { targetModal: this },
         });
 
         this.dispatchEvent(event);
-    };
+    }
 }
 
 defineCustomElement(componentSelector, PieModal);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
[Fixed] - Multiple modals from opening when more than one exist

Video:


https://github.com/justeattakeaway/pie/assets/2299779/094b035f-0f41-49ce-a3ef-d2f4902238b2



## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
