### PR TITLE
ci(pie-monorepo): DSW-000 remove 'ref' property so environment gets deleted, rather than last deploy

### DIFF
--- a/.github/actions/amplify-teardown/action.yml
+++ b/.github/actions/amplify-teardown/action.yml
@@ -32,7 +32,6 @@ runs:
     with:
       token: ${{ inputs.github-token }}
       environment: ${{ inputs.environment-name }}
-      ref: ${{ github.ref_name }}
 
   - name: Delete Amplify branch
     shell: bash


### PR DESCRIPTION
The last PR works as expected, however only the deploys were getting deleted, not the environment:


As per the docs, this will remove the env from the 'environments' tab:

https://github.com/strumwolf/delete-deployment-environment?tab=readme-ov-file#deactives-and-removes-deployment-environment-also-from-settings

## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
