### PR TITLE
feat(pie-icons-webc): DSW-000 set height and width on icon hosts (follow up)

### DIFF
--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -32,7 +32,6 @@ $breakpoint-wide: 768px;
     --btn-height--small: 40px;
     --btn-height--medium: 48px;
     --btn-height--large: 56px;
-    --icon-display-override: block;
 
     /**
     * Mixin for updating the button styles based on the size passed in.

--- a/packages/components/pie-chip/src/chip.scss
+++ b/packages/components/pie-chip/src/chip.scss
@@ -47,7 +47,7 @@
     --chip-dismissible-offset: calc(var(--chip-gap) / -2); // ensures the spacing between the text and close icon is 4px
 
     // Pie Webc Icon var that is used to ensure the correctly sized icon passed in a slot
-    --icon-display-override: block;
+    --icon-size-override: 16px;
 
     position: relative;
     display: flex;

--- a/packages/components/pie-icon-button/src/iconButton.scss
+++ b/packages/components/pie-icon-button/src/iconButton.scss
@@ -14,7 +14,6 @@
     --btn-border-radius: var(--dt-radius-rounded-e);
     --btn-bg-color: var(--dt-color-interactive-brand);
     --btn-icon-fill: var(--dt-color-content-interactive-primary);
-    --icon-display-override: block;
 
     block-size: var(--btn-dimension, var(--btn-dimension-default));
     inline-size: var(--btn-dimension, var(--btn-dimension-default));

--- a/packages/components/pie-tag/src/tag.scss
+++ b/packages/components/pie-tag/src/tag.scss
@@ -16,7 +16,6 @@
     --tag-transparent-bg-color: transparent;
 
     // Pie Webc Icon var that is used to ensure the correctly sized icon passed in a slot
-    --icon-display-override: block;
     --icon-size-override: 16px;
 
     display: inline-flex;

--- a/packages/tools/pie-icons-webc/build.js
+++ b/packages/tools/pie-icons-webc/build.js
@@ -36,13 +36,17 @@ const componentSelector = '${kebabCase(name)}';
  * @tagname ${kebabCase(name)}
  */
 export class ${name} extends LitElement implements IconProps {
-    // The following styles make sure that the icon will be sized correctly
+    // The following styles make sure that the icon will be sized correctly.
+    // "--icon-size-override" css var can be used in parent components to make sure the icon
+    // stays the correct size for cases where the icon is added by consumers via a slot,
+    // for example in Button, IconButton, Chip and Tag.
+    // Might be changed later to assigning a size prop to an icon slot
+    // (POC: https://github.com/justeattakeaway/pie/pull/1128)
     static styles = css\`
         :host {
             display: inline-block;
         }
         :host svg {
-            display: var(--icon-display-override);
             width: var(--icon-size-override);
             height: var(--icon-size-override);
         }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

Looks like `--icon-display-override` var is not needed anymore if we set display style on the host. I also noticed that for pie-chip `--icon-size-override` was not set to any value so I corrected it as well.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] If it is a `PIE Docs` change, I have reviewed the Docs site preview
- [ ] If it is a component change, I have reviewed the Storybook preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] If it is a `PIE Docs` change, I have reviewed the PR preview
- [ ] If there are visual test updates, I have reviewed them
