### PR TITLE
test(pie-switch): DSW-1556 add test to prevent accessibility regression

### DIFF
--- a/packages/components/pie-switch/test/component/pie-switch.spec.ts
+++ b/packages/components/pie-switch/test/component/pie-switch.spec.ts
@@ -28,6 +28,17 @@ test.describe('Component: `Pie switch`', () => {
         await expect(pieSwitch).toBeVisible();
     });
 
+    test('should have a "visible" input to help with accessibility', async ({ mount, page }) => {
+        // Arrange
+        await mount(PieSwitch);
+
+        // Act
+        const input = page.locator(inputSelector);
+
+        // Assert
+        await expect(input).toBeVisible();
+    });
+
     test('should set `checked` to `false` by default', async ({ mount }) => {
         // Arrange
         const component = await mount(PieSwitch);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

There was an issue where the switch component wasn't being announced properly by NVDA. I discovered that the styling changes that @jamieomaguire and I made as part of #1103 fixed the issue, so this PR adds a test which covers the key part of those changes to prevent a regression.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
