### PR TITLE
test(pie-switch): DSW-1576 updated visual tests to only take screenshots at 375px

### DIFF
--- a/.changeset/old-flowers-relax.md
+++ b/.changeset/old-flowers-relax.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-form-label": minor
+"@justeattakeaway/pie-switch": minor
+"@justeattakeaway/pie-input": minor
+"@justeattakeaway/pie-link": minor
+---
+
+[Changed] - Visual tests to only take screenshots in 375px

--- a/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
@@ -1,6 +1,7 @@
 
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import {
     WebComponentTestWrapper,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
@@ -40,6 +41,6 @@ test.describe('Pie Form Label - Visual tests`', () => {
             },
         });
 
-        await percySnapshot(page, 'Pie Form Label - Visual Test');
+        await percySnapshot(page, 'Pie Form Label - Visual Test', percyWidths);
     });
 });

--- a/packages/components/pie-input/test/visual/pie-input.spec.ts
+++ b/packages/components/pie-input/test/visual/pie-input.spec.ts
@@ -1,6 +1,7 @@
 
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import { PieInput, InputProps } from '../../src/index.ts';
 
 test.describe('PieInput - Visual tests`', () => {
@@ -9,6 +10,6 @@ test.describe('PieInput - Visual tests`', () => {
             props: {} as InputProps,
         });
 
-        await percySnapshot(page, 'PieInput - Visual Test');
+        await percySnapshot(page, 'PieInput - Visual Test', percyWidths);
     });
 });

--- a/packages/components/pie-link/test/visual/pie-link.spec.ts
+++ b/packages/components/pie-link/test/visual/pie-link.spec.ts
@@ -1,6 +1,7 @@
 
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import type {
     PropObject, WebComponentPropValues, WebComponentTestInput,
 } from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
@@ -62,5 +63,5 @@ componentVariants.forEach((variant) => test(`should render all prop variations f
         );
     }));
 
-    await percySnapshot(page, `PIE Link - Variant: ${variant}`);
+    await percySnapshot(page, `PIE Link - Variant: ${variant}`, percyWidths);
 }));

--- a/packages/components/pie-switch/test/visual/pie-switch.spec.ts
+++ b/packages/components/pie-switch/test/visual/pie-switch.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@sand4rt/experimental-ct-web';
 import percySnapshot from '@percy/playwright';
+import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import { PieSwitch } from '../../src/index.ts';
 import { SwitchProps, labelPlacements } from '../../src/defs.ts';
 
@@ -17,7 +18,7 @@ import { SwitchProps, labelPlacements } from '../../src/defs.ts';
             },
         });
 
-        await percySnapshot(page, `Switch - checked = ${checked} and disabled = ${disabled}`);
+        await percySnapshot(page, `Switch - checked = ${checked} and disabled = ${disabled}`, percyWidths);
     });
 });
 
@@ -32,7 +33,7 @@ test.describe('Prop: `Label`', () => {
                     } as SwitchProps,
                 });
 
-                await percySnapshot(page, `Switch - label placement: ${placement}`);
+                await percySnapshot(page, `Switch - label placement: ${placement}`, percyWidths);
             });
         });
     });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Updated - `pie-switch`, `pie-input`, `pie-form-label`, `pie-link` - Visual tests only take screenshots in 375px

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
