### PR TITLE
fix(pie-monorepo): DSW-000 fix divider stories

### DIFF
--- a/.changeset/tough-icons-vanish.md
+++ b/.changeset/tough-icons-vanish.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Fixed] - divider stories aren't visible

--- a/apps/pie-storybook/stories/pie-divider.stories.ts
+++ b/apps/pie-storybook/stories/pie-divider.stories.ts
@@ -47,16 +47,11 @@ const dividerStoryMeta: DividerStoryMeta = {
 
 export default dividerStoryMeta;
 
-const Template : TemplateFunction<DividerProps> = ({ variant, orientation }) => {
-    if (orientation === 'vertical') {
-        return html`
-            <div style="height: 250px">
+const Template : TemplateFunction<DividerProps> = ({ variant, orientation }) => html`
+            <div style="${orientation === 'horizontal' ? 'width' : 'height'}: 400px">
                 <pie-divider variant="${variant}" orientation="${orientation}"></pie-divider>
             </div>
         `;
-    }
-    return html`<pie-divider variant="${variant}" orientation="${orientation}" />`;
-};
 
 const createDividerStory = createStory<DividerProps>(Template, defaultArgs);
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
when we introduced this [commit](https://github.com/justeattakeaway/pie/pull/976/commits/29b408a8feb8de81ed0bba0d480ff134e0187363#diff-49fec5f1927f17f5b3e531ef05b7fba91112ff6a58a49fa4571ad48f3d43317aR90) to center the content of our stories, the divider became invisible as the parent of the inner stories is set to flex / center and that will shrink children to only span their content, and the divider didn't have a width value set / content to span

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
