### PR TITLE
revert(pie-monorepo): DSW-000 revert turbo update

### DIFF
--- a/.changeset/long-peaches-learn.md
+++ b/.changeset/long-peaches-learn.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Changed] - Reverted `turbo` back to `1.10.16`. Our current caused a bug that resulted in the `check-change-type` CI job not corretly detecting changes in the repo, resulting in deployments not being triggered.

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "stylelint-config-standard-scss": "13.0.0",
     "stylelint-order": "6.0.4",
     "ts-node": "10.9.1",
-    "turbo": "1.12.4",
+    "turbo": "1.10.16",
     "typescript": "5.1.3",
     "vite": "4.5.2",
     "vite-plugin-dts": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29159,7 +29159,7 @@ __metadata:
     stylelint-config-standard-scss: 13.0.0
     stylelint-order: 6.0.4
     ts-node: 10.9.1
-    turbo: 1.12.4
+    turbo: 1.10.16
     typescript: 5.1.3
     vite: 4.5.2
     vite-plugin-dts: 2.3.0
@@ -36303,58 +36303,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo-darwin-64@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo-darwin-64@npm:1.12.4"
+"turbo-darwin-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-darwin-64@npm:1.10.16"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-darwin-arm64@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo-darwin-arm64@npm:1.12.4"
+"turbo-darwin-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-darwin-arm64@npm:1.10.16"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-linux-64@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo-linux-64@npm:1.12.4"
+"turbo-linux-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-linux-64@npm:1.10.16"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm64@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo-linux-arm64@npm:1.12.4"
+"turbo-linux-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-linux-arm64@npm:1.10.16"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-windows-64@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo-windows-64@npm:1.12.4"
+"turbo-windows-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-windows-64@npm:1.10.16"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-windows-arm64@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo-windows-arm64@npm:1.12.4"
+"turbo-windows-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-windows-arm64@npm:1.10.16"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo@npm:1.12.4":
-  version: 1.12.4
-  resolution: "turbo@npm:1.12.4"
+"turbo@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo@npm:1.10.16"
   dependencies:
-    turbo-darwin-64: 1.12.4
-    turbo-darwin-arm64: 1.12.4
-    turbo-linux-64: 1.12.4
-    turbo-linux-arm64: 1.12.4
-    turbo-windows-64: 1.12.4
-    turbo-windows-arm64: 1.12.4
+    turbo-darwin-64: 1.10.16
+    turbo-darwin-arm64: 1.10.16
+    turbo-linux-64: 1.10.16
+    turbo-linux-arm64: 1.10.16
+    turbo-windows-64: 1.10.16
+    turbo-windows-arm64: 1.10.16
   dependenciesMeta:
     turbo-darwin-64:
       optional: true
@@ -36370,7 +36370,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: d387fb91af6ed0ea925201d3858180353c5d93be564829de2e22f48fe57124d1347d2abb8b99215901a305d4c6da4a0daf4c28afeec20fa1bc1ae2762c3b8d3d
+  checksum: 69d1892593449b264e0bd48b851317a743016ab62cf470e7293b2cc3781240e863c48232c89f65a5a4ce97eb791ca550b201593449350da073db07703a19cfa5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
---
"pie-monorepo": patch
---

[Changed] - Reverted `turbo` back to `1.10.16`. Our current caused a bug that resulted in the `check-change-type` CI job not corretly detecting changes in the repo, resulting in deployments not being triggered.


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
