### PR TITLE
chore(pie-assistive-text): DSW-1773 update conditional rendering

### DIFF
--- a/.changeset/forty-bats-float.md
+++ b/.changeset/forty-bats-float.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-assistive-text": patch
+---
+
+[Fixed] - Issue where self-closing tag was causing rendering issues of variant icon in SPA's

--- a/packages/components/pie-assistive-text/src/index.ts
+++ b/packages/components/pie-assistive-text/src/index.ts
@@ -21,7 +21,7 @@ const componentSelector = 'pie-assistive-text';
  * @slot - Default slot
  */
 export class PieAssistiveText extends LitElement implements AssistiveTextProps {
-    @property()
+    @property({ type: String })
     @validPropertyValues(componentSelector, variants, 'default')
     public variant?: AssistiveTextProps['variant'] = 'default';
 
@@ -32,8 +32,8 @@ export class PieAssistiveText extends LitElement implements AssistiveTextProps {
     private renderIcon (): TemplateResult {
         const { variant } = this;
         return html`
-            ${variant === 'success' ? html`<icon-check-circle class="c-assistiveText-icon" size="s" />` : nothing}
-            ${variant === 'error' ? html`<icon-alert-circle class="c-assistiveText-icon" size="s" />` : nothing}`;
+            ${variant === 'success' ? html`<icon-check-circle class="c-assistiveText-icon" size="s" ></icon-check-circle>` : nothing}
+            ${variant === 'error' ? html`<icon-alert-circle class="c-assistiveText-icon" size="s"></icon-alert-circle>` : nothing}`;
     }
 
     render () {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
This PR fixes an issue with pie-assistive-text where the conditional rendering implementation for icons was causing slots not to render in SPA applications. Moving the conditional logic to the template seems to fix the issue.

I've tested my changes in Aperture using the snapshot, and the slot now renders as expected across all aperture apps 👍🏼 

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If it is a component change, I have reviewed the Storybook preview
- [x] If there are visual test updates, I have reviewed them properly before approving

No visual tests to review
