### PR TITLE
feat(pie-input): DSW-0 enable HTML form resets

### DIFF
--- a/.changeset/many-plums-rhyme.md
+++ b/.changeset/many-plums-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-input": minor
+---
+
+[Added] - Provide a `formResetCallback` method to enable HTML form resets

--- a/.changeset/short-terms-tell.md
+++ b/.changeset/short-terms-tell.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-input": minor
+"pie-storybook": minor
+---
+
+[Added] - defaultValue prop to fallback to if the input is reset

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -109,6 +109,13 @@ const inputStoryMeta: InputStoryMeta = {
                 summary: false,
             },
         },
+        defaultValue: {
+            description: 'An optional default value to use when the input is reset.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -120,7 +127,7 @@ const inputStoryMeta: InputStoryMeta = {
 };
 
 const Template = ({
-    type, value, name, pattern, minlength, maxlength, autocomplete, placeholder, autoFocus, inputmode, readonly,
+    type, value, name, pattern, minlength, maxlength, autocomplete, placeholder, autoFocus, inputmode, readonly, defaultValue,
 }: InputProps) => {
     const [, updateArgs] = UseArgs();
 
@@ -151,6 +158,7 @@ const Template = ({
         autocomplete="${ifDefined(autocomplete)}"
         placeholder="${ifDefined(placeholder)}"
         inputmode="${ifDefined(inputmode)}"
+        defaultValue="${ifDefined(defaultValue)}"
         ?autoFocus="${autoFocus}"
         ?readonly="${readonly}"
         @input="${onInput}"

--- a/packages/components/pie-input/src/defs.ts
+++ b/packages/components/pie-input/src/defs.ts
@@ -61,6 +61,11 @@ export interface InputProps {
      * See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly) for more information.
      */
     readonly?: boolean;
+
+    /**
+     * An optional default value to use when the input is reset.
+     */
+    defaultValue?: string;
 }
 
 // TODO - There is a ticket to add default prop values to our existing components. This might be replaced by the code added in that ticket.

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -70,6 +70,14 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
         return (this.input as HTMLInputElement).validity;
     }
 
+    /**
+     * Called when the form that owns this component is reset.
+     * Resets the value to the default value.
+     */
+    public formResetCallback (): void {
+        this.value = InputDefaultPropertyValues.value;
+    }
+
     protected firstUpdated (_changedProperties: PropertyValues<this>): void {
         super.firstUpdated(_changedProperties);
         this._internals.setFormValue(this.value as string);

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -59,6 +59,9 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
     @property({ type: Boolean })
     public readonly?: InputProps['readonly'];
 
+    @property({ type: String })
+    public defaultValue?: InputProps['defaultValue'];
+
     @query('input')
     private input?: HTMLInputElement;
 
@@ -75,7 +78,7 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
      * Resets the value to the default value.
      */
     public formResetCallback (): void {
-        this.value = InputDefaultPropertyValues.value;
+        this.value = this.defaultValue ?? InputDefaultPropertyValues.value;
     }
 
     protected firstUpdated (_changedProperties: PropertyValues<this>): void {

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -467,6 +467,25 @@ test.describe('PieInput - Component tests', () => {
                 expect((await component.locator('input').inputValue())).toBe('test');
             });
         });
+
+        test.describe('defaultValue', () => {
+            test('should correctly reset the input value to the default value if one is provided when the form is reset', async ({ page }) => {
+                // Arrange
+                await page.setContent(`
+                    <form id="testForm" action="/foo" method="POST">
+                        <pie-input type="text" name="username" defaultValue="foo"></pie-input>
+                        <button type="reset">Submit</button>
+                    </form>
+                `);
+
+                // Act & Assert
+                await page.locator('pie-input').type('test');
+                expect(await page.evaluate(() => document.querySelector('pie-input')?.value)).toBe('test');
+
+                await page.click('button[type="reset"]');
+                expect(await page.evaluate(() => document.querySelector('pie-input')?.value)).toBe('foo');
+            });
+        });
     });
 
     test.describe('Events', () => {

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -664,5 +664,22 @@ test.describe('PieInput - Component tests', () => {
             // Assert
             expect(formDataObj.username).toBe('test2');
         });
+
+        test('should correctly reset the input value when the form is reset', async ({ page }) => {
+            // Arrange
+            await page.setContent(`
+                <form id="testForm" action="/foo" method="POST">
+                    <pie-input type="text" name="username"></pie-input>
+                    <button type="reset">Submit</button>
+                </form>
+            `);
+
+            // Act & Assert
+            await page.locator('pie-input').type('test');
+            expect(await page.evaluate(() => document.querySelector('pie-input')?.value)).toBe('test');
+
+            await page.click('button[type="reset"]');
+            expect(await page.evaluate(() => document.querySelector('pie-input')?.value)).toBe('');
+        });
     });
 });


### PR DESCRIPTION
---
"@justeattakeaway/pie-input": minor
---

[Added] - Provide a `formResetCallback` method to enable HTML form resets