### PR TITLE
fix(pie-docs): DSW-000 add correct storybook link to webc page link

### DIFF
--- a/.changeset/eighty-suits-explode.md
+++ b/.changeset/eighty-suits-explode.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Added] - Correct link added for web component storybook page

--- a/apps/pie-docs/src/engineers/getting-started/structure.md
+++ b/apps/pie-docs/src/engineers/getting-started/structure.md
@@ -14,7 +14,7 @@ Currently, JET has several officially supported component systems that implement
 - [Snacks](https://snacks.takeaway.com/) – a set of **React components** created by the legacy Takeaway design system team
 - [Skip PIE Project](https://react.pie.design/) – a set of **React components** created by the Skip web team
 
-We are also currently building the [PIE Web Component System](https://www.pie.design/storybook). The long-term aim will be to migrate JET teams over to this Web Component System, so we have **one single source of truth** for our global PIE components.
+We are also currently building the [PIE Web Component System](https://webc.pie.design/). The long-term aim will be to migrate JET teams over to this Web Component System, so we have **one single source of truth** for our global PIE components.
 
 For more details on Fozzie, Snacks and Skip PIE, please check out the **documentation portals** linked above.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5535,19 +5535,19 @@ __metadata:
   resolution: "@justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-webc-core": 0.19.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.45.6, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.46.0, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-spinner": 0.5.5
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
@@ -5556,12 +5556,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.17.5, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.18.0, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
@@ -5581,7 +5581,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-components-config@0.12.0, @justeattakeaway/pie-components-config@workspace:configs/pie-components-config":
+"@justeattakeaway/pie-components-config@0.13.0, @justeattakeaway/pie-components-config@workspace:configs/pie-components-config":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-components-config@workspace:configs/pie-components-config"
   dependencies:
@@ -5604,18 +5604,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-cookie-banner@0.17.6, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.18.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeat/pie-design-tokens": 6.0.0
-    "@justeattakeaway/pie-button": 0.45.6
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-button": 0.46.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-divider": 0.12.4
     "@justeattakeaway/pie-icon-button": 0.27.7
-    "@justeattakeaway/pie-link": 0.15.4
-    "@justeattakeaway/pie-modal": 0.40.0
+    "@justeattakeaway/pie-link": 0.16.0
+    "@justeattakeaway/pie-modal": 0.41.0
     "@justeattakeaway/pie-switch": 0.27.3
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
@@ -5639,7 +5639,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
@@ -5651,7 +5651,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-input": ^0.14.0
     "@justeattakeaway/pie-switch": ^0.27.3
     "@justeattakeaway/pie-webc-core": 0.19.1
@@ -5671,7 +5671,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-spinner": 0.5.5
     "@justeattakeaway/pie-webc-core": 0.19.1
@@ -5735,7 +5735,7 @@ __metadata:
   dependencies:
     "@babel/core": 7.23.9
     "@babel/node": 7.20.7
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icons": 4.14.0
     "@justeattakeaway/pie-icons-configs": 4.5.1
     "@justeattakeaway/pie-webc-core": 0.19.1
@@ -5772,19 +5772,19 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-assistive-text": 0.2.4
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.15.4, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.16.0, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
@@ -5792,14 +5792,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.40.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.41.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeat/pie-design-tokens": 6.0.0
-    "@justeattakeaway/pie-button": 0.45.6
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-button": 0.46.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icon-button": 0.27.7
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-spinner": 0.5.5
@@ -5817,7 +5817,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icon-button": 0.27.7
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-webc-core": 0.19.1
@@ -5831,7 +5831,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     cem-plugin-module-file-extensions: 0.0.5
@@ -5843,7 +5843,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
@@ -5857,7 +5857,7 @@ __metadata:
   resolution: "@justeattakeaway/pie-tag@workspace:packages/components/pie-tag"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-webc-core": 0.19.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
@@ -5869,12 +5869,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   dependencies:
-    "@justeattakeaway/pie-components-config": 0.12.0
+    "@justeattakeaway/pie-components-config": 0.13.0
     lit: 3.1.2
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-testing@0.12.0, @justeattakeaway/pie-webc-testing@workspace:packages/components/pie-webc-testing":
+"@justeattakeaway/pie-webc-testing@0.12.1, @justeattakeaway/pie-webc-testing@workspace:packages/components/pie-webc-testing":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-testing@workspace:packages/components/pie-webc-testing"
   peerDependencies:
@@ -5887,9 +5887,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.6
-    "@justeattakeaway/pie-components-config": 0.12.0
-    "@justeattakeaway/pie-modal": 0.40.0
+    "@justeattakeaway/pie-button": 0.46.0
+    "@justeattakeaway/pie-components-config": 0.13.0
+    "@justeattakeaway/pie-modal": 0.41.0
     "@justeattakeaway/pie-webc-core": 0.19.1
   languageName: unknown
   linkType: soft
@@ -29120,7 +29120,7 @@ __metadata:
     "@justeattakeaway/browserslist-config-pie": 0.2.0
     "@justeattakeaway/generator-pie-component": 0.20.1
     "@justeattakeaway/pie-icons": 4.14.0
-    "@justeattakeaway/pie-webc-testing": 0.12.0
+    "@justeattakeaway/pie-webc-testing": 0.12.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
     "@justeattakeaway/stylelint-config-pie": 0.7.0
     "@percy/cli": 1.26.3
@@ -29176,18 +29176,18 @@ __metadata:
   dependencies:
     "@justeat/pie-design-tokens": 6.0.0
     "@justeattakeaway/pie-assistive-text": 0.2.4
-    "@justeattakeaway/pie-button": 0.45.6
-    "@justeattakeaway/pie-card": 0.17.5
+    "@justeattakeaway/pie-button": 0.46.0
+    "@justeattakeaway/pie-card": 0.18.0
     "@justeattakeaway/pie-chip": 0.3.0
-    "@justeattakeaway/pie-cookie-banner": 0.17.6
+    "@justeattakeaway/pie-cookie-banner": 0.18.0
     "@justeattakeaway/pie-css": 0.11.0
     "@justeattakeaway/pie-divider": 0.12.4
     "@justeattakeaway/pie-form-label": 0.12.2
     "@justeattakeaway/pie-icon-button": 0.27.7
     "@justeattakeaway/pie-icons-webc": 0.19.1
     "@justeattakeaway/pie-input": 0.14.0
-    "@justeattakeaway/pie-link": 0.15.4
-    "@justeattakeaway/pie-modal": 0.40.0
+    "@justeattakeaway/pie-link": 0.16.0
+    "@justeattakeaway/pie-modal": 0.41.0
     "@justeattakeaway/pie-notification": 0.3.5
     "@justeattakeaway/pie-spinner": 0.5.5
     "@justeattakeaway/pie-switch": 0.27.3
@@ -38174,7 +38174,7 @@ __metadata:
     "@angular/platform-browser": 15.2.0
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     rxjs: 7.8.0
     tslib: 2.3.0
@@ -38194,8 +38194,8 @@ __metadata:
     "@babel/plugin-transform-runtime": 7.21.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-react": 7.18.6
-    "@justeattakeaway/pie-button": 0.45.6
-    "@justeattakeaway/pie-cookie-banner": 0.17.6
+    "@justeattakeaway/pie-button": 0.46.0
+    "@justeattakeaway/pie-cookie-banner": 0.18.0
     "@justeattakeaway/pie-css": 0.11.0
     "@lit/react": 1.0.2
     babel-loader: 8
@@ -38212,7 +38212,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     "@lit-labs/nextjs": 0.1.3
     "@lit/react": 1.0.2
@@ -38234,7 +38234,7 @@ __metadata:
     "@babel/plugin-transform-logical-assignment-operators": 7.22.11
     "@babel/plugin-transform-nullish-coalescing-operator": 7.22.11
     "@babel/plugin-transform-optional-chaining": 7.23.0
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     babel-loader: 8
     core-js: 3.30.0
@@ -38249,7 +38249,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     "@types/node": 18
     nuxt: 3.4.3
@@ -38261,7 +38261,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     "@lit/react": 1.0.2
     react: 17.0.2
@@ -38274,7 +38274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     "@lit/react": 1.0.2
     react: 18.2.0
@@ -38288,11 +38288,11 @@ __metadata:
   resolution: "wc-vanilla@workspace:apps/examples/wc-vanilla"
   dependencies:
     "@justeat/pie-design-tokens": 6.0.0
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     "@justeattakeaway/pie-icon-button": 0.27.7
     "@justeattakeaway/pie-icons-webc": 0.19.1
-    "@justeattakeaway/pie-modal": 0.40.0
+    "@justeattakeaway/pie-modal": 0.41.0
     vite: 4.5.2
   languageName: unknown
   linkType: soft
@@ -38301,7 +38301,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
-    "@justeattakeaway/pie-button": 0.45.6
+    "@justeattakeaway/pie-button": 0.46.0
     "@justeattakeaway/pie-css": 0.11.0
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Adds a correct link to https://webc.pie.design/ for the web components storybook page. Was previously a url going to a 404 page.

## Author Checklist (complete before requesting a review)
- [X] I have performed a self-review of my code
- [X] If it is a `PIE Docs` change, I have reviewed the Docs site preview

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview

### Reviewer 2
- [x] If it is a `PIE Docs` change, I have reviewed the PR preview
