### PR TITLE
feat(pie-input): DSW-1586 add size property to input component

### DIFF
--- a/.changeset/eighty-pears-sip.md
+++ b/.changeset/eighty-pears-sip.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - Support for the new `size` prop in `pie-input`

--- a/.changeset/new-mayflies-wait.md
+++ b/.changeset/new-mayflies-wait.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-input": minor
+---
+
+[Added] - `size` property to input component

--- a/apps/pie-storybook/stories/pie-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-input.stories.ts
@@ -6,7 +6,7 @@ import { useArgs as UseArgs } from '@storybook/preview-api';
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-input';
 import {
-    types, inputModes, statusTypes, InputProps as InputPropsBase,
+    types, inputModes, statusTypes, InputProps as InputPropsBase, sizes,
 } from '@justeattakeaway/pie-input';
 /* eslint-enable import/no-duplicates */
 
@@ -34,6 +34,7 @@ const defaultArgs: InputProps = {
     leadingSlot: 'None',
     trailingSlot: 'None',
     assistiveText: '',
+    size: 'medium',
 };
 
 const slotOptions = ['Icon (Placeholder)', 'Short text (#)', 'None'] as const;
@@ -188,6 +189,11 @@ const inputStoryMeta: InputStoryMeta = {
                 summary: undefined,
             },
         },
+        size: {
+            description: 'The size of the input field. Can be `small`, `medium`, or `large`. Defaults to `medium`.',
+            control: 'select',
+            options: sizes,
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -219,6 +225,7 @@ const Template = ({
     assistiveText,
     status,
     step,
+    size,
 }: InputProps) => {
     const [, updateArgs] = UseArgs();
 
@@ -271,6 +278,7 @@ const Template = ({
             ?readonly="${readonly}"
             assistiveText="${ifDefined(assistiveText)}"
             status=${ifDefined(status)}
+            size="${ifDefined(size)}"
             @input="${onInput}"
             @change="${onChange}">
             ${renderLeadingOrTrailingSlot('leading', leadingSlot)}

--- a/packages/components/pie-input/README.md
+++ b/packages/components/pie-input/README.md
@@ -92,6 +92,7 @@ import { PieInput } from '@justeattakeaway/pie-input/dist/react';
 | `step` | `number` | - | An optional amount that value should be incremented or decremented by when using the up and down arrows in the input. Only applies when type is `number`. |
 | `min` | `number` | - | The minimum value of the input. Only applies when type is `number`. If the value provided is lower, the input is invalid. |
 | `max` | `number` | - | The maximum value of the input. Only applies when type is `number`. If the value provided is higher, the input is invalid. |
+| `size` | `'small'`, `'medium'`, `'large'` | `medium` | The size of the input field. Can be `small`, `medium`, or `large`. Defaults to `medium`. |
 
 
 In your markup or JSX, you can then use these to set the properties for the `pie-input` component:

--- a/packages/components/pie-input/src/defs.ts
+++ b/packages/components/pie-input/src/defs.ts
@@ -1,6 +1,8 @@
 export const types = ['text', 'number', 'password', 'url', 'email', 'tel'] as const;
 export const inputModes = ['none', 'text', 'tel', 'url', 'email', 'numeric', 'decimal', 'search'] as const;
 export const statusTypes = ['success', 'error'] as const;
+export const sizes = ['small', 'medium', 'large'] as const;
+
 export interface InputProps {
     /**
      * The type of HTML input to render.
@@ -96,6 +98,11 @@ export interface InputProps {
      * The maximum value of the input. Only applies when type is `number`. If the value provided is higher, the input is invalid.
      */
     max?: number;
+
+    /**
+     * The size of the input field. Can be `small`, `medium`, or `large`. Defaults to `medium`.
+     */
+    size?: typeof sizes[number];
 }
 
 // TODO - There is a ticket to add default prop values to our existing components. This might be replaced by the code added in that ticket.
@@ -107,7 +114,7 @@ type SubsetRequiredProperties<T, K extends keyof T> = Required<Pick<T, K>>;
 /**
  * The default values for the `InputProps` that are required (i.e. they have a fallback value in the component).
  */
-type DefaultInputPropValues = SubsetRequiredProperties<InputProps, 'type' | 'value'>;
+type DefaultInputPropValues = SubsetRequiredProperties<InputProps, 'type' | 'value' | 'size'>;
 
 /**
  * Default values for optional properties that have default fallback values in the component.
@@ -115,4 +122,5 @@ type DefaultInputPropValues = SubsetRequiredProperties<InputProps, 'type' | 'val
 export const InputDefaultPropertyValues: DefaultInputPropValues = {
     type: 'text',
     value: '',
+    size: 'medium',
 };

--- a/packages/components/pie-input/src/index.ts
+++ b/packages/components/pie-input/src/index.ts
@@ -86,6 +86,9 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
     @property({ type: Number })
     public max?: InputProps['max'];
 
+    @property({ type: String })
+    public size?: InputProps['size'] = InputDefaultPropertyValues.size;
+
     @query('input')
     private input?: HTMLInputElement;
 
@@ -173,10 +176,11 @@ export class PieInput extends FormControlMixin(RtlMixin(LitElement)) implements 
             status,
             type,
             value,
+            size,
         } = this;
 
         return html`
-            <div>
+            <div data-test-id="pie-input-shell" size=${ifDefined(size)}>
                 <slot name="leading"></slot>
                 <input
                     type=${ifDefined(type)}

--- a/packages/components/pie-input/test/component/pie-input.spec.ts
+++ b/packages/components/pie-input/test/component/pie-input.spec.ts
@@ -8,6 +8,7 @@ import { statusTypes } from '../../src/defs.ts';
 
 const componentSelector = '[data-test-id="pie-input"]';
 const assistiveTextSelector = '[data-test-id="pie-input-assistive-text"]';
+const componentShellSelector = '[data-test-id="pie-input-shell"]';
 
 /**
  * Sets up form data extraction for testing form submissions. This function expects a form element
@@ -765,6 +766,34 @@ test.describe('PieInput - Component tests', () => {
 
                 // Assert
                 expect(isValid).toBe(true);
+            });
+        });
+
+        test.describe('size', () => {
+            test('should default to medium size if no size prop provided', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {});
+
+                // Act
+                const inputShell = component.locator(componentShellSelector);
+
+                // Assert
+                expect(inputShell).toHaveAttribute('size', 'medium');
+            });
+
+            test('should apply the size prop to the HTML input rendered', async ({ mount }) => {
+                // Arrange
+                const component = await mount(PieInput, {
+                    props: {
+                        size: 'large',
+                    } as InputProps,
+                });
+
+                // Act
+                const inputShell = component.locator(componentShellSelector);
+
+                // Assert
+                expect(inputShell).toHaveAttribute('size', 'large');
             });
         });
     });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Adds a new `size` property to `pie-input`. Styling will come in an upcoming ticket.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] If it is a component change, I have reviewed the Storybook preview

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] If it is a component change, I have reviewed the Storybook preview

### Reviewer 2
- [x] If it is a component change, I have reviewed the Storybook preview
(Reviewed by @xander-marjoram)
