### PR TITLE
fix(pie-icon-button): DSW-000 use the spinner brand variant for the primary disabled state

### DIFF
--- a/.changeset/honest-icons-rest.md
+++ b/.changeset/honest-icons-rest.md
@@ -1,0 +1,4 @@
+---
+"@justeattakeaway/pie-icon-button": minor
+---
+[Fixed] - The spinner of the disabled primary variant should use the spinner brand variant.

--- a/packages/components/pie-icon-button/src/index.ts
+++ b/packages/components/pie-icon-button/src/index.ts
@@ -38,11 +38,11 @@ export class PieIconButton extends LitElement implements IconButtonProps {
      * @private
      */
     private renderSpinner (): TemplateResult {
-        const { variant, size } = this;
+        const { variant, size, disabled } = this;
         const spinnerSize = size === 'xsmall' ? 'small' : 'medium';
         let spinnerVariant = 'brand';
         if (variant?.includes('secondary')) spinnerVariant = 'secondary';
-        if (variant === 'primary' || variant === 'ghost-inverse') spinnerVariant = 'inverse';
+        if ((variant === 'primary' && !disabled) || variant === 'ghost-inverse') spinnerVariant = 'inverse';
 
         return html`
                 <pie-spinner

--- a/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
+++ b/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
@@ -20,6 +20,7 @@ import { sizes, variants } from '@/defs';
 const props: PropObject = {
     size: sizes,
     variant: variants,
+    isLoading: [true, false],
     disabled: [true, false],
 };
 

--- a/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
+++ b/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
@@ -31,7 +31,7 @@ const props: PropObject = {
 const closeSVG = '<svg xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--close"><path d="M11.868 3.205 8 7.072 4.133 3.205l-.928.927L7.073 8l-3.868 3.867.928.928L8 8.927l3.868 3.868.927-.928L8.928 8l3.867-3.868-.927-.927Z"></path></svg>';
 
 // Renders a <pie-icon-button> HTML string with the given prop values
-const renderTestPieIconButton = (propVals: WebComponentPropValues) => `<pie-icon-button size="${propVals.size}" variant="${propVals.variant}" ${propVals.disabled ? 'disabled' : ''}>${closeSVG}</pie-icon-button>`;
+const renderTestPieIconButton = (propVals: WebComponentPropValues) => `<pie-icon-button size="${propVals.size}" variant="${propVals.variant}" ${propVals.disabled ? 'disabled' : ''} ${propVals.isLoading ? 'isLoading' : ''}>${closeSVG}</pie-icon-button>`;
 
 const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(props);
 const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
@@ -55,7 +55,7 @@ test.beforeEach(async ({ page, mount }) => {
 componentVariants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page, mount }) => {
     await Promise.all(componentPropsMatrixByVariant[variant].map(async (combo: WebComponentPropValues) => {
         const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieIconButton);
-        const propKeyValues = `size: ${testComponent.propValues.size}, disabled: ${testComponent.propValues.disabled}`;
+        const propKeyValues = `size: ${testComponent.propValues.size}, disabled: ${testComponent.propValues.disabled}, isLoading: ${testComponent.propValues.isLoading}`;
         const darkMode = variant.includes('inverse');
 
         await mount(


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- requested as part of the component design review

variant=primary, isLoading, disabled (before):
![Screenshot 2023-11-24 at 14 52 29](https://github.com/justeattakeaway/pie/assets/28605803/1e3daffc-ef59-4554-9612-36f45b636133)

After: 
<img width="177" alt="Screenshot 2023-11-24 at 14 52 44" src="https://github.com/justeattakeaway/pie/assets/28605803/d1743a6c-6044-4d35-ba21-bb88d81bd74c">




## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
