### PR TITLE
fix(pie-components-config): DSW-000 fixed generator for components outside of pie-monorepo

### DIFF
--- a/.changeset/blue-mayflies-collect.md
+++ b/.changeset/blue-mayflies-collect.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-components-config": minor
+---
+
+[Removed] - `private` property in package.json so components can be generated outside of PIE

--- a/configs/pie-components-config/package.json
+++ b/configs/pie-components-config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@justeattakeaway/pie-components-config",
   "version": "0.6.1",
-  "private": true,
   "main": "index.js",
   "type": "module",
   "description": "Shared configuration files for PIE components",


### PR DESCRIPTION
This PR fixes an issue where the `pie-components-config` dependency couldn't be resolved for components that are generated outside of the pie-monorepo