### PR TITLE
fix(pie-storybook): DSW-000 remove the content padding for modal stories

### DIFF
--- a/.changeset/real-crabs-battle.md
+++ b/.changeset/real-crabs-battle.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": patch
+---
+
+[Changed] - updated the modal story padding to match design example

--- a/apps/pie-storybook/stories/pie-modal.stories.ts
+++ b/apps/pie-storybook/stories/pie-modal.stories.ts
@@ -31,7 +31,7 @@ const defaultArgs: ModalProps = {
     isLoading: false,
     size: 'medium',
     position: 'center',
-    slot: '<p>Body copy</p>',
+    slot: '<p style="margin:0">Body copy</p>',
     leadingAction: {
         text: 'Confirm',
         variant: 'primary',


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- requested during the design review, the body copy text should not have any margin to match designs example.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
