### PR TITLE
fix(pie-button): DSW-1606 button mount readded to visual tests

### DIFF
--- a/.changeset/tender-mugs-lie.md
+++ b/.changeset/tender-mugs-lie.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": patch
+---
+
+[Fixed] - Button mount re-added to visual tests to fix visual regressions

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -13,6 +13,7 @@ import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
+import { PieButton } from '@/index';
 import { sizes, variants, iconPlacements } from '@/defs';
 
 const props: PropObject = {
@@ -38,8 +39,21 @@ const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(p
 const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
 const componentVariants: string[] = Object.keys(componentPropsMatrixByVariant);
 
-// eslint-disable-next-line no-empty-pattern
-test.beforeEach(async ({ }, testInfo) => {
+// This ensures the component is registered in the DOM for each test
+// This is not required if your tests mount the web component directly in the tests
+test.beforeEach(async ({ page, mount }, testInfo) => {
+    await mount(
+        PieButton,
+        {},
+    );
+
+    // Removing the element so it's not present in the tests (but is still registered in the DOM)
+    await page.evaluate(() => {
+        const element : Element | null = document.querySelector('pie-button');
+        element?.remove();
+    });
+
+    // extend timeout for button tests to run
     testInfo.setTimeout(testInfo.timeout + 40000);
 });
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] - Button mount re-added to visual tests to fix visual regressions

## Author Checklist
- [x] I have performed a self-review of my code
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
