### PR TITLE
fix(stylelint-no-logical-props-shorthands): DSW-000 update logic and revert unnecessary changes in CSS

### DIFF
--- a/.changeset/angry-socks-cough.md
+++ b/.changeset/angry-socks-cough.md
@@ -1,0 +1,9 @@
+---
+"@justeattakeaway/stylelint-no-logical-props-shorthands": minor
+---
+
+[Added] - missing shorthands for logical properties (inset-block/inset-inline)
+[Fixed] - plugin logic to raise errors only when logical properties shorthands are used with CSS variables
+[Fixed] - README.md title
+
+

--- a/.changeset/dull-bags-count.md
+++ b/.changeset/dull-bags-count.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Fixed] - reverted unnecessary CSS updates for logical properties

--- a/.changeset/many-planes-joke.md
+++ b/.changeset/many-planes-joke.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": patch
+---
+
+[Fixed] - reverted unnecessary CSS updates for logical properties

--- a/apps/pie-docs/src/assets/styles/components/_componentDetailsTable.scss
+++ b/apps/pie-docs/src/assets/styles/components/_componentDetailsTable.scss
@@ -54,8 +54,7 @@
 
 .c-componentDetailsTable-token {
     background-color: var(--dt-color-container-default);
-    padding-block-start: 2px;
-    padding-block-end: 2px;
+    padding-block: 2px;
     padding-inline-start: var(--dt-spacing-a);
     padding-inline-end: var(--dt-spacing-a);
     border-radius: var(--dt-radius-rounded-b);

--- a/apps/pie-docs/src/assets/styles/components/_componentStatusTable.scss
+++ b/apps/pie-docs/src/assets/styles/components/_componentStatusTable.scss
@@ -41,8 +41,7 @@ $breakpoint-wide: 992px;
 .c-componentStatus-status {
     display: inline;
     background: var(--bg-colour);
-    padding-block-start: 2px;
-    padding-block-end: 2px;
+    padding-block: 2px;
     padding-inline-start: var(--dt-spacing-a);
     padding-inline-end: var(--dt-spacing-a);
     border-radius: var(--dt-radius-rounded-b);

--- a/apps/pie-docs/src/assets/styles/components/_list.scss
+++ b/apps/pie-docs/src/assets/styles/components/_list.scss
@@ -51,8 +51,7 @@
         @include p.font-size(--dt-font-body-s-size);
         @include p.line-height(--dt-font-body-s-line-height);
         background-color: var(--dt-color-container-strong);
-        padding-block-start: 2px;
-        padding-block-end: 2px;
+        padding-block: 2px;
         padding-inline-start: var(--dt-spacing-a);
         padding-inline-end: var(--dt-spacing-a);
         border-radius: var(--dt-radius-rounded-b);

--- a/apps/pie-docs/src/assets/styles/components/_nav.scss
+++ b/apps/pie-docs/src/assets/styles/components/_nav.scss
@@ -71,8 +71,7 @@ $nav-item-inline-start-margin: calc($nav-category-gap + $nav-category-icon-width
 }
 
 .c-nav-category {
-    padding-block-start: 10px;
-    padding-block-end: 10px;
+    padding-block: 10px;
     padding-inline-start: var(--dt-spacing-d);
     padding-inline-end: var(--dt-spacing-d);
     font-weight: var(--dt-font-weight-bold);
@@ -80,12 +79,10 @@ $nav-item-inline-start-margin: calc($nav-category-gap + $nav-category-icon-width
 
 .c-nav-item {
     display: block;
-    padding-block-start: 10px;
-    padding-block-end: 10px;
+    padding-block: 10px;
     padding-inline-start: var(--dt-spacing-d);
     padding-inline-end: var(--dt-spacing-d);
-    margin-block-start: 0;
-    margin-block-end: 2px;
+    margin-block: 0 2px;
     margin-inline-start: $nav-item-inline-start-margin;
     margin-inline-end: var(--dt-spacing-d);
     text-decoration: none;
@@ -104,12 +101,10 @@ $nav-item-inline-start-margin: calc($nav-category-gap + $nav-category-icon-width
 }
 
 .c-nav-subCategory {
-    padding-block-start: 10px;
-    padding-block-end: 10px;
+    padding-block: 10px;
     padding-inline-start: calc(var(--dt-spacing-d) + $nav-item-inline-start-margin);
     padding-inline-end: var(--dt-spacing-d);
-    margin-block-start: 0;
-    margin-block-end: 2px;
+    margin-block: 0 2px;
 
     + .c-nav-list {
         margin-inline-start: var(--dt-spacing-d);

--- a/apps/pie-docs/src/assets/styles/components/_resourceTable.scss
+++ b/apps/pie-docs/src/assets/styles/components/_resourceTable.scss
@@ -57,8 +57,7 @@
 .c-resourceTable-status {
     display: inline;
     background: var(--bg-colour);
-    padding-block-start: 2px;
-    padding-block-end: 2px;
+    padding-block: 2px;
     padding-inline-start: var(--dt-spacing-a);
     padding-inline-end: var(--dt-spacing-a);
     border-radius: var(--dt-radius-rounded-b);

--- a/apps/pie-docs/src/assets/styles/plugins/_prism.scss
+++ b/apps/pie-docs/src/assets/styles/plugins/_prism.scss
@@ -101,8 +101,7 @@ div.code-toolbar > .toolbar > .toolbar-item > button {
     background: var(--dt-color-interactive-light);
     padding-block-start: var(--dt-spacing-a);
     padding-block-end: var(--dt-spacing-a);
-    padding-inline-start: 10px;
-    padding-inline-end: 10px;
+    padding-inline: 10px;
     border-radius: 4px 0 0;
     border-width: 1px 0 0 1px;
     border-style: solid none none solid;
@@ -127,12 +126,9 @@ code:not(code[class*='language-']) {
     display: inline-block;
     background-color: var(--dt-color-container-strong);
     border: 1px solid var(--dt-color-border-strong);
-    margin-block-start: 0;
-    margin-block-end: 0;
-    margin-inline-start: 2px;
-    margin-inline-end: 2px;
-    padding-block-start: 2px;
-    padding-block-end: 2px;
+    margin-block: 0;
+    margin-inline: 2px;
+    padding-block: 2px;
     padding-inline-start: var(--dt-spacing-a);
     padding-inline-end: var(--dt-spacing-a);
     border-radius: 2px;

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -175,16 +175,14 @@
 
         margin-inline-start: var(--dt-spacing-d);
         margin-inline-end: var(--dt-spacing-d);
-        margin-block-start: 14px;
-        margin-block-end: 14px; // This is deliberately not a custom property
+        margin-block: 14px; // This is deliberately not a custom property
 
         @media (min-width: $breakpoint-wide) {
             --modal-header-font-size: calc(var(--dt-font-heading-m-size--wide) * 1px);
             --modal-header-font-line-height: calc(var(--dt-font-heading-m-line-height--wide) * 1px);
             margin-inline-start: var(--dt-spacing-e);
             margin-inline-end: var(--dt-spacing-e);
-            margin-block-start: 20px;
-            margin-block-end: 20px; // This is deliberately not a custom property
+            margin-block: 20px; // This is deliberately not a custom property
         }
     }
 

--- a/packages/tools/stylelint-no-logical-props-shorthands/README.md
+++ b/packages/tools/stylelint-no-logical-props-shorthands/README.md
@@ -1,4 +1,4 @@
-# stylelint-config-pie
+# stylelint-no-logical-props-shorthands
 
 [![npm version](https://badge.fury.io/js/@justeattakeaway%stylelint-no-logical-props-shorthands.svg)](https://badge.fury.io/js/@justeattakeaway%stylelint-no-logical-props-shorthands)
 

--- a/packages/tools/stylelint-no-logical-props-shorthands/__tests__/__snapshots__/plugin.test.js.snap
+++ b/packages/tools/stylelint-no-logical-props-shorthands/__tests__/__snapshots__/plugin.test.js.snap
@@ -1,16 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`stylelint-no-logical-props-shorthands > when given invalid CSS > when autofix is true > when a single value is given > provides the expected suggestion 1`] = `
-"a { margin-block-start: 10px; margin-block-end: 10px; }
+"a { margin-block: 10px; }
+"
+`;
+
+exports[`stylelint-no-logical-props-shorthands > when given invalid CSS > when autofix is true > when multiple values are given > and value contains a CSS variable > should provide the expected suggestion 1`] = `
+"a { margin-block-start: 12px; margin-block-end: var(--dt-spacing-e); }
+"
+`;
+
+exports[`stylelint-no-logical-props-shorthands > when given invalid CSS > when autofix is true > when multiple values are given > and value does not contains a CSS variable > should keep it unchanged 1`] = `
+"a { margin-block: 12px 34px; }
 "
 `;
 
 exports[`stylelint-no-logical-props-shorthands > when given invalid CSS > when autofix is true > when multiple values are given > and values are complex > provides the expected suggestion 1`] = `
 "a { padding-inline-start: calc(var(--dt-spacing-d) + $nav-item-inline-start-margin); padding-inline-end: var(--dt-spacing-d); }
-"
-`;
-
-exports[`stylelint-no-logical-props-shorthands > when given invalid CSS > when autofix is true > when multiple values are given > provides the expected suggestion 1`] = `
-"a { margin-block-start: 12px; margin-block-end: 34px; }
 "
 `;

--- a/packages/tools/stylelint-no-logical-props-shorthands/__tests__/plugin.test.js
+++ b/packages/tools/stylelint-no-logical-props-shorthands/__tests__/plugin.test.js
@@ -36,7 +36,7 @@ describe('stylelint-no-logical-props-shorthands', () => {
     });
 
     describe('when given invalid CSS', () => {
-        const invalidCSS = `a { margin-block: 10px; }
+        const invalidCSS = `a { margin-block: var(--dt-spacing-e); }
 `;
         beforeEach(() => {
             result = stylelint.lint({
@@ -73,16 +73,32 @@ describe('stylelint-no-logical-props-shorthands', () => {
             });
 
             describe('when multiple values are given', () => {
-                it('provides the expected suggestion', async () => {
-                    const code = `a { margin-block: 12px 34px; }
-`;
-                    const result = await stylelint.lint({
-                        code,
-                        config,
-                        fix: true,
-                    });
+                describe('and value does not contains a CSS variable', () => {
+                    it('should keep it unchanged', async () => {
+                        const code = `a { margin-block: 12px 34px; }
+    `;
+                        const result = await stylelint.lint({
+                            code,
+                            config,
+                            fix: true,
+                        });
 
-                    expect(result.output).toMatchSnapshot();
+                        expect(result.output).toMatchSnapshot();
+                    });
+                });
+
+                describe('and value contains a CSS variable', () => {
+                    it('should provide the expected suggestion', async () => {
+                        const code = `a { margin-block: 12px var(--dt-spacing-e); }
+    `;
+                        const result = await stylelint.lint({
+                            code,
+                            config,
+                            fix: true,
+                        });
+
+                        expect(result.output).toMatchSnapshot();
+                    });
                 });
 
                 describe('and values are complex', () => {

--- a/packages/tools/stylelint-no-logical-props-shorthands/index.js
+++ b/packages/tools/stylelint-no-logical-props-shorthands/index.js
@@ -63,9 +63,11 @@ function ruleFunction (primaryOption, secondaryOption, context) {
         // Iterate over CSS declarations
         root.walkDecls((decl) => {
             const hasDisallowedShorthand = disallowedShorthands.includes(decl.prop);
+            const hasVariableInValue = decl.value.indexOf('var(--') > -1;
+            const hasUnwantedCondition = hasDisallowedShorthand && hasVariableInValue;
 
             // The expectation is met, there's nothing to be done
-            if (!hasDisallowedShorthand) return;
+            if (!hasUnwantedCondition) return;
 
             if (isAutoFixing) {
                 // Replace shorthand declarations with the long syntax equivalent declarations

--- a/packages/tools/stylelint-no-logical-props-shorthands/index.js
+++ b/packages/tools/stylelint-no-logical-props-shorthands/index.js
@@ -13,6 +13,8 @@ const disallowedShorthands = [
     'padding-inline',
     'margin-block',
     'margin-inline',
+    'inset-block',
+    'inset-inline',
 ];
 
 /**


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### @justeattakeaway/stylelint-no-logical-props-shorthands

[Added] - missing shorthands for logical properties (inset-block/inset-inline)
[Fixed] - plugin logic to raise errors only when logical properties shorthands are used with CSS variables
[Fixed] - README.md title

### pie-docs

[Fixed] - reverted unnecessary CSS updates for logical properties

### @justeattakeaway/pie-modal

[Fixed] - reverted unnecessary CSS updates for logical properties



## Author Checklist (complete before requesting a review)
- [X] I have performed a self-review of my code
- [X] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [X] If it is a component change, I have reviewed the Storybook preview
- [X] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview

### Reviewer 2
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
