### PR TITLE
feat(pie-switch): DSW-1571 rename isDisabled prop to disabled

### DIFF
--- a/.changeset/dirty-tables-press.md
+++ b/.changeset/dirty-tables-press.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-switch": minor
+"@justeattakeaway/pie-cookie-banner": patch
+"pie-storybook": patch
+"pie-docs": patch
+---
+
+[Changed] - Rename `isDisabled` pie-switch prop to `disabled` to align with native attribute

--- a/.changeset/late-fishes-pretend.md
+++ b/.changeset/late-fishes-pretend.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-wrapper-react": patch
+---
+
+[Fixed] - Trailing whitespace linting error

--- a/apps/pie-docs/src/components/switch/code/props.json
+++ b/apps/pie-docs/src/components/switch/code/props.json
@@ -14,12 +14,24 @@
             }
         ],
         [
-            "isDisabled",
+            "disabled",
             {
                 "type": "code",
                 "item": ["true", "false"]
             },
             "Same as the HTML disabled attribute - indicates whether the switch is disabled or not.",
+            {
+                "type": "code",
+                "item": ["false"]
+            }
+        ],
+        [
+            "required",
+            {
+                "type": "code",
+                "item": ["true", "false"]
+            },
+            "Same as the HTML required attribute - indicates whether the switch must be turned or not.",
             {
                 "type": "code",
                 "item": ["false"]

--- a/apps/pie-storybook/stories/pie-switch.stories.ts
+++ b/apps/pie-storybook/stories/pie-switch.stories.ts
@@ -14,7 +14,7 @@ type SwitchStoryMeta = StoryMeta<SwitchProps>;
 
 const defaultArgs: SwitchProps = {
     checked: false,
-    isDisabled: false,
+    disabled: false,
     label: 'Label',
     labelPlacement: 'leading',
     aria: {
@@ -37,7 +37,7 @@ const switchStoryMeta: SwitchStoryMeta = {
                 summary: false,
             },
         },
-        isDisabled: {
+        disabled: {
             description: 'Same as the HTML disabled attribute - indicates whether the switch is disabled or not',
             control: 'boolean',
             defaultValue: {
@@ -111,7 +111,7 @@ const Template : TemplateFunction<SwitchProps> = (props) => {
     const {
         aria,
         checked,
-        isDisabled,
+        disabled,
         label,
         labelPlacement,
         name,
@@ -129,7 +129,7 @@ const Template : TemplateFunction<SwitchProps> = (props) => {
             .aria="${aria}"
             ?required="${required}"
             ?checked="${checked}"
-            ?isDisabled="${isDisabled}"
+            ?disabled="${disabled}"
             @change="${changeAction}">
         </pie-switch>`;
 };

--- a/packages/components/pie-cookie-banner/src/defs.ts
+++ b/packages/components/pie-cookie-banner/src/defs.ts
@@ -86,8 +86,8 @@ export type PreferenceIds = 'all' | 'necessary' | 'functional' | 'analytical' | 
 
 export interface Preference {
     id: PreferenceIds;
-    isDisabled?: boolean;
     checked?: boolean;
+    disabled?: boolean;
     hasDivider?: boolean;
     hasDescription?: boolean;
 }
@@ -100,8 +100,8 @@ export const preferences: Preference[] = [
     },
     {
         id: 'necessary',
-        isDisabled: true,
         checked: true,
+        disabled: true,
         hasDescription: true,
     },
     {

--- a/packages/components/pie-cookie-banner/src/index.ts
+++ b/packages/components/pie-cookie-banner/src/index.ts
@@ -171,7 +171,7 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
         if (id === toggleAllNode.id) {
             const { checked } = e.target as HTMLInputElement;
             this._preferencesNodes.forEach((node) => {
-                node.checked = node.isDisabled ? node.checked : checked;
+                node.checked = node.disabled ? node.checked : checked;
             });
         } else {
             toggleAllNode.checked = [...this._preferencesNodes]
@@ -185,7 +185,7 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
      * @private
      */
     private renderPreference ({
-        id, checked, isDisabled, hasDivider, hasDescription,
+        id, checked, disabled, hasDivider, hasDescription,
     }: Preference): TemplateResult {
         const title = this._localiseText(`preferencesManagement.${id}.title`);
         const descriptionLocaleKey = `preferencesManagement.${id}.description`;
@@ -201,7 +201,7 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
                 <pie-switch
                     id="${id}"
                     ?checked="${checked}"
-                    ?isDisabled="${isDisabled}"
+                    ?disabled="${disabled}"
                     @change="${this._handleSwitchStates}">
                 </pie-switch>
             </div>

--- a/packages/components/pie-cookie-banner/test/component/pie-cookie-banner.spec.ts
+++ b/packages/components/pie-cookie-banner/test/component/pie-cookie-banner.spec.ts
@@ -208,7 +208,7 @@ test.describe('PieCookieBanner - Component tests', () => {
         await page.click(managePreferencesSelector);
         // eslint-disable-next-line no-restricted-syntax
         for (const preference of preferences) { // turn on all preferences
-            if (preference.id !== 'all' && !preference.isDisabled) {
+            if (preference.id !== 'all' && !preference.disabled) {
                 // eslint-disable-next-line no-await-in-loop
                 await page.click(getPreferenceItemSelector(preference.id));
             }

--- a/packages/components/pie-switch/src/defs.ts
+++ b/packages/components/pie-switch/src/defs.ts
@@ -21,9 +21,9 @@ export interface SwitchProps {
      */
     required: boolean;
     /**
-     * Same as the HTML disabled attribute - indicates whether the switch disabled or not
+     * Same as the HTML disabled attribute - indicates whether the switch is disabled or not
      */
-    isDisabled?: boolean;
+    disabled?: boolean;
     /**
      * The label value of the component
      */

--- a/packages/components/pie-switch/src/index.ts
+++ b/packages/components/pie-switch/src/index.ts
@@ -73,7 +73,7 @@ export class PieSwitch extends RtlMixin(LitElement) implements SwitchProps {
     public name?: string;
 
     @property({ type: Boolean, reflect: true })
-    public isDisabled = false;
+    public disabled = false;
 
     static styles = unsafeCSS(styles);
 
@@ -83,7 +83,7 @@ export class PieSwitch extends RtlMixin(LitElement) implements SwitchProps {
     private handleFormAssociation () : void {
         const isFormAssociated = !!this._internals.form && !!this.name && !!this.value;
         if (isFormAssociated) {
-            if (this.isDisabled) {
+            if (this.disabled) {
                 this._internals.setFormValue(null);
                 this._internals.setValidity({});
             } else if (this.checked) {
@@ -186,7 +186,7 @@ export class PieSwitch extends RtlMixin(LitElement) implements SwitchProps {
             aria,
             checked,
             required,
-            isDisabled,
+            disabled,
             isRTL,
         } = this;
 
@@ -196,7 +196,7 @@ export class PieSwitch extends RtlMixin(LitElement) implements SwitchProps {
             <div
                 class="c-switch-wrapper"
                 ?isRTL=${isRTL}
-                ?isDisabled=${isDisabled}>
+                ?disabled=${disabled}>
                 ${labelPlacement === 'leading' ? this.renderSwitchLabel() : nothing}
                 <label
                     data-test-id="switch-component"
@@ -210,7 +210,7 @@ export class PieSwitch extends RtlMixin(LitElement) implements SwitchProps {
                         class="c-switch-input"
                         .required=${required}
                         .checked="${checked}"
-                        .disabled="${isDisabled}"
+                        .disabled="${disabled}"
                         @change="${this.onChange}"
                         aria-label="${aria?.label || nothing}"
                         aria-describedby="${aria?.describedBy ? switchId : nothing}">

--- a/packages/components/pie-switch/src/switch.scss
+++ b/packages/components/pie-switch/src/switch.scss
@@ -20,7 +20,7 @@
     font-family: var(--dt-font-body-l-family);
     cursor: pointer;
 
-    &[isDisabled] {
+    &[disabled] {
         cursor: not-allowed;
     }
 }
@@ -78,7 +78,7 @@
         }
     }
 
-    [isDisabled] & {
+    [disabled] & {
         background-color: var(--switch-bg-color--disabled);
         pointer-events: none;
     }

--- a/packages/components/pie-switch/test/component/pie-switch.spec.ts
+++ b/packages/components/pie-switch/test/component/pie-switch.spec.ts
@@ -17,7 +17,7 @@ test.describe('Component: `Pie switch`', () => {
         await mount(PieSwitch, {
             props: {
                 checked: false,
-                isDisabled: false,
+                disabled: false,
             },
         });
 
@@ -39,7 +39,7 @@ test.describe('Component: `Pie switch`', () => {
         expect(pieSwitchComponent).toBe(false);
     });
 
-    test('should set `isDisabled` to `false` by default', async ({ mount }) => {
+    test('should set `disabled` to `false` by default', async ({ mount }) => {
         // Arrange
         const component = await mount(PieSwitch);
 

--- a/packages/components/pie-switch/test/visual/pie-switch.spec.ts
+++ b/packages/components/pie-switch/test/visual/pie-switch.spec.ts
@@ -8,16 +8,16 @@ import { SwitchProps, labelPlacements } from '@/defs';
     [false, true],
     [true, false],
     [true, true],
-].forEach(([checked, isDisabled]) => {
-    test(`should render correctly with checked = ${checked} and isDisabled = ${isDisabled}`, async ({ page, mount }) => {
+].forEach(([checked, disabled]) => {
+    test(`should render correctly with checked = ${checked} and disabled = ${disabled}`, async ({ page, mount }) => {
         await mount(PieSwitch, {
             props: {
                 checked,
-                isDisabled,
+                disabled,
             },
         });
 
-        await percySnapshot(page, `Switch - checked = ${checked} and isDisabled = ${isDisabled}`);
+        await percySnapshot(page, `Switch - checked = ${checked} and disabled = ${disabled}`);
     });
 });
 

--- a/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
+++ b/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
@@ -94,7 +94,7 @@ export function addReactWrapper (customElementsObject, folderName = process.argv
             let eventNames = '';
             if (component.class.events && component.class.events.length > 0) {
                 eventNames = events?.flat().reduce((pre, event) => `${pre
-                    }        ${`on${formatEventName(event.name)}`}: '${event.name}' as EventName<${event.type}>, ${event.description ? `// ${event.description}` : ''}\n`, '');
+                    }        ${`on${formatEventName(event.name)}`}: '${event.name}' as EventName<${event.type}>,${event.description ? ` // ${event.description}` : ''}\n`, '');
             }
 
             let eventsObject = '{}';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5543,7 +5543,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.12.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.13.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
@@ -5554,7 +5554,7 @@ __metadata:
     "@justeattakeaway/pie-icon-button": 0.24.3
     "@justeattakeaway/pie-link": 0.11.3
     "@justeattakeaway/pie-modal": 0.35.5
-    "@justeattakeaway/pie-switch": 0.19.0
+    "@justeattakeaway/pie-switch": 0.20.0
     "@justeattakeaway/pie-webc-core": 0.13.0
   languageName: unknown
   linkType: soft
@@ -5748,7 +5748,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-switch@0.19.0, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
+"@justeattakeaway/pie-switch@0.20.0, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
@@ -28993,7 +28993,7 @@ __metadata:
     "@justeat/pie-design-tokens": 5.9.0
     "@justeattakeaway/pie-button": 0.41.0
     "@justeattakeaway/pie-card": 0.14.3
-    "@justeattakeaway/pie-cookie-banner": 0.12.0
+    "@justeattakeaway/pie-cookie-banner": 0.13.0
     "@justeattakeaway/pie-css": 0.9.0
     "@justeattakeaway/pie-divider": 0.9.3
     "@justeattakeaway/pie-form-label": 0.8.3
@@ -29003,7 +29003,7 @@ __metadata:
     "@justeattakeaway/pie-modal": 0.35.5
     "@justeattakeaway/pie-notification": 0.1.3
     "@justeattakeaway/pie-spinner": 0.3.1
-    "@justeattakeaway/pie-switch": 0.19.0
+    "@justeattakeaway/pie-switch": 0.20.0
     "@justeattakeaway/pie-tag": 0.1.0
     "@storybook/addon-a11y": 7.6.3
     "@storybook/addon-designs": 7.0.7
@@ -38016,7 +38016,7 @@ __metadata:
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
     "@justeattakeaway/pie-button": 0.41.0
-    "@justeattakeaway/pie-cookie-banner": 0.12.0
+    "@justeattakeaway/pie-cookie-banner": 0.13.0
     "@justeattakeaway/pie-css": 0.9.0
     "@lit/react": 1.0.2
     babel-loader: 8


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- [Changed] - Rename `isDisabled` pie-switch prop to `disabled` to align with native attribute
- [Fixed] - Trailing whitespace linting error from react wrapper

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [x] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If it is a component change, I have reviewed the Storybook preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
