### PR TITLE
fix(pie-icons-react): DSW-000 list build dependencies as dev deps

### DIFF
--- a/.changeset/quick-ears-exist.md
+++ b/.changeset/quick-ears-exist.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-icons-react": minor
+"pie-monorepo": minor
+---
+
+[Fixed] - list pie-icons-configs as a dev dependency

--- a/packages/tools/pie-icons-react/package.json
+++ b/packages/tools/pie-icons-react/package.json
@@ -51,6 +51,8 @@
     "@babel/core": "7.23.3",
     "@babel/node": "7.20.7",
     "@babel/preset-react": "7.18.6",
+    "@justeattakeaway/pie-icons": "4.9.3",
+    "@justeattakeaway/pie-icons-configs": "4.5.1",
     "@svgr/core": "6.4.0",
     "pascal-case": "3.1.2",
     "react": "18.2.0",
@@ -58,10 +60,6 @@
     "rollup": "3.20.2",
     "rollup-plugin-typescript2": "0.34.1",
     "typescript": "5.3.2"
-  },
-  "dependencies": {
-    "@justeattakeaway/pie-icons": "4.9.3",
-    "@justeattakeaway/pie-icons-configs": "4.5.1"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5468,27 +5468,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.40.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.40.1, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-spinner": 0.3.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-spinner": 0.3.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
     element-internals-polyfill: 1.3.8
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.14.2, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.14.3, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-components-config@0.6.0, @justeattakeaway/pie-components-config@workspace:configs/pie-components-config":
+"@justeattakeaway/pie-components-config@0.6.1, @justeattakeaway/pie-components-config@workspace:configs/pie-components-config":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-components-config@workspace:configs/pie-components-config"
   dependencies:
@@ -5496,19 +5496,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.11.5, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.11.6, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.40.0
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-divider": 0.9.2
-    "@justeattakeaway/pie-icon-button": 0.22.0
-    "@justeattakeaway/pie-link": 0.11.2
-    "@justeattakeaway/pie-modal": 0.34.0
-    "@justeattakeaway/pie-switch": 0.18.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-button": 0.40.1
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-divider": 0.9.3
+    "@justeattakeaway/pie-icon-button": 0.23.0
+    "@justeattakeaway/pie-link": 0.11.3
+    "@justeattakeaway/pie-modal": 0.34.1
+    "@justeattakeaway/pie-switch": 0.18.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
@@ -5523,31 +5523,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-divider@0.9.2, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
+"@justeattakeaway/pie-divider@0.9.3, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.8.2, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.8.3, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.22.0, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.23.0, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-spinner": 0.3.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-icons-webc": 0.12.0
+    "@justeattakeaway/pie-spinner": 0.3.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
@@ -5600,7 +5600,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-webc@0.11.1, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
+"@justeattakeaway/pie-icons-webc@0.12.0, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
@@ -5608,7 +5608,7 @@ __metadata:
     "@babel/node": 7.20.7
     "@justeattakeaway/pie-icons": 4.9.3
     "@justeattakeaway/pie-icons-configs": 4.5.1
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-webc-core": 0.13.0
     "@open-wc/testing": 4.0.0
     "@rollup/plugin-typescript": 11.1.5
     "@web/test-runner": 0.16.1
@@ -5648,61 +5648,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-link@0.11.2, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.11.3, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.34.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.34.1, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.40.0
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-icon-button": 0.22.0
-    "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-spinner": 0.3.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-button": 0.40.1
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-icon-button": 0.23.0
+    "@justeattakeaway/pie-icons-webc": 0.12.0
+    "@justeattakeaway/pie-spinner": 0.3.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
     "@types/body-scroll-lock": 3.1.2
     body-scroll-lock: 3.1.5
     dialog-polyfill: 0.5.6
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-notification@0.1.2, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
+"@justeattakeaway/pie-notification@0.1.3, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-spinner@0.3.0, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
+"@justeattakeaway/pie-spinner@0.3.1, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-switch@0.18.0, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
+"@justeattakeaway/pie-switch@0.18.1, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.6.0
-    "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-webc-core": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.6.1
+    "@justeattakeaway/pie-icons-webc": 0.12.0
+    "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-core@0.12.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
+"@justeattakeaway/pie-webc-core@0.13.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   dependencies:
@@ -29065,19 +29065,19 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.40.0
-    "@justeattakeaway/pie-card": 0.14.2
-    "@justeattakeaway/pie-cookie-banner": 0.11.5
+    "@justeattakeaway/pie-button": 0.40.1
+    "@justeattakeaway/pie-card": 0.14.3
+    "@justeattakeaway/pie-cookie-banner": 0.11.6
     "@justeattakeaway/pie-css": 0.8.0
-    "@justeattakeaway/pie-divider": 0.9.2
-    "@justeattakeaway/pie-form-label": 0.8.2
-    "@justeattakeaway/pie-icon-button": 0.22.0
-    "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-link": 0.11.2
-    "@justeattakeaway/pie-modal": 0.34.0
-    "@justeattakeaway/pie-notification": 0.1.2
-    "@justeattakeaway/pie-spinner": 0.3.0
-    "@justeattakeaway/pie-switch": 0.18.0
+    "@justeattakeaway/pie-divider": 0.9.3
+    "@justeattakeaway/pie-form-label": 0.8.3
+    "@justeattakeaway/pie-icon-button": 0.23.0
+    "@justeattakeaway/pie-icons-webc": 0.12.0
+    "@justeattakeaway/pie-link": 0.11.3
+    "@justeattakeaway/pie-modal": 0.34.1
+    "@justeattakeaway/pie-notification": 0.1.3
+    "@justeattakeaway/pie-spinner": 0.3.1
+    "@justeattakeaway/pie-switch": 0.18.1
     "@storybook/addon-a11y": 7.5.1
     "@storybook/addon-designs": 7.0.5
     "@storybook/addon-essentials": 7.5.1
@@ -38015,7 +38015,7 @@ __metadata:
     "@angular/platform-browser": 15.2.0
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@types/jasmine": 4.3.0
     jasmine-core: 4.5.0
@@ -38042,7 +38042,7 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.21.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit/react": 1.0.2
     babel-loader: 8
@@ -38059,7 +38059,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit-labs/nextjs": 0.1.3
     "@lit/react": 1.0.2
@@ -38081,7 +38081,7 @@ __metadata:
     "@babel/plugin-transform-logical-assignment-operators": 7.22.11
     "@babel/plugin-transform-nullish-coalescing-operator": 7.22.11
     "@babel/plugin-transform-optional-chaining": 7.23.0
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     babel-loader: 8
     core-js: 3.30.0
@@ -38096,7 +38096,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@types/node": 18
     nuxt: 3.4.3
@@ -38108,7 +38108,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit/react": 1.0.2
     react: 17.0.2
@@ -38121,7 +38121,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@lit/react": 1.0.2
     react: 18.2.0
@@ -38135,11 +38135,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
-    "@justeattakeaway/pie-icon-button": 0.22.0
-    "@justeattakeaway/pie-icons-webc": 0.11.1
-    "@justeattakeaway/pie-modal": 0.34.0
+    "@justeattakeaway/pie-icon-button": 0.23.0
+    "@justeattakeaway/pie-icons-webc": 0.12.0
+    "@justeattakeaway/pie-modal": 0.34.1
     vite: 4.3.9
   languageName: unknown
   linkType: soft
@@ -38148,7 +38148,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.40.0
+    "@justeattakeaway/pie-button": 0.40.1
     "@justeattakeaway/pie-css": 0.8.0
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- the latest [release](https://github.com/justeattakeaway/pie/releases/tag/%40justeattakeaway%2Fpie-icons-react%404.12.0) of `pie-icons-react` throws the following error when it's installed.

![image](https://github.com/justeattakeaway/pie/assets/28605803/e25a6527-7186-41e6-a7ca-0a5cf7ec8436)

this is happening because `@justeattakeaway/pie-icons-configs` is a private package and should be listed as a dev dependency. 

- the fix is tested in pie-aperture locally (pr to follow) 🟢 

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
