### PR TITLE
docs(pie-docs): DSW-0 updates some images width on iconography page

### DIFF
--- a/.changeset/sour-gorillas-marry.md
+++ b/.changeset/sour-gorillas-marry.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Changed] - updates some image sizes for iconography foundation page

--- a/apps/pie-docs/src/foundations/iconography/overview.md
+++ b/apps/pie-docs/src/foundations/iconography/overview.md
@@ -15,7 +15,7 @@ This is the default icon set used throughout our products across Web, Android an
 
 {% contentPageImage {
     src: "../../../assets/img/foundations/iconography/small-icon-set.svg",
-    width: "33.91",
+    width: "35px",
     caption: "The example above shows what our ‘Kebab bowl’ icon looks like on the small set."
 } %}
 
@@ -25,7 +25,7 @@ This set should be used for illustrative purposes, such as communications or mar
 
 {% contentPageImage {
     src: "../../../assets/img/foundations/iconography/large-icon-set.svg",
-    width: "65.65px",
+    width: "70px",
     caption: "The example above shows what our ‘Kebab bowl’ icon looks like on the Large set."
 } %}
 
@@ -100,7 +100,7 @@ This is the default look for our icons and should always be considered as the fi
 
 {% contentPageImage {
     src: "../../../assets/img/foundations/iconography/appearance-default.svg",
-    width: "32.8px"
+    width: "35px"
 } %}
 
 ### Fill
@@ -109,7 +109,7 @@ Fill icons should be used sparingly, mainly for icons that need to present inter
 
 {% contentPageImage {
     src: "../../../assets/img/foundations/iconography/appearance-fill.svg",
-    width: "32.81px"
+    width: "35px"
 } %}
 
 ---
@@ -165,7 +165,7 @@ Abstract icons are more difficult to comprehend than literal icons. Instead of u
             alt: "This image shows a button with the text reading find a restaurant. The icon used is a magnifying glass as this image is often used to convey search functionality and is well understood in websites and apps"
         }]
     },
-    dont: { 
+    dont: {
         type: usageTypes.image,
         items: [{
             src: "../../../assets/img/foundations/iconography/how-to-choose-an-icon-dont.svg",
@@ -188,7 +188,7 @@ Icons act as a visual cue to improve the legibility and scannability of your pro
             alt: "This image shows an app menu bar with four icons. Each icon is accompanied by a label. For example there is an icon that represents a house coupled with a label that says home. This makes it clear that pressing the home icon takes you to the home page"
         }]
     },
-    dont: { 
+    dont: {
         type: usageTypes.image,
         items: [{
         src:"../../../assets/img/foundations/iconography/pairing-text-with-icons-dont.svg",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5491,53 +5491,53 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-assistive-text@0.2.1, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
+"@justeattakeaway/pie-assistive-text@0.2.2, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.45.4, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.45.5, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-spinner": 0.5.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-spinner": 0.5.4
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
     element-internals-polyfill: 1.3.10
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.17.3, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.17.4, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-chip@0.1.1, @justeattakeaway/pie-chip@workspace:packages/components/pie-chip":
+"@justeattakeaway/pie-chip@0.2.0, @justeattakeaway/pie-chip@workspace:packages/components/pie-chip":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-chip@workspace:packages/components/pie-chip"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.10.0
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-spinner": 0.5.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-spinner": 0.5.4
+    "@justeattakeaway/pie-webc-core": 0.19.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
@@ -5563,20 +5563,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-cookie-banner@0.17.2, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.17.3, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-divider": 0.12.2
-    "@justeattakeaway/pie-icon-button": 0.27.4
-    "@justeattakeaway/pie-link": 0.15.2
-    "@justeattakeaway/pie-modal": 0.38.6
-    "@justeattakeaway/pie-switch": 0.27.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-divider": 0.12.3
+    "@justeattakeaway/pie-icon-button": 0.27.5
+    "@justeattakeaway/pie-link": 0.15.3
+    "@justeattakeaway/pie-modal": 0.38.7
+    "@justeattakeaway/pie-switch": 0.27.1
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -5593,27 +5593,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-divider@0.12.2, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
+"@justeattakeaway/pie-divider@0.12.3, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.12.0, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.12.1, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-input": ^0.12.0
-    "@justeattakeaway/pie-switch": ^0.27.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-input": ^0.12.1
+    "@justeattakeaway/pie-switch": ^0.27.1
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -5625,15 +5625,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.27.4, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.27.5, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-spinner": 0.5.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-spinner": 0.5.4
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -5688,7 +5688,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-webc@0.17.3, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
+"@justeattakeaway/pie-icons-webc@0.18.0, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
@@ -5697,7 +5697,7 @@ __metadata:
     "@justeattakeaway/pie-components-config": 0.11.0
     "@justeattakeaway/pie-icons": 4.9.3
     "@justeattakeaway/pie-icons-configs": 4.5.1
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@rollup/plugin-typescript": 11.1.6
     "@web/test-runner": 0.16.1
     just-kebab-case: 4.2.0
@@ -5738,43 +5738,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-input@0.12.0, @justeattakeaway/pie-input@^0.12.0, @justeattakeaway/pie-input@workspace:packages/components/pie-input":
+"@justeattakeaway/pie-input@0.12.1, @justeattakeaway/pie-input@^0.12.1, @justeattakeaway/pie-input@workspace:packages/components/pie-input":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-input@workspace:packages/components/pie-input"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.15.2, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.15.3, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.38.6, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.38.7, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-icon-button": 0.27.4
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-spinner": 0.5.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icon-button": 0.27.5
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-spinner": 0.5.4
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     "@types/body-scroll-lock": 3.1.2
     body-scroll-lock: 3.1.5
@@ -5783,58 +5783,58 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-notification@0.3.2, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
+"@justeattakeaway/pie-notification@0.3.3, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-spinner@0.5.3, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
+"@justeattakeaway/pie-spinner@0.5.4, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-switch@0.27.0, @justeattakeaway/pie-switch@^0.27.0, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
+"@justeattakeaway/pie-switch@0.27.1, @justeattakeaway/pie-switch@^0.27.1, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
     element-internals-polyfill: 1.3.10
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-tag@0.7.0, @justeattakeaway/pie-tag@workspace:packages/components/pie-tag":
+"@justeattakeaway/pie-tag@0.7.1, @justeattakeaway/pie-tag@workspace:packages/components/pie-tag":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-tag@workspace:packages/components/pie-tag"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-webc-core": 0.19.0
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-core@0.18.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
+"@justeattakeaway/pie-webc-core@0.19.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   dependencies:
@@ -5856,10 +5856,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-components-config": 0.11.0
-    "@justeattakeaway/pie-modal": 0.38.6
-    "@justeattakeaway/pie-webc-core": 0.18.0
+    "@justeattakeaway/pie-modal": 0.38.7
+    "@justeattakeaway/pie-webc-core": 0.19.0
   languageName: unknown
   linkType: soft
 
@@ -28932,23 +28932,23 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-assistive-text": 0.2.1
-    "@justeattakeaway/pie-button": 0.45.4
-    "@justeattakeaway/pie-card": 0.17.3
-    "@justeattakeaway/pie-chip": 0.1.1
-    "@justeattakeaway/pie-cookie-banner": 0.17.2
+    "@justeattakeaway/pie-assistive-text": 0.2.2
+    "@justeattakeaway/pie-button": 0.45.5
+    "@justeattakeaway/pie-card": 0.17.4
+    "@justeattakeaway/pie-chip": 0.2.0
+    "@justeattakeaway/pie-cookie-banner": 0.17.3
     "@justeattakeaway/pie-css": 0.10.0
-    "@justeattakeaway/pie-divider": 0.12.2
-    "@justeattakeaway/pie-form-label": 0.12.0
-    "@justeattakeaway/pie-icon-button": 0.27.4
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-input": 0.12.0
-    "@justeattakeaway/pie-link": 0.15.2
-    "@justeattakeaway/pie-modal": 0.38.6
-    "@justeattakeaway/pie-notification": 0.3.2
-    "@justeattakeaway/pie-spinner": 0.5.3
-    "@justeattakeaway/pie-switch": 0.27.0
-    "@justeattakeaway/pie-tag": 0.7.0
+    "@justeattakeaway/pie-divider": 0.12.3
+    "@justeattakeaway/pie-form-label": 0.12.1
+    "@justeattakeaway/pie-icon-button": 0.27.5
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-input": 0.12.1
+    "@justeattakeaway/pie-link": 0.15.3
+    "@justeattakeaway/pie-modal": 0.38.7
+    "@justeattakeaway/pie-notification": 0.3.3
+    "@justeattakeaway/pie-spinner": 0.5.4
+    "@justeattakeaway/pie-switch": 0.27.1
+    "@justeattakeaway/pie-tag": 0.7.1
     "@storybook/addon-a11y": 7.6.3
     "@storybook/addon-designs": 7.0.7
     "@storybook/addon-essentials": 7.6.3
@@ -37873,7 +37873,7 @@ __metadata:
     "@angular/platform-browser": 15.2.0
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     rxjs: 7.8.0
     tslib: 2.3.0
@@ -37893,8 +37893,8 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.21.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-button": 0.45.4
-    "@justeattakeaway/pie-cookie-banner": 0.17.2
+    "@justeattakeaway/pie-button": 0.45.5
+    "@justeattakeaway/pie-cookie-banner": 0.17.3
     "@justeattakeaway/pie-css": 0.10.0
     "@lit/react": 1.0.2
     babel-loader: 8
@@ -37911,7 +37911,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     "@lit-labs/nextjs": 0.1.3
     "@lit/react": 1.0.2
@@ -37933,7 +37933,7 @@ __metadata:
     "@babel/plugin-transform-logical-assignment-operators": 7.22.11
     "@babel/plugin-transform-nullish-coalescing-operator": 7.22.11
     "@babel/plugin-transform-optional-chaining": 7.23.0
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     babel-loader: 8
     core-js: 3.30.0
@@ -37948,7 +37948,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     "@types/node": 18
     nuxt: 3.4.3
@@ -37960,7 +37960,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     "@lit/react": 1.0.2
     react: 17.0.2
@@ -37973,7 +37973,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     "@lit/react": 1.0.2
     react: 18.2.0
@@ -37987,11 +37987,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 5.9.0
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
-    "@justeattakeaway/pie-icon-button": 0.27.4
-    "@justeattakeaway/pie-icons-webc": 0.17.3
-    "@justeattakeaway/pie-modal": 0.38.6
+    "@justeattakeaway/pie-icon-button": 0.27.5
+    "@justeattakeaway/pie-icons-webc": 0.18.0
+    "@justeattakeaway/pie-modal": 0.38.7
     vite: 4.5.2
   languageName: unknown
   linkType: soft
@@ -38000,7 +38000,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.4
+    "@justeattakeaway/pie-button": 0.45.5
     "@justeattakeaway/pie-css": 0.10.0
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

During another work I noticed that a few image size values were incorrect on iconography overview page.

---
"pie-docs": patch
---

[Changed] - updates some image sizes for iconography foundation page.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [x] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
- [x] If there are visual test updates, I have reviewed them
