### PR TITLE
fix(pie-modal): DSW-1671 Fix for modal rendering outside the viewport when scroll is locked

### DIFF
--- a/.changeset/shy-snails-dress.md
+++ b/.changeset/shy-snails-dress.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": patch
+---
+
+[Fixed] - scroll lock behaviour for Safari

--- a/.changeset/shy-snails-dress.md
+++ b/.changeset/shy-snails-dress.md
@@ -2,4 +2,4 @@
 "@justeattakeaway/pie-modal": patch
 ---
 
-[Fixed] - scroll lock behaviour for Safari
+[Fixed] - scroll lock issue for Safari when the modal is opened while the page is scrolled

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -151,6 +151,10 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
             const modalScrollContainer = this._dialog?.querySelector('.c-modal-scrollContainer');
 
             if (modalScrollContainer) {
+                // Hack to prevent Safari rendering the modal outside the viewport
+                // when the body scroll lock is active
+                if ('scrollTo' in window) window.scrollTo(0, 0);
+
                 disableBodyScroll(modalScrollContainer);
             }
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

-  Fixes `pie-modal` positioning in Safari when the page is scrolled down 

## Context

Unlike other browsers, some versions of Safari behave differently when the `body` element style is set with `overflow: hidden;`. Most browsers will scroll the content to the top, Safari doesn't.

On Chrome, when the document is scrolled, `window.scrollY` will have some positive value. When the scroll is locked and `overflow` is `hidden`, the `window.scrollY` will be `0`.

Scrolling back to the top, as it happens in every other browser,  provided the expected results for both `pie-modal` and `pie-cookie-banner` when used with a Safari browser.

## How to test

- open the URL with the test page using updated versions of `pie-modal` and `pie-cookie-banner`:  https://pr55-aperture-nextjs-app.pie.design/modal-cookie-banner
- scroll to the bottom (or the middle)
- open the "Manage preferences" modal, it should be entirely visible in the viewport
- click the "Open Modal" button (it is between the paragraphs), a modal should also be entirely visible in the viewport

## In which browsers it was tested

For the sake of reference, this solution was tested in the following Safari versions:

- iPhone 14.0
- iPad mini 15.5
- iPad mini 15.6
- Desktop 16.5.1


## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
