### PR TITLE
fix(pie-monorepo): DSW-000 fix dangerjs reporting when no changeset category

### DIFF
--- a/.changeset/seven-buckets-compare.md
+++ b/.changeset/seven-buckets-compare.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Fixed] - Danger reporting when no categories added to changeset

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -12,10 +12,12 @@ danger.git.created_files.filter((filepath) => filepath.includes('.changeset/') &
             const diffString = result.diff;
             const changesetCategoryRegex = /(?<=\[).+?(?=\])/g;
             const changesetCategories = diffString.match(changesetCategoryRegex);
-            const numberOfCategories = changesetCategories.length;
+            const numberOfCategories = changesetCategories ? changesetCategories.length : 0;
 
             // Check if at least one of the valid changeset categories is present
-            if (!validChangesetCategories.some((cat) => changesetCategories.includes(cat))) {
+            if (numberOfCategories === 0) {
+                fail(`:memo: Your changeset doesn't include a category. Please add one of: \`${validChangesetCategories.join(', ')}\`. Filepath: \`${filepath}`);
+            } else if (!validChangesetCategories.some((cat) => changesetCategories.includes(cat))) {
                 fail(`:memo: Your changeset includes an invalid category. Please use one of: \`${validChangesetCategories.join(', ')}\`. Filepath: \`${filepath}`);
             }
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] - Danger reporting when no categories added to changeset


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
