### PR TITLE
fix(pie-icons-webc): DSW-1539 icon display and size override variables

### DIFF
--- a/.changeset/chilled-snails-cry.md
+++ b/.changeset/chilled-snails-cry.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icon-button": patch
+---
+
+[Changed] - `--btn-icon-display`, `--btn-icon-size` and `--btn-icon-size-default` to `--icon-display-override` and `--icon-size-override` variables

--- a/.changeset/fluffy-dolls-flash.md
+++ b/.changeset/fluffy-dolls-flash.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-webc": patch
+---
+
+[Changed] - `--btn-icon-size` and `--btn-icon-display` to `--icon-display-override` and `--icon-size-override` variable for display, width and height icon styles for `:host svg`

--- a/.changeset/hip-files-wash.md
+++ b/.changeset/hip-files-wash.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": patch
+---
+
+[Changed] - `--btn-icon-display` and `--btn-icon-size` to `--icon-display-override` and `--icon-size-override` variables

--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -38,7 +38,7 @@ $breakpoint-wide: 768px;
     --btn-height--small: 40px;
     --btn-height--medium: 48px;
     --btn-height--large: 56px;
-    --btn-icon-display: block;
+    --icon-display-override: block;
 
     /**
     * Mixin for updating the button styles based on the size passed in.
@@ -50,31 +50,31 @@ $breakpoint-wide: 768px;
             --btn-padding: 6px var(--dt-spacing-b);
             --btn-font-size: #{p.font-size(--dt-font-size-14)};
             --btn-line-height: calc(var(--dt-font-size-14-line-height) * 1px);
-            --btn-icon-size: 16px;
+            --icon-size-override: 16px;
         } @else if $size == 'small-expressive' {
             --btn-height: var(--btn-height--small);
             --btn-padding: 6px var(--dt-spacing-d);
             --btn-font-size: #{p.font-size(--dt-font-size-20)};
             --btn-line-height: calc(var(--dt-font-size-20-line-height) * 1px);
-            --btn-icon-size: 20px;
+            --icon-size-override: 20px;
         } @else if $size == 'small-productive' {
             --btn-height: var(--btn-height--small);
             --btn-padding: 8px var(--dt-spacing-d);
             --btn-font-size: #{p.font-size(--dt-font-size-16)};
             --btn-line-height: calc(var(--dt-font-size-16-line-height) * 1px);
-            --btn-icon-size: 20px;
+            --icon-size-override: 20px;
         } @else if $size == 'medium' {
             --btn-height: var(--btn-height--medium);
             --btn-padding: 10px var(--dt-spacing-e);
             --btn-font-size: #{p.font-size(--dt-font-size-20)};
             --btn-line-height: calc(var(--dt-font-size-20-line-height) * 1px);
-            --btn-icon-size: 24px;
+            --icon-size-override: 24px;
         } @else if $size == 'large' {
             --btn-height: var(--btn-height--large);
             --btn-padding: 14px var(--dt-spacing-e);
             --btn-font-size: #{p.font-size(--dt-font-size-20)};
             --btn-line-height: calc(var(--dt-font-size-20-line-height) * 1px);
-            --btn-icon-size: 24px;
+            --icon-size-override: 24px;
         }
     }
 
@@ -255,6 +255,6 @@ $breakpoint-wide: 768px;
 
 // Used to size an SVG if one is passed in (when not using the component icons)
 ::slotted(svg) {
-    height: var(--btn-icon-size);
-    width: var(--btn-icon-size);
+    height: var(--icon-size-override);
+    width: var(--icon-size-override);
 }

--- a/packages/components/pie-icon-button/src/iconButton.scss
+++ b/packages/components/pie-icon-button/src/iconButton.scss
@@ -6,7 +6,7 @@
     --btn-dimension-default: 48px;
 
     // Sizing is set to Medium button icon size, as that is the default
-    --btn-icon-size-default: 24px;
+    --icon-size-override: 24px;
 }
 
 // Base button styles
@@ -14,7 +14,7 @@
     --btn-border-radius: var(--dt-radius-rounded-e);
     --btn-bg-color: var(--dt-color-interactive-brand);
     --btn-icon-fill: var(--dt-color-content-interactive-primary);
-    --btn-icon-display: block;
+    --icon-display-override: block;
 
     block-size: var(--btn-dimension, var(--btn-dimension-default));
     inline-size: var(--btn-dimension, var(--btn-dimension-default));
@@ -37,8 +37,8 @@
     }
 
     svg {
-        height: var(--btn-icon-size, var(--btn-icon-size-default));
-        width: var(--btn-icon-size, var(--btn-icon-size-default));
+        height: var(--icon-size-override);
+        width: var(--icon-size-override);
     }
 
     &[variant='primary'] {
@@ -109,7 +109,7 @@
 
     &[size='xsmall'] {
         --btn-dimension: 32px;
-        --btn-icon-size: 20px;
+        --icon-size-override: 20px;
     }
 
     &[size='small'] {
@@ -122,7 +122,7 @@
 
     &[size='large'] {
         --btn-dimension: 56px;
-        --btn-icon-size: 28px;
+        --icon-size-override: 28px;
     }
 }
 

--- a/packages/tools/pie-icons-webc/build.js
+++ b/packages/tools/pie-icons-webc/build.js
@@ -39,9 +39,9 @@ export class ${name} extends LitElement implements IconProps {
     // The following styles make sure that the icon will be sized correctly
     static styles = css\`
         :host svg {
-            display: var(--btn-icon-display, inline);
-            width: var(--btn-icon-size, 24px);
-            height: var(--btn-icon-size, 24px);
+            display: var(--icon-display-override);
+            width: var(--icon-size-override);
+            height: var(--icon-size-override);
         }
     \`;
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

---
"@justeattakeaway/pie-icons-webc": patch
---

[Changed] - `--btn-icon-size` and `--btn-icon-display` to `--icon-display-override` and `--icon-size-override` variable for display, width and height icon styles for `:host svg`

---
"@justeattakeaway/pie-button": patch
---

[Changed] - `--btn-icon-display` and `--btn-icon-size` to `--icon-display-override` and `--icon-size-override` variables

---
"@justeattakeaway/pie-icon-button": patch
---

[Changed] - `--btn-icon-display` and `--btn-icon-size` to `--icon-display-override` and `--icon-size-override` variables

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If it is a component change, I have reviewed the Storybook preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
