### PR TITLE
chore(pie-monorepo): DSW-1755 use correct function to dispatch pie-aperture workflow

### DIFF
--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -30,8 +30,7 @@ module.exports = async ({ github, context }, execa) => {
                 owner: 'justeattakeaway',
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
-                ref: 'main',
-                inputs: {
+                client_payload: {
                   'pie-branch': '${{ github.ref_name }}',
                   'pie-pr-number': '${{ github.event.number }}',
                   'snapshots': JSON.stringify(newTags)

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -26,13 +26,14 @@ module.exports = async ({ github, context }, execa) => {
 
         try {
             // Attempt to dispatch event to PIE Aperture
-            await github.rest.actions.createWorkflowDispatch({
+            await github.rest.repos.createDispatchEvent({
                 owner: 'justeattakeaway',
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 ref: 'main',
                 inputs: {
                   'pie-branch': '${{ github.ref_name }}',
+                  'pie-pr-number': '${{ github.event.number }}',
                   'snapshots': JSON.stringify(newTags)
                 }
               })


### PR DESCRIPTION
I was accidentally using the wrong function to trigger the PIE aperture repo from PIE. This PR should address it!