### PR TITLE
ci(pie-monorepo): DSW-000 fix env var in teardown action

### DIFF
--- a/.github/actions/amplify-teardown/action.yml
+++ b/.github/actions/amplify-teardown/action.yml
@@ -2,6 +2,9 @@ name: enivronment-teardown
 description: Teardown preview after merge
 
 inputs:
+  github-token:
+    description: 'The GitHub token for the account that hosts your app'
+    required: true
   amplify-app-id:
     description: 'The ID for your app which you can get from the end of its ARN'
     required: true
@@ -26,8 +29,6 @@ runs:
   steps:
   - name: Delete associated GitHub environment
     uses: actions/github-script@v6
-    env:
-      GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
     with:
       script: |
         const owner = context.repo.owner;
@@ -44,6 +45,8 @@ runs:
         } catch (err) {
           console.log(`Failed to delete environment ${envName} with error: ${err}`);
         }
+    env:
+      GITHUB_TOKEN: ${{ inputs.github-token }}
 
   - name: Delete Amplify branch
     shell: bash

--- a/.github/workflows/closed.yml
+++ b/.github/workflows/closed.yml
@@ -43,7 +43,7 @@ jobs:
             core.setOutput('hasStorybookEnv', hasStorybookEnv);
 
       - name: Delete associated docs environments
-        if: steps.list-environments.outputs.hasDocsEnv == true
+        if: steps.list-environments.outputs.hasDocsEnv == 'true'
         uses: ./.github/actions/amplify-teardown
         with:
           amplify-app-id: dvskdcoepjoyf
@@ -54,7 +54,7 @@ jobs:
           branch-name: 'pr${{ github.event.number }}'
 
       - name: Delete associated storybook environment
-        if: steps.list-environments.outputs.hasStorybookEnv == true
+        if: steps.list-environments.outputs.hasStorybookEnv == 'true'
         uses: ./.github/actions/amplify-teardown
         with:
           amplify-app-id: d17ja0ul7nrdy0

--- a/.github/workflows/closed.yml
+++ b/.github/workflows/closed.yml
@@ -46,6 +46,7 @@ jobs:
         if: steps.list-environments.outputs.hasDocsEnv == 'true'
         uses: ./.github/actions/amplify-teardown
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           amplify-app-id: dvskdcoepjoyf
           aws-region: 'eu-west-1'
           aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
@@ -57,6 +58,7 @@ jobs:
         if: steps.list-environments.outputs.hasStorybookEnv == 'true'
         uses: ./.github/actions/amplify-teardown
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           amplify-app-id: d17ja0ul7nrdy0
           aws-region: 'eu-west-1'
           aws-access-key-id: ${{ secrets.AWS_KEY_ID }}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Composite Actions don't have access to secrets; this is by design to make actions more secure.

To solve this issue, we simply need to pass the secret as an input to the action.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
