### PR TITLE
ci(pie-monorepo): DSW-1755 trigger aperture workflows via /test-aperture comment

### DIFF
--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -1,0 +1,50 @@
+module.exports = async ({ github, context }, execa) => {
+    await execa.command('yarn changeset:version --snapshot snapshot-release', { stdio: 'inherit' });
+
+    const releaseProcess = execa.command('yarn changeset:publish --no-git-tags --snapshot --tag snapshot-release');
+    releaseProcess.stdout.pipe(process.stdout);
+
+    const { stdout } = await releaseProcess;
+
+    const newTags = Array
+        .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
+        .map(([_, tag]) => tag)
+        .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
+
+    let body;
+
+    if (newTags.length > 0) {
+        const multiple = newTags.length > 1;
+
+        body = `@${context.actor} Your snapshot${multiple ? 's have' : ' has'} been published to npm!\n\nTest the snapshot${multiple ? 's' : ''} by updating your \`package.json\` with the newly-published version${multiple ? 's' : ''}:\n`;
+
+        if (multiple) {
+            body += `> [!NOTE]\n> If you have more than one of these packages installed, we suggest using the new snapshots for all of them to help avoid version conflicts.\n\n${newTags.map(tag => `\`\`\`sh\nyarn up ${tag} --mode=update-lockfile\n\`\`\``).join('\n')}\nThen finally:\n\`\`\`sh\nyarn install\n\`\`\``;
+        } else {
+            body += `\`\`\`sh\nyarn up ${newTags[0]}\n\`\`\``;
+        }
+
+        // Dispatch event to PIE Aperture using node-fetch
+        await github.rest.actions.createWorkflowDispatch({
+            owner: 'justeattakeaway',
+            repo: 'pie-aperture',
+            event_type: 'pie-trigger',
+            ref: 'main',
+            inputs: {
+              'pie-branch': '${{ github.ref_name }}',
+              'snapshots': newTags
+            }
+          })
+
+    } else {
+        body = `No changed packages found! Please make sure you have added a changeset entry for the packages you would like to snapshot.`;
+    }
+
+    // Create a GitHub comment with the update instructions
+    await github.rest.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body,
+    });
+};

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -24,7 +24,7 @@ module.exports = async ({ github, context }, execa) => {
             body += `\`\`\`sh\nyarn up ${newTags[0]}\n\`\`\``;
         }
 
-        // Dispatch event to PIE Aperture using node-fetch
+        // Dispatch event to PIE Aperture using github script
         await github.rest.actions.createWorkflowDispatch({
             owner: 'justeattakeaway',
             repo: 'pie-aperture',

--- a/.github/workflows/test-aperture.yml
+++ b/.github/workflows/test-aperture.yml
@@ -1,0 +1,152 @@
+name: Changeset Snapshot
+
+on:
+  issue_comment:
+    types:
+      - created
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  snapshot:
+    name: Snapshot Release
+    if: |
+      github.event.issue.pull_request &&
+      (startsWith(github.event.comment.body, '/test-aperture'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce permission requirement
+        uses: prince-chrismc/check-actor-permissions-action@v1
+        with:
+          permission: write
+
+      - name: Add initial reaction
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.CHANGESETS_TOKEN }}
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
+      - name: Validate pull request
+        uses: actions/github-script@v6
+        id: pr_data
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+        with:
+          script: |
+            try {
+              const pullRequest = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+
+              // Pull request from fork
+              if (context.payload.repository.full_name !== pullRequest.data.head.repo.full_name) {
+                const errorMessage = '`/test-aperture` is not supported on pull requests from forked repositories.';
+
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: errorMessage,
+                });
+
+                core.setFailed(errorMessage);
+              }
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`);
+            }
+
+      - name: Add link to build
+        uses: actions/github-script@v6
+        id: build-link
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+        with:
+          github-token: ${{ secrets.CHANGESETS_TOKEN }}
+          script: |
+            try {
+              const buildLink = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+              const body = `Starting a new snapshot build. You can view the logs [here](${buildLink}).`;
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`);
+            }
+
+       # issue_comment event doesn't provide access to head_ref env var.
+       # This action provides us with the env vars we need to do a git diff.
+       # https://github.com/actions/checkout/issues/331#issuecomment-1242708547
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: Checkout default branch
+        uses: actions/checkout@v3
+
+      # issue_comment requires us to checkout the branch
+      # https://github.com/actions/checkout/issues/331#issuecomment-1120113003
+      - name: Checkout pull request branch
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Repo
+        uses: ./.github/actions/setup-repo
+        with:
+          node-version: 20
+          os: ubuntu-latest
+
+      - name: Create an .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+
+      - name: Build Packages
+        uses: ./.github/actions/run-script
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        with:
+          script-name: "build"
+
+      - name: Get Markdown Changeset Files Difference
+        id: diff_changeset_files
+        run: |
+            git fetch origin ${{ steps.comment-branch.outputs.base_ref }}
+            git diff --name-only origin/${{ steps.comment-branch.outputs.base_ref }}...HEAD .changeset/*.md > changeset_diff.txt
+
+      - name: Delete Unrelated Markdown Files in Changeset
+        run: |
+            for file in $(ls .changeset/*.md); do
+              if ! grep -q "$(basename $file)" changeset_diff.txt; then
+                rm "$file"
+              fi
+            done
+
+      - name: Create and publish snapshot release and trigger aperture
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+        with:
+          github-token: ${{ secrets.CHANGESETS_TOKEN }}
+          script: |
+            const execa = require('execa');
+            const script = require('./.github/workflows/changeset-snapshot/test-aperture.js')
+            await script({ github, context }, execa);
+
+      - name: Add failure comment
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          token: ${{ secrets.CHANGESETS_TOKEN }}
+          body: The build failed, please see the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) or take a look at the [Workflow Tooling wiki page](https://github.com/justeattakeaway/pie/wiki/Workflow-Tooling#snapshot-releases) to make sure your PR meets the requirements.

--- a/yarn.lock
+++ b/yarn.lock
@@ -27383,6 +27383,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:2, node-fetch@npm:^2.0.0, node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:2.6.1":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
@@ -27401,20 +27415,6 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.0.0, node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: ^5.0.0
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 
@@ -29152,6 +29152,7 @@ __metadata:
     glob: 10.3.3
     husky: 8.0.3
     jsdom: 24.0.0
+    node-fetch: 2
     npm-run-all: 4.1.5
     pinst: 3.0.0
     postcss: 8.4.32


### PR DESCRIPTION
This is a small PR (that's still a WIP) that will allow me to more easily test CI triggers between PIE <> Aperture, given GHA can be quite tricky to run on forked repositories.

This PR simply duplicates the existing snapshot JS, and adds some additional code to fire an event to PIE Aperture.

I've also duplicated the `/snapit` action, but instead, using `/test-aperture` to test these changes without impacting existing functionality.

The goal of this PR is just to use it for testing purposes until we've proven it works, afterwhich, it'll be refactored to make better use of our existing code.

GHA workflows that're triggered via comments need to exist within `main` for security reasons, hence why I'm looking to merge this in a WIP state.


**End goal**

The end goal for this work, is to allow contributors to add a `/test-aperture` comment to their PIE PR, and have Github actions:

- Automatically create a branch in PIE Aperture (if it doesn't exist)
- This PR will contain updates to all the package.json files to update to the latest snapshot changes, allowing us to more easily trigger the deployment / CI tests in Aperture, _before_ a PIE PR has merged.

- Having an automated mechanism in place, allows us to more easily enforce these checks have been done, as testing of changes in Aperture is currently quite inconsistent from change to change.