### PR TITLE
feat(pie-input): DSW-1582 add a value property to input

### DIFF
--- a/.changeset/modern-bees-visit.md
+++ b/.changeset/modern-bees-visit.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-input": minor
+---
+
+[Added] - `value` property to input component

--- a/.changeset/tricky-walls-perform.md
+++ b/.changeset/tricky-walls-perform.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - value prop to pie-input stories

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -51,7 +51,7 @@ const inputStoryMeta: InputStoryMeta = {
 const Template = ({ type, value }: InputProps) => {
     const [, updateArgs] = UseArgs();
 
-    function onPieInput (event: CustomEvent) {
+    function onInput (event: CustomEvent) {
         updateArgs({ value: event.detail.value });
 
         action(PIE_INPUT_EVENT)({
@@ -63,7 +63,7 @@ const Template = ({ type, value }: InputProps) => {
     <pie-input
         type="${ifDefined(type)}"
         .value="${value}"
-        @pie-input="${onPieInput}"></pie-input>
+        @input="${onInput}"></pie-input>
     `;
 };
 

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -1,9 +1,11 @@
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { action } from '@storybook/addon-actions';
+import { useArgs as UseArgs } from '@storybook/preview-api';
 
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-input';
-import { types, InputProps } from '@justeattakeaway/pie-input';
+import { types, InputProps, PIE_INPUT_EVENT } from '@justeattakeaway/pie-input';
 /* eslint-enable import/no-duplicates */
 
 import { type StoryMeta } from '../types';
@@ -14,6 +16,7 @@ type InputStoryMeta = StoryMeta<InputProps>;
 
 const defaultArgs: InputProps = {
     type: 'text',
+    value: '',
 };
 
 const inputStoryMeta: InputStoryMeta = {
@@ -28,6 +31,13 @@ const inputStoryMeta: InputStoryMeta = {
                 summary: 'text',
             },
         },
+        value: {
+            description: 'The value of the input.',
+            control: 'text',
+            defaultValue: {
+                summary: 'value',
+            },
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -38,11 +48,24 @@ const inputStoryMeta: InputStoryMeta = {
     },
 };
 
-export default inputStoryMeta;
+const Template = ({ type, value }: InputProps) => {
+    const [, updateArgs] = UseArgs();
 
-const Template = ({ type }: InputProps) => html`
-    <pie-input type=${ifDefined(type)}></pie-input>
-`;
+    function onPieInput (event: CustomEvent) {
+        updateArgs({ value: event.detail.value });
+
+        action(PIE_INPUT_EVENT)({
+            ...event.detail,
+        });
+    }
+
+    return html`
+    <pie-input
+        type="${ifDefined(type)}"
+        .value="${value}"
+        @pie-input="${onPieInput}"></pie-input>
+    `;
+};
 
 const FormTemplate: TemplateFunction<InputProps> = (props: InputProps) => html`
 <h2>Fake form</h2>
@@ -88,3 +111,5 @@ const createInputStoryWithForm = createStory<InputProps>(FormTemplate, defaultAr
 
 export const Default = createStory<InputProps>(Template, defaultArgs)();
 export const FormIntegration = createInputStoryWithForm();
+
+export default inputStoryMeta;

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -5,7 +5,7 @@ import { useArgs as UseArgs } from '@storybook/preview-api';
 
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-input';
-import { types, InputProps, PIE_INPUT_EVENT } from '@justeattakeaway/pie-input';
+import { types, InputProps } from '@justeattakeaway/pie-input';
 /* eslint-enable import/no-duplicates */
 
 import { type StoryMeta } from '../types';
@@ -54,7 +54,7 @@ const Template = ({ type, value }: InputProps) => {
     function onInput (event: CustomEvent) {
         updateArgs({ value: event.detail.value });
 
-        action(PIE_INPUT_EVENT)({
+        action('input')({
             ...event.detail,
         });
     }

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -51,11 +51,13 @@ const inputStoryMeta: InputStoryMeta = {
 const Template = ({ type, value }: InputProps) => {
     const [, updateArgs] = UseArgs();
 
-    function onInput (event: CustomEvent) {
-        updateArgs({ value: event.detail.value });
+    function onInput (event: InputEvent) {
+        const inputElement = event.target as HTMLInputElement;
+        updateArgs({ value: inputElement?.value });
 
         action('input')({
-            ...event.detail,
+            data: event.data,
+            value: inputElement.value,
         });
     }
 

--- a/packages/components/pie-input/custom-elements.json
+++ b/packages/components/pie-input/custom-elements.json
@@ -98,10 +98,10 @@
                     "events": [
                         {
                             "type": {
-                                "text": "CustomEvent"
+                                "text": "InputEvent"
                             },
                             "description": "when the input value is changed.",
-                            "name": "pie-input"
+                            "name": "input"
                         }
                     ],
                     "attributes": [

--- a/packages/components/pie-input/custom-elements.json
+++ b/packages/components/pie-input/custom-elements.json
@@ -13,6 +13,15 @@
                         "text": "['text', 'number', 'password', 'search', 'url', 'email', 'tel']"
                     },
                     "default": "['text', 'number', 'password', 'search', 'url', 'email', 'tel']"
+                },
+                {
+                    "kind": "variable",
+                    "name": "PIE_INPUT_EVENT",
+                    "type": {
+                        "text": "string"
+                    },
+                    "default": "'pie-input'",
+                    "description": "Event name for when when the input value is changed"
                 }
             ],
             "exports": [
@@ -21,6 +30,14 @@
                     "name": "types",
                     "declaration": {
                         "name": "types",
+                        "module": "src/defs.js"
+                    }
+                },
+                {
+                    "kind": "js",
+                    "name": "PIE_INPUT_EVENT",
+                    "declaration": {
+                        "name": "PIE_INPUT_EVENT",
                         "module": "src/defs.js"
                     }
                 }
@@ -54,6 +71,37 @@
                             "default": "'text'",
                             "attribute": "type",
                             "reflects": true
+                        },
+                        {
+                            "kind": "field",
+                            "name": "value",
+                            "type": {
+                                "text": "string"
+                            },
+                            "privacy": "public",
+                            "default": "''",
+                            "attribute": "value"
+                        },
+                        {
+                            "kind": "field",
+                            "name": "handleInput",
+                            "privacy": "private",
+                            "description": "Handles the input event and dispatches a custom event with the input event data and input value.",
+                            "parameters": [
+                                {
+                                    "description": "The input event.",
+                                    "name": "event"
+                                }
+                            ]
+                        }
+                    ],
+                    "events": [
+                        {
+                            "type": {
+                                "text": "CustomEvent"
+                            },
+                            "description": "when the input value is changed.",
+                            "name": "pie-input"
                         }
                     ],
                     "attributes": [
@@ -64,9 +112,21 @@
                             },
                             "default": "'text'",
                             "fieldName": "type"
+                        },
+                        {
+                            "name": "value",
+                            "type": {
+                                "text": "string"
+                            },
+                            "default": "''",
+                            "fieldName": "value"
                         }
                     ],
                     "mixins": [
+                        {
+                            "name": "FormControlMixin",
+                            "package": "@justeattakeaway/pie-webc-core"
+                        },
                         {
                             "name": "RtlMixin",
                             "package": "@justeattakeaway/pie-webc-core"

--- a/packages/components/pie-input/src/defs.ts
+++ b/packages/components/pie-input/src/defs.ts
@@ -5,4 +5,16 @@ export interface InputProps {
      * The type of HTML input to render.
      */
     type?: typeof types[number];
+
+    /**
+     * The value of the input.
+     */
+    value: string;
 }
+
+/**
+ * Event name for when when the input value is changed
+ * @constant
+ */
+
+export const PIE_INPUT_EVENT = 'pie-input';

--- a/packages/components/pie-input/src/defs.ts
+++ b/packages/components/pie-input/src/defs.ts
@@ -11,10 +11,3 @@ export interface InputProps {
      */
     value: string;
 }
-
-/**
- * Event name for when when the input value is changed
- * @constant
- */
-
-export const PIE_INPUT_EVENT = 'pie-input';

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@justeattakeaway/pie-webc-core';
 
 import styles from './input.scss?inline';
-import { types, InputProps, PIE_INPUT_EVENT } from './defs';
+import { types, InputProps } from './defs';
 
 // Valid values available to consumers
 export * from './defs';
@@ -17,7 +17,7 @@ const componentSelector = 'pie-input';
 
 /**
  * @tagname pie-input
- * @event {CustomEvent} pie-input - when the input value is changed.
+ * @event {InputEvent} input - when the input value is changed.
  */
 export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements InputProps {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
@@ -30,23 +30,11 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
     public value = '';
 
     /**
-     * Handles the input event and dispatches a custom event with the input event data and input value.
+     * Handles data processing in response to the input event. The native input event is left to bubble up.
      * @param event - The input event.
      */
     private handleInput = (event: InputEvent) => {
         this.value = (event.target as HTMLInputElement).value;
-
-        this.dispatchEvent(new CustomEvent(
-            PIE_INPUT_EVENT,
-            {
-                detail: {
-                    data: event.data,
-                    value: this.value,
-                },
-                bubbles: true,
-                composed: true,
-            },
-        ));
     };
 
     render () {

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -1,13 +1,14 @@
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { live } from 'lit/directives/live.js';
 
 import {
     validPropertyValues, RtlMixin, defineCustomElement, FormControlMixin,
 } from '@justeattakeaway/pie-webc-core';
 
 import styles from './input.scss?inline';
-import { types, InputProps } from './defs';
+import { types, InputProps, PIE_INPUT_EVENT } from './defs';
 
 // Valid values available to consumers
 export * from './defs';
@@ -16,6 +17,7 @@ const componentSelector = 'pie-input';
 
 /**
  * @tagname pie-input
+ * @event {CustomEvent} pie-input - when the input value is changed.
  */
 export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements InputProps {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
@@ -24,11 +26,36 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
     @validPropertyValues(componentSelector, types, 'text')
     public type: InputProps['type'] = 'text';
 
+    @property({ type: String })
+    public value = '';
+
+    /**
+     * Handles the input event and dispatches a custom event with the input event data and input value.
+     * @param event - The input event.
+     */
+    private handleInput = (event: InputEvent) => {
+        this.value = (event.target as HTMLInputElement).value;
+
+        this.dispatchEvent(new CustomEvent(
+            PIE_INPUT_EVENT,
+            {
+                detail: {
+                    data: event.data,
+                    value: this.value,
+                },
+                bubbles: true,
+                composed: true,
+            },
+        ));
+    };
+
     render () {
-        const { type } = this;
+        const { type, value } = this;
 
         return html`<input
             type=${ifDefined(type)}
+            .value=${live(value)}
+            @input=${this.handleInput}
             data-test-id="pie-input">`;
     }
 

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -82,7 +82,6 @@ test.describe('PieInput - Component tests', () => {
 
             test('should emit a custom event with the input event data and input value', async ({ mount, page }) => {
                 // Arrange
-
                 const messages: PieInputEvent[] = [];
                 const expectedMessages = [
                     { data: 't', value: 't' },

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -46,5 +46,70 @@ test.describe('PieInput - Component tests', () => {
                 expect(input).toHaveAttribute('type', 'number');
             });
         });
+
+        test.describe('value', () => {
+            test('should default to an empty string if no value prop provided', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {});
+
+                // Act
+                const input = component.locator('input');
+
+                // Assert
+                expect((await input.inputValue())).toBe('');
+            });
+
+            test('should apply the value prop to the HTML input rendered', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {
+                    props: {
+                        value: 'test',
+                    } as InputProps,
+                });
+
+                // Act
+                const input = component.locator('input');
+
+                // Assert
+                expect((await input.inputValue())).toBe('test');
+            });
+        });
+    });
+
+    test.describe('Events', () => {
+        test.describe('pie-input', () => {
+            type PieInputEvent = CustomEvent<{ data: string, value: string }>;
+
+            test('should emit a custom event with the input event data and input value', async ({ mount, page }) => {
+                // Arrange
+
+                const messages: PieInputEvent[] = [];
+                const expectedMessages = [
+                    { data: 't', value: 't' },
+                    { data: 'e', value: 'te' },
+                    { data: 's', value: 'tes' },
+                    { data: 't', value: 'test' },
+                    { data: null, value: 'tes' }
+                ];
+
+                const component = await mount(PieInput, {
+                    props: {} as InputProps,
+                    on: {
+                        'pie-input': (data: PieInputEvent) => {
+                            messages.push(data);
+                        },
+                    },
+                });
+
+                const input = component.locator('input');
+
+                // Act
+                await input.type('test');
+                await page.keyboard.press('Backspace');
+
+                // Assert
+                expect(messages).toEqual(expectedMessages);
+            });
+        });
     });
 });

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -133,7 +133,7 @@ test.describe('PieInput - Component tests', () => {
                 expect(await output.innerText()).toEqual(expectedMessage);
             });
 
-            test('should correctly handle input including backspaces, tracking data property', async ({ page }) => {
+            test('should correctly handle input including backspaces in the event.data property', async ({ page }) => {
                 // Arrange
                 const expectedMessage = 'tes';
 


### PR DESCRIPTION
## Tested in:
- PIE Aperture NextJS (SSR Enabled)

## Note:
- Vanilla form integration is coming in a separate PR

---
"@justeattakeaway/pie-input": minor
---

[Added] - `value` property to input component


---
"pie-storybook": minor
---

[Added] - value prop to pie-input stories