### PR TITLE
fix(pie-input): DSW-0 required input value

### DIFF
--- a/.changeset/unlucky-oranges-divide.md
+++ b/.changeset/unlucky-oranges-divide.md
@@ -2,4 +2,4 @@
 "@justeattakeaway/pie-input": minor
 ---
 
-[Added] - Guard against `undefined` being passed as a value to the `value` prop and write a supporting browser test
+[Added] - Make the `value` property required and default to an empty string

--- a/.changeset/unlucky-oranges-divide.md
+++ b/.changeset/unlucky-oranges-divide.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-input": minor
+---
+
+[Added] - Guard against `undefined` being passed as a value to the `value` prop and write a supporting browser test

--- a/packages/components/pie-input/src/defs.ts
+++ b/packages/components/pie-input/src/defs.ts
@@ -10,7 +10,7 @@ export interface InputProps {
     /**
      * The value of the input (used as a key/value pair in HTML forms with `name`).
      */
-    value?: string;
+    value: string;
 
     /**
      * The name of the input (used as a key/value pair with `value`). This is required in order to work properly with forms.

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -113,7 +113,7 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
 
         return html`<input
             type=${ifDefined(type)}
-            .value=${live(value)}
+            .value=${live(ifDefined(value))}
             name=${ifDefined(name)}
             pattern=${ifDefined(pattern)}
             minlength=${ifDefined(minlength)}

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -72,14 +72,14 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
 
     protected firstUpdated (_changedProperties: PropertyValues<this>): void {
         super.firstUpdated(_changedProperties);
-        this._internals.setFormValue(this.value as string);
+        this._internals.setFormValue(this.value);
     }
 
     protected updated (_changedProperties: PropertyValues<this>): void {
         super.updated(_changedProperties);
 
         if (_changedProperties.has('value')) {
-            this._internals.setFormValue(this.value as string);
+            this._internals.setFormValue(this.value);
         }
     }
 

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -30,7 +30,7 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
     public type? = InputDefaultPropertyValues.type;
 
     @property({ type: String })
-    public value? = InputDefaultPropertyValues.value;
+    public value = InputDefaultPropertyValues.value;
 
     @property({ type: String })
     public name?: InputProps['name'];
@@ -113,7 +113,7 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
 
         return html`<input
             type=${ifDefined(type)}
-            .value=${live(ifDefined(value))}
+            .value=${live(value)}
             name=${ifDefined(name)}
             pattern=${ifDefined(pattern)}
             minlength=${ifDefined(minlength)}

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -121,21 +121,6 @@ test.describe('PieInput - Component tests', () => {
                 expect((await input.inputValue())).toBe('');
             });
 
-            test('should default to an empty string if undefined value prop provided', async ({ mount }) => {
-                // Arrange
-                const component = await mount(PieInput, {
-                    props: {
-                        value: undefined,
-                    } as InputProps,
-                });
-
-                // Act
-                const input = component.locator('input');
-
-                // Assert
-                expect((await input.inputValue())).toBe('');
-            });
-
             test('should apply the value prop to the HTML input rendered', async ({ mount }) => {
                 // Arrange
                 const component = await mount(PieInput, {

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -121,6 +121,21 @@ test.describe('PieInput - Component tests', () => {
                 expect((await input.inputValue())).toBe('');
             });
 
+            test('should default to an empty string if undefined value prop provided', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {
+                    props: {
+                        value: undefined,
+                    } as InputProps,
+                });
+
+                // Act
+                const input = component.locator('input');
+
+                // Assert
+                expect((await input.inputValue())).toBe('');
+            });
+
             test('should apply the value prop to the HTML input rendered', async ({ mount }) => {
                 // Arrange
                 const component = await mount(PieInput, {


### PR DESCRIPTION
---
"@justeattakeaway/pie-input": minor
---

[Added] - Make the `value` property required and default to an empty string