### PR TITLE
fix(pie-modal): DSW-1671 Fix for modal rendering outside the viewport when scroll is locked

### DIFF
--- a/.changeset/shy-snails-dress.md
+++ b/.changeset/shy-snails-dress.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": patch
+---
+
+[Fixed] - scroll lock behaviour for Safari

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -151,6 +151,10 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
             const modalScrollContainer = this._dialog?.querySelector('.c-modal-scrollContainer');
 
             if (modalScrollContainer) {
+                // Hack to prevent Safari rendering the modal outside the viewport
+                // when the body scroll lock is active
+                if ('scrollTo' in window) window.scrollTo(0, 0);
+
                 disableBodyScroll(modalScrollContainer);
             }
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
