### PR TITLE
fix(pie-icons-react): DSW-000 fix incorrect "types" location in package.json

### DIFF
--- a/.changeset/purple-oranges-pay.md
+++ b/.changeset/purple-oranges-pay.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-react": patch
+---
+
+[Fixed] - Incorrect "types" location in package.json

--- a/packages/tools/pie-icons-react/package.json
+++ b/packages/tools/pie-icons-react/package.json
@@ -3,7 +3,7 @@
   "version": "4.15.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "esm/index.d.ts",
+  "types": "esm/icons/index.d.ts",
   "exports": {
     ".": {
       "import": "./esm/index.js",


### PR DESCRIPTION
Hey, we're trying to use `@justeattakeaway/pie-icons-react` in one of our Typescript projects. When we try and import one of the icons we receive the following error: 

> error TS7016: Could not find a declaration file for module '@justeattakeaway/pie-icons-react'. '/Users/xxx.xxx/xxx/node_modules/@justeattakeaway/pie-icons-react/dist/index.js' implicitly has an 'any' type.

I attempted to debug using `tsc --traceResolution`. It seems to try and load `esm/index.d.ts` as referenced in the[ package.json file](https://github.com/jansul/justeattakeaway-pie/blob/main/packages/tools/pie-icons-react/package.json#L6), however this does not seem to actually exist in the distributed files.

This PR updates the above to instead point to `esm/icons/index.d.ts`. There is also a copy in `dist/icons/index.d.ts`, however the esm version seemed more appropriate given it was already looking for a file there. I don't know too much about ES modules though 😅 

I've tested this by modifying `package.json` locally, and the types seem to work as expected:

![image](https://github.com/jansul/justeattakeaway-pie/assets/1927518/abe38ee1-ea1b-48bf-a280-3144fad8f630)
