### PR TITLE
feat(pie-input): DSW-1588 add leading and trailing content slots

### DIFF
--- a/.changeset/wicked-pots-appear.md
+++ b/.changeset/wicked-pots-appear.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-input": minor
+"pie-storybook": minor
+---
+
+[Added] - Leading and Trailing content slots to pie-input component

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -5,7 +5,7 @@ import { useArgs as UseArgs } from '@storybook/preview-api';
 
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-input';
-import { types, inputModes, InputProps as InputPropsOriginal } from '@justeattakeaway/pie-input';
+import { types, inputModes, InputProps as InputPropsBase } from '@justeattakeaway/pie-input';
 /* eslint-enable import/no-duplicates */
 
 import { type StoryMeta } from '../types';
@@ -14,7 +14,7 @@ import '@justeattakeaway/pie-button';
 import '@justeattakeaway/pie-icons-webc/IconPlaceholder';
 
 // Extending the props type definition to include storybook specific properties for controls
-type InputProps = InputPropsOriginal & {
+type InputProps = InputPropsBase & {
     leadingSlot: typeof slotOptions[number];
     trailingSlot: typeof slotOptions[number];
 };

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -128,20 +128,14 @@ const inputStoryMeta: InputStoryMeta = {
             },
         },
         leadingSlot: {
-            description: 'An icon or short text to display at the start of the input.',
+            description: 'An icon or short text to display at the start of the input. <br><b>*Not a component Prop</b>',
             control: 'select',
             options: slotOptions,
-            defaultValue: {
-                summary: 'text',
-            },
         },
         trailingSlot: {
-            description: 'An icon or short text to display at the end of the input.',
+            description: 'An icon or short text to display at the end of the input. <br><b>*Not a component Prop</b>',
             control: 'select',
             options: slotOptions,
-            defaultValue: {
-                summary: 'text',
-            },
         },
     },
     args: defaultArgs,

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -1,16 +1,23 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { action } from '@storybook/addon-actions';
 import { useArgs as UseArgs } from '@storybook/preview-api';
 
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-input';
-import { types, inputModes, InputProps } from '@justeattakeaway/pie-input';
+import { types, inputModes, InputProps as InputPropsOriginal } from '@justeattakeaway/pie-input';
 /* eslint-enable import/no-duplicates */
 
 import { type StoryMeta } from '../types';
 import { createStory, type TemplateFunction } from '../utilities';
 import '@justeattakeaway/pie-button';
+import '@justeattakeaway/pie-icons-webc/IconPlaceholder';
+
+// Extending the props type definition to include storybook specific properties for controls
+type InputProps = InputPropsOriginal & {
+    leadingSlot: typeof slotOptions[number];
+    trailingSlot: typeof slotOptions[number];
+};
 
 type InputStoryMeta = StoryMeta<InputProps>;
 
@@ -20,7 +27,11 @@ const defaultArgs: InputProps = {
     name: 'testName',
     autocomplete: 'off',
     autoFocus: false,
+    leadingSlot: 'None',
+    trailingSlot: 'None',
 };
+
+const slotOptions = ['Icon (Placeholder)', 'Short text (#)', 'None'] as const;
 
 const inputStoryMeta: InputStoryMeta = {
     title: 'Input',
@@ -116,6 +127,22 @@ const inputStoryMeta: InputStoryMeta = {
                 summary: '',
             },
         },
+        leadingSlot: {
+            description: 'An icon or short text to display at the start of the input.',
+            control: 'select',
+            options: slotOptions,
+            defaultValue: {
+                summary: 'text',
+            },
+        },
+        trailingSlot: {
+            description: 'An icon or short text to display at the end of the input.',
+            control: 'select',
+            options: slotOptions,
+            defaultValue: {
+                summary: 'text',
+            },
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -127,7 +154,20 @@ const inputStoryMeta: InputStoryMeta = {
 };
 
 const Template = ({
-    type, value, name, pattern, minlength, maxlength, autocomplete, placeholder, autoFocus, inputmode, readonly, defaultValue,
+    type,
+    value,
+    name,
+    pattern,
+    minlength,
+    maxlength,
+    autocomplete,
+    placeholder,
+    autoFocus,
+    inputmode,
+    readonly,
+    defaultValue,
+    leadingSlot,
+    trailingSlot,
 }: InputProps) => {
     const [, updateArgs] = UseArgs();
 
@@ -147,22 +187,37 @@ const Template = ({
         });
     }
 
+    function renderLeadingOrTrailingSlot (slotName: 'leading' | 'trailing', slotValue: typeof slotOptions[number]) {
+        if (slotValue === slotOptions[0]) {
+            return html`<icon-placeholder slot="${slotName}"></icon-placeholder>`;
+        }
+
+        if (slotValue === slotOptions[1]) {
+            return html`<span slot="${slotName}">#</span>`;
+        }
+
+        return nothing;
+    }
+
     return html`
-    <pie-input
-        type="${ifDefined(type)}"
-        .value="${value}"
-        name="${ifDefined(name)}"
-        pattern="${ifDefined(pattern)}"
-        minlength="${ifDefined(minlength)}"
-        maxlength="${ifDefined(maxlength)}"
-        autocomplete="${ifDefined(autocomplete)}"
-        placeholder="${ifDefined(placeholder)}"
-        inputmode="${ifDefined(inputmode)}"
-        defaultValue="${ifDefined(defaultValue)}"
-        ?autoFocus="${autoFocus}"
-        ?readonly="${readonly}"
-        @input="${onInput}"
-        @change="${onChange}"></pie-input>
+        <pie-input
+            type="${ifDefined(type)}"
+            .value="${value}"
+            name="${ifDefined(name)}"
+            pattern="${ifDefined(pattern)}"
+            minlength="${ifDefined(minlength)}"
+            maxlength="${ifDefined(maxlength)}"
+            autocomplete="${ifDefined(autocomplete)}"
+            placeholder="${ifDefined(placeholder)}"
+            inputmode="${ifDefined(inputmode)}"
+            defaultValue="${ifDefined(defaultValue)}"
+            ?autoFocus="${autoFocus}"
+            ?readonly="${readonly}"
+            @input="${onInput}"
+            @change="${onChange}">
+            ${renderLeadingOrTrailingSlot('leading', leadingSlot)}
+            ${renderLeadingOrTrailingSlot('trailing', trailingSlot)}
+        </pie-input>
     `;
 };
 

--- a/packages/components/pie-input/README.md
+++ b/packages/components/pie-input/README.md
@@ -16,7 +16,8 @@
 4. [Peer Dependencies](#peer-dependencies)
 5. [Props](#props)
 6. [Events](#events)
-7. [Contributing](#contributing)
+7. [Slots](#slots)
+8. [Contributing](#contributing)
 
 ## pie-input
 
@@ -127,6 +128,12 @@ In your markup or JSX, you can then use these to set the properties for the `pie
 |-------|------|-------------|
 | `change` | `CustomEvent` | Triggered when the input loses focus after it's value has changed. |
 | `input` | `InputEvent` | Triggered when the input value is changed. |
+
+## Slots
+| Slot | Description |
+|------|-------------|
+| `leading` | An icon or short text to display at the start of the input. |
+| `trailing` | An icon or short text to display at the end of the input. |
 
 ## Contributing
 

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -21,6 +21,8 @@ const componentSelector = 'pie-input';
  * @tagname pie-input
  * @event {InputEvent} input - when the input value is changed.
  * @event {CustomEvent} change - when the input value is changed.
+ * @slot leading - An icon or short text to display at the start of the input.
+ * @slot trailing - An icon or short text to display at the end of the input.
  */
 export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements InputProps {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
@@ -122,21 +124,26 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
             type, value, name, pattern, minlength, maxlength, autocomplete, placeholder, autoFocus, inputmode, readonly,
         } = this;
 
-        return html`<input
-            type=${ifDefined(type)}
-            .value=${live(value)}
-            name=${ifDefined(name)}
-            pattern=${ifDefined(pattern)}
-            minlength=${ifDefined(minlength)}
-            maxlength=${ifDefined(maxlength)}
-            autocomplete=${ifDefined(autocomplete)}
-            ?autofocus=${autoFocus}
-            inputmode=${ifDefined(inputmode)}
-            placeholder=${ifDefined(placeholder)}
-            ?readonly=${readonly}
-            @input=${this.handleInput}
-            @change=${this.handleChange}
-            data-test-id="pie-input">`;
+        return html`
+            <div>
+                <slot name="leading"></slot>
+                <input
+                    type=${ifDefined(type)}
+                    .value=${live(value)}
+                    name=${ifDefined(name)}
+                    pattern=${ifDefined(pattern)}
+                    minlength=${ifDefined(minlength)}
+                    maxlength=${ifDefined(maxlength)}
+                    autocomplete=${ifDefined(autocomplete)}
+                    ?autofocus=${autoFocus}
+                    inputmode=${ifDefined(inputmode)}
+                    placeholder=${ifDefined(placeholder)}
+                    ?readonly=${readonly}
+                    @input=${this.handleInput}
+                    @change=${this.handleChange}
+                    data-test-id="pie-input">
+                <slot name="trailing"></slot>
+            </div>`;
     }
 
     // Renders a `CSSResult` generated from SCSS by Vite

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -1,6 +1,7 @@
 
 import { test, expect } from '@sand4rt/experimental-ct-web';
 import type { Page } from '@playwright/test';
+import { IconPlaceholder } from '@justeattakeaway/pie-icons-webc/IconPlaceholder';
 import { PieInput, InputProps } from '../../src/index.ts';
 
 const componentSelector = '[data-test-id="pie-input"]';
@@ -65,6 +66,9 @@ test.describe('PieInput - Component tests', () => {
     test.beforeEach(async ({ mount }) => {
         const component = await mount(PieInput);
         await component.unmount();
+
+        const iconComponent = await mount(IconPlaceholder);
+        await iconComponent.unmount();
     });
 
     test('should render successfully', async ({ mount, page }) => {
@@ -629,6 +633,62 @@ test.describe('PieInput - Component tests', () => {
 
                 // Assert
                 expect(messages).toStrictEqual(expectedMessages);
+            });
+        });
+    });
+
+    test.describe('Slots', () => {
+        test.describe('leading', () => {
+            test('should render the leading slot content', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {
+                    slots: {
+                        leading: '<icon-placeholder id="leading"></icon-placeholder>',
+                    },
+                });
+
+                // Act
+                const leadingSlot = component.locator('#leading');
+
+                // Assert
+                expect(leadingSlot).toBeVisible();
+            });
+        });
+
+        test.describe('trailing', () => {
+            test('should render the trailing slot content', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {
+                    slots: {
+                        trailing: '<icon-placeholder id="trailing"></icon-placeholder>',
+                    },
+                });
+
+                // Act
+                const trailingSlot = component.locator('#trailing');
+
+                // Assert
+                expect(trailingSlot).toBeVisible();
+            });
+        });
+
+        test.describe('leading and trailing', () => {
+            test('should render both the leading and trailing slot content', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {
+                    slots: {
+                        leading: '<icon-placeholder id="leading"></icon-placeholder>',
+                        trailing: '<span id="trailing">#</span>',
+                    },
+                });
+
+                // Act
+                const leadingSlot = component.locator('#leading');
+                const trailingSlot = component.locator('#trailing');
+
+                // Assert
+                expect(leadingSlot).toBeVisible();
+                expect(trailingSlot).toBeVisible();
             });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5491,7 +5491,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-assistive-text@0.0.0, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
+"@justeattakeaway/pie-assistive-text@0.1.0, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text"
   dependencies:
@@ -5816,7 +5816,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-tag@0.5.0, @justeattakeaway/pie-tag@workspace:packages/components/pie-tag":
+"@justeattakeaway/pie-tag@0.6.0, @justeattakeaway/pie-tag@workspace:packages/components/pie-tag":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-tag@workspace:packages/components/pie-tag"
   dependencies:
@@ -28925,7 +28925,7 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-assistive-text": 0.0.0
+    "@justeattakeaway/pie-assistive-text": 0.1.0
     "@justeattakeaway/pie-button": 0.45.2
     "@justeattakeaway/pie-card": 0.17.2
     "@justeattakeaway/pie-chip": 0.0.0
@@ -28941,7 +28941,7 @@ __metadata:
     "@justeattakeaway/pie-notification": 0.3.1
     "@justeattakeaway/pie-spinner": 0.5.2
     "@justeattakeaway/pie-switch": 0.26.0
-    "@justeattakeaway/pie-tag": 0.5.0
+    "@justeattakeaway/pie-tag": 0.6.0
     "@storybook/addon-a11y": 7.6.3
     "@storybook/addon-designs": 7.0.7
     "@storybook/addon-essentials": 7.6.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Added] - Leading and Trailing content slots to pie-input component

## Author Checklist (complete before requesting a review)
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests
- [X] If it is a component change, I have reviewed the Storybook preview

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them
