### PR TITLE
feat(pie-input): DSW-1582 dispatch change event

### DIFF
--- a/.changeset/cool-planets-battle.md
+++ b/.changeset/cool-planets-battle.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-switch": minor
+---
+
+[Changed] - Use new event wrapper function to standardise the change event structure

--- a/.changeset/early-hotels-travel.md
+++ b/.changeset/early-hotels-travel.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Added] - Readme section for how we use events in our web components

--- a/.changeset/itchy-owls-smile.md
+++ b/.changeset/itchy-owls-smile.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+---
+
+[Added] - new wrapNativeEvent function to standardise how we structure custom versions of native browser events such as 'change'

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -69,12 +69,19 @@ const Template = ({ type, value, name }: InputProps) => {
         });
     }
 
+    function onChange (event: CustomEvent) {
+        action('change')({
+            detail: event.detail,
+        });
+    }
+
     return html`
     <pie-input
         type="${ifDefined(type)}"
         .value="${value}"
         name="${ifDefined(name)}"
-        @input="${onInput}"></pie-input>
+        @input="${onInput}"
+        @change="${onChange}"></pie-input>
     `;
 };
 
@@ -98,20 +105,20 @@ const FormTemplate: TemplateFunction<InputProps> = (props: InputProps) => {
     return html`
         <h2>Fake form</h2>
         <form id="testForm" @submit="${onSubmit}">
-                <section>
-                    <h2>Contact information</h2>
-                    <p>
-                        <label for="name">
-                            <span>Name: </span>
-                        </label>
-                        ${Template({ ...props, type: 'text' })}
-                    </p>
-                </section>
-                <section style="display: flex; gap: var(--dt-spacing-a); justify-content: flex-end; flex-wrap: wrap; margin-top: var(--dt-spacing-b);">
-                    <pie-button type="reset" variant="secondary">Reset</pie-button>
-                    <pie-button type="submit" variant="primary">Submit</pie-button>
-                </section>
-            </form>
+            <section>
+                <h2>Contact information</h2>
+                <p>
+                    <label for="name">
+                        <span>Name: </span>
+                    </label>
+                    ${Template({ ...props, type: 'text' })}
+                </p>
+            </section>
+            <section style="display: flex; gap: var(--dt-spacing-a); justify-content: flex-end; flex-wrap: wrap; margin-top: var(--dt-spacing-b);">
+                <pie-button type="reset" variant="secondary">Reset</pie-button>
+                <pie-button type="submit" variant="primary">Submit</pie-button>
+            </section>
+        </form>
     `;
 };
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -3,7 +3,7 @@
 This readme contains some general information that is relevant for all components. For specific information about a component, please refer to the readme in the component's directory.
 
 ## Events
-Some components dispatch events that consuming applications can listen for. In some cases, we simply allow native events, such as `input` to bubble up from the component. However, in some cases we need to dispatch custom events. This could be due to the fact that the component does not have a native counter part, and so the event is unique to the component. Or it could be that the native event, such as `change`
+Some components dispatch events that consuming applications can listen for. In some cases, we simply allow native events, such as `input` to bubble up from the component. However, in some cases we need to dispatch custom events. This could be due to the fact that the component does not have a native counterpart, and so the event is unique to the component. Or it could be that the native event, such as `change`
 has `composed` set to false. This prevents such events from bubbling outside of the shadow DOM. [Reference](https://javascript.info/shadow-dom-events#event-composed).
 
 In the case of native events that do not bubble, we will dispatch a custom event that is the same name as the native event and attach a reference to the original event. The original event can be accessed via `detail.sourceEvent`. For example:

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -2,6 +2,16 @@
 
 This readme contains some general information that is relevant for all components. For specific information about a component, please refer to the readme in the component's directory.
 
+## Events
+Some components dispatch events that consuming applications can listen for. In some cases, we simply allow native events, such as `input` to bubble up from the component. However, in some cases we need to dispatch custom events. This could be due to the fact that the component does not have a native counter part, and so the event is unique to the component. Or it could be that the native event, such as `change`
+has `composed` set to false. This prevents such events from bubbling outside of the shadow DOM. [Reference](https://javascript.info/shadow-dom-events#event-composed).
+
+In the case of native events that do not bubble, we will dispatch a custom event that is the same name as the native event and attach a reference to the original event.
+
+In the case of unique component events, we will dispatch a custom event with a unique name that begins with `pie-`.
+
+In both cases, these can be listened to the same way as any other event.
+
 ## Testing
 
 ### Browser tests

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -6,7 +6,13 @@ This readme contains some general information that is relevant for all component
 Some components dispatch events that consuming applications can listen for. In some cases, we simply allow native events, such as `input` to bubble up from the component. However, in some cases we need to dispatch custom events. This could be due to the fact that the component does not have a native counter part, and so the event is unique to the component. Or it could be that the native event, such as `change`
 has `composed` set to false. This prevents such events from bubbling outside of the shadow DOM. [Reference](https://javascript.info/shadow-dom-events#event-composed).
 
-In the case of native events that do not bubble, we will dispatch a custom event that is the same name as the native event and attach a reference to the original event.
+In the case of native events that do not bubble, we will dispatch a custom event that is the same name as the native event and attach a reference to the original event. The original event can be accessed via `detail.sourceEvent`. For example:
+
+```ts
+inputEl.addEventListener('change', (e: CustomEvent) => {
+    console.log(e.detail.sourceEvent);
+});
+```
 
 In the case of unique component events, we will dispatch a custom event with a unique name that begins with `pie-`.
 

--- a/packages/components/pie-input/custom-elements.json
+++ b/packages/components/pie-input/custom-elements.json
@@ -1,164 +1,183 @@
 {
-  "schemaVersion": "1.0.0",
-  "readme": "",
-  "modules": [
-    {
-      "kind": "javascript-module",
-      "path": "src/defs.js",
-      "declarations": [
+    "schemaVersion": "1.0.0",
+    "readme": "",
+    "modules": [
         {
-          "kind": "variable",
-          "name": "types",
-          "type": {
-            "text": "['text', 'number', 'password', 'search', 'url', 'email', 'tel']"
-          },
-          "default": "['text', 'number', 'password', 'search', 'url', 'email', 'tel']"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "types",
-          "declaration": {
-            "name": "types",
-            "module": "src/defs.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/index.js",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PieInput",
-          "members": [
-            {
-              "kind": "field",
-              "name": "shadowRootOptions",
-              "type": {
-                "text": "object"
-              },
-              "static": true,
-              "default": "{ ...LitElement.shadowRootOptions, delegatesFocus: true }"
-            },
-            {
-              "kind": "field",
-              "name": "type",
-              "type": {
-                "text": "InputProps['type']"
-              },
-              "privacy": "public",
-              "default": "'text'",
-              "attribute": "type",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "public",
-              "default": "''",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "public",
-              "default": "''",
-              "attribute": "name"
-            },
-            {
-              "kind": "field",
-              "name": "handleInput",
-              "privacy": "private",
-              "description": "Handles data processing in response to the input event. The native input event is left to bubble up.",
-              "parameters": [
+            "kind": "javascript-module",
+            "path": "src/defs.js",
+            "declarations": [
                 {
-                  "description": "The input event.",
-                  "name": "event"
+                    "kind": "variable",
+                    "name": "types",
+                    "type": {
+                        "text": "['text', 'number', 'password', 'search', 'url', 'email', 'tel']"
+                    },
+                    "default": "['text', 'number', 'password', 'search', 'url', 'email', 'tel']"
                 }
-              ]
-            }
-          ],
-          "events": [
-            {
-              "type": {
-                "text": "InputEvent"
-              },
-              "description": "when the input value is changed.",
-              "name": "input"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "type",
-              "type": {
-                "text": "InputProps['type']"
-              },
-              "default": "'text'",
-              "fieldName": "type"
-            },
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "value"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "name"
-            }
-          ],
-          "mixins": [
-            {
-              "name": "FormControlMixin",
-              "package": "@justeattakeaway/pie-webc-core"
-            },
-            {
-              "name": "RtlMixin",
-              "package": "@justeattakeaway/pie-webc-core"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "pie-input",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "*",
-          "declaration": {
-            "name": "*",
-            "package": "./defs"
-          }
+            ],
+            "exports": [
+                {
+                    "kind": "js",
+                    "name": "types",
+                    "declaration": {
+                        "name": "types",
+                        "module": "src/defs.js"
+                    }
+                }
+            ]
         },
         {
-          "kind": "js",
-          "name": "PieInput",
-          "declaration": {
-            "name": "PieInput",
-            "module": "src/index.js"
-          }
+            "kind": "javascript-module",
+            "path": "src/index.js",
+            "declarations": [
+                {
+                    "kind": "class",
+                    "description": "",
+                    "name": "PieInput",
+                    "members": [
+                        {
+                            "kind": "field",
+                            "name": "shadowRootOptions",
+                            "type": {
+                                "text": "object"
+                            },
+                            "static": true,
+                            "default": "{ ...LitElement.shadowRootOptions, delegatesFocus: true }"
+                        },
+                        {
+                            "kind": "field",
+                            "name": "type",
+                            "type": {
+                                "text": "InputProps['type']"
+                            },
+                            "privacy": "public",
+                            "default": "'text'",
+                            "attribute": "type",
+                            "reflects": true
+                        },
+                        {
+                            "kind": "field",
+                            "name": "value",
+                            "type": {
+                                "text": "string"
+                            },
+                            "privacy": "public",
+                            "default": "''",
+                            "attribute": "value"
+                        },
+                        {
+                            "kind": "field",
+                            "name": "name",
+                            "type": {
+                                "text": "string"
+                            },
+                            "privacy": "public",
+                            "default": "''",
+                            "attribute": "name"
+                        },
+                        {
+                            "kind": "field",
+                            "name": "handleInput",
+                            "privacy": "private",
+                            "description": "Handles data processing in response to the input event. The native input event is left to bubble up.",
+                            "parameters": [
+                                {
+                                    "description": "The input event.",
+                                    "name": "event"
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "field",
+                            "name": "handleChange",
+                            "privacy": "private",
+                            "description": "Captures the native change event and wraps it in a custom event.",
+                            "parameters": [
+                                {
+                                    "description": "The change event.",
+                                    "name": "event"
+                                }
+                            ]
+                        }
+                    ],
+                    "events": [
+                        {
+                            "type": {
+                                "text": "InputEvent"
+                            },
+                            "description": "when the input value is changed.",
+                            "name": "input"
+                        },
+                        {
+                            "type": {
+                                "text": "CustomEvent"
+                            },
+                            "description": "when the input value is changed.",
+                            "name": "change"
+                        }
+                    ],
+                    "attributes": [
+                        {
+                            "name": "type",
+                            "type": {
+                                "text": "InputProps['type']"
+                            },
+                            "default": "'text'",
+                            "fieldName": "type"
+                        },
+                        {
+                            "name": "value",
+                            "type": {
+                                "text": "string"
+                            },
+                            "default": "''",
+                            "fieldName": "value"
+                        },
+                        {
+                            "name": "name",
+                            "type": {
+                                "text": "string"
+                            },
+                            "default": "''",
+                            "fieldName": "name"
+                        }
+                    ],
+                    "mixins": [
+                        {
+                            "name": "FormControlMixin",
+                            "package": "@justeattakeaway/pie-webc-core"
+                        },
+                        {
+                            "name": "RtlMixin",
+                            "package": "@justeattakeaway/pie-webc-core"
+                        }
+                    ],
+                    "superclass": {
+                        "name": "LitElement",
+                        "package": "lit"
+                    },
+                    "tagName": "pie-input",
+                    "customElement": true
+                }
+            ],
+            "exports": [
+                {
+                    "kind": "js",
+                    "name": "*",
+                    "declaration": {
+                        "name": "*",
+                        "package": "./defs"
+                    }
+                },
+                {
+                    "kind": "js",
+                    "name": "PieInput",
+                    "declaration": {
+                        "name": "PieInput",
+                        "module": "src/index.js"
+                    }
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -6,7 +6,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 
 import {
-    validPropertyValues, RtlMixin, defineCustomElement, FormControlMixin,
+    validPropertyValues, RtlMixin, defineCustomElement, FormControlMixin, wrapNativeEvent,
 } from '@justeattakeaway/pie-webc-core';
 
 import styles from './input.scss?inline';
@@ -20,6 +20,7 @@ const componentSelector = 'pie-input';
 /**
  * @tagname pie-input
  * @event {InputEvent} input - when the input value is changed.
+ * @event {CustomEvent} change - when the input value is changed.
  */
 export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements InputProps {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
@@ -56,6 +57,20 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
         this._internals.setFormValue(this.value);
     };
 
+    /**
+     * Captures the native change event and wraps it in a custom event.
+     * @param event - The change event.
+     */
+    private handleChange = (event: Event) => {
+        // We have to create our own change event because the native one
+        // does not penetrate the shadow boundary.
+
+        // This is because some events set `composed` to `false`.
+        // Reference: https://javascript.info/shadow-dom-events#event-composed
+        const customChangeEvent = wrapNativeEvent(event);
+        this.dispatchEvent(customChangeEvent);
+    };
+
     render () {
         const { type, value, name } = this;
 
@@ -64,6 +79,7 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
             .value=${live(value)}
             name=${ifDefined(name)}
             @input=${this.handleInput}
+            @change=${this.handleChange}
             data-test-id="pie-input">`;
     }
 

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -303,7 +303,7 @@ test.describe('PieInput - Component tests', () => {
 
                 // Act
                 await input.type('test');
-                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab'); // Change events on inputs are triggered when they lose focus after the value was changed
 
                 // Assert
                 expect(messages).toStrictEqual(expectedMessages);

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -260,6 +260,55 @@ test.describe('PieInput - Component tests', () => {
                 expect(await page.locator('#output').innerText()).toEqual(expectedMessage);
             });
         });
+
+        test.describe('change', () => {
+            test('should dispatch a change event when the input value changes', async ({ mount, page }) => {
+                // Arrange
+                const messages: CustomEvent[] = [];
+
+                await mount(PieInput, {
+                    props: {} as InputProps,
+                    on: {
+                        change: (data: CustomEvent) => {
+                            messages.push(data);
+                        },
+                    },
+                });
+
+                const input = page.locator('pie-input');
+
+                // Act
+                await input.type('test');
+                await page.keyboard.press('Tab');
+
+                // Assert
+                expect(messages.length).toEqual(1);
+            });
+
+            test('should dispatch a custom event that contains the original native event', async ({ mount, page }) => {
+                // Arrange
+                const messages: CustomEvent[] = [];
+                const expectedMessages = [{ sourceEvent: { isTrusted: true } }];
+
+                await mount(PieInput, {
+                    props: {} as InputProps,
+                    on: {
+                        change: (data: CustomEvent) => {
+                            messages.push(data);
+                        },
+                    },
+                });
+
+                const input = page.locator('pie-input');
+
+                // Act
+                await input.type('test');
+                await page.keyboard.press('Tab');
+
+                // Assert
+                expect(messages).toStrictEqual(expectedMessages);
+            });
+        });
     });
 
     test.describe('Form integration', () => {

--- a/packages/components/pie-switch/custom-elements.json
+++ b/packages/components/pie-switch/custom-elements.json
@@ -54,24 +54,6 @@
                     "members": [
                         {
                             "kind": "field",
-                            "name": "formAssociated",
-                            "type": {
-                                "text": "boolean"
-                            },
-                            "static": true,
-                            "default": "true"
-                        },
-                        {
-                            "kind": "field",
-                            "name": "_internals",
-                            "type": {
-                                "text": "ElementInternals"
-                            },
-                            "privacy": "private",
-                            "readonly": true
-                        },
-                        {
-                            "kind": "field",
                             "name": "input",
                             "type": {
                                 "text": "HTMLInputElement | undefined"
@@ -335,6 +317,10 @@
                         }
                     ],
                     "mixins": [
+                        {
+                            "name": "FormControlMixin",
+                            "package": "@justeattakeaway/pie-webc-core"
+                        },
                         {
                             "name": "RtlMixin",
                             "package": "@justeattakeaway/pie-webc-core"

--- a/packages/components/pie-switch/src/index.ts
+++ b/packages/components/pie-switch/src/index.ts
@@ -3,7 +3,7 @@ import {
 } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import {
-    RtlMixin, validPropertyValues, defineCustomElement, FormControlMixin,
+    RtlMixin, validPropertyValues, defineCustomElement, FormControlMixin, wrapNativeEvent,
 } from '@justeattakeaway/pie-webc-core';
 import styles from './switch.scss?inline';
 import {
@@ -94,13 +94,7 @@ export class PieSwitch extends FormControlMixin(RtlMixin(LitElement)) implements
     onChange (event: Event) {
         const { checked } = event?.currentTarget as HTMLInputElement;
         this.checked = checked;
-        const changedEvent = new CustomEvent(
-            ON_SWITCH_CHANGED_EVENT,
-            {
-                bubbles: true,
-                composed: true,
-            },
-        );
+        const changedEvent = wrapNativeEvent(event);
 
         this.dispatchEvent(changedEvent);
         this.handleFormAssociation();

--- a/packages/components/pie-switch/src/index.ts
+++ b/packages/components/pie-switch/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@justeattakeaway/pie-webc-core';
 import styles from './switch.scss?inline';
 import {
-    SwitchProps, ON_SWITCH_CHANGED_EVENT, AriaProps, labelPlacements,
+    SwitchProps, AriaProps, labelPlacements,
 } from './defs';
 import 'element-internals-polyfill';
 import '@justeattakeaway/pie-icons-webc/IconCheck';

--- a/packages/components/pie-webc-core/src/functions/index.ts
+++ b/packages/components/pie-webc-core/src/functions/index.ts
@@ -1,1 +1,2 @@
 export * from './defineCustomElement';
+export * from './wrapNativeEvent';

--- a/packages/components/pie-webc-core/src/functions/wrapNativeEvent.ts
+++ b/packages/components/pie-webc-core/src/functions/wrapNativeEvent.ts
@@ -1,0 +1,14 @@
+/**
+ * Wraps the native event in a custom event. This is useful for native events that have `composed` set to `false`
+ * as these cannot propagate outside of the shadow DOM.
+ * @param event - The native event.
+ */
+export function wrapNativeEvent (event: Event) {
+    return new CustomEvent(event.type, {
+        detail: {
+            sourceEvent: event,
+        },
+        bubbles: event.bubbles,
+        cancelable: event.cancelable,
+    });
+}


### PR DESCRIPTION
---
"@justeattakeaway/pie-switch": minor
---

[Changed] - Use new event wrapper function to standardise the change event structure

---
"pie-monorepo": minor
---

[Added] - Readme section for how we use events in our web components

---
"@justeattakeaway/pie-webc-core": minor
---

[Added] - new wrapNativeEvent function to standardise how we structure custom versions of native browser events such as 'change'