### PR TITLE
feat(pie-switch): DSW-1758 remove unnecessary id

### DIFF
--- a/.changeset/dirty-kings-live.md
+++ b/.changeset/dirty-kings-live.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-switch": minor
+---
+
+[Changed] - markup to remove the Input element's id
+[Removed] - redundant browser tests that relied on the element's id

--- a/packages/components/pie-switch/src/index.ts
+++ b/packages/components/pie-switch/src/index.ts
@@ -158,11 +158,9 @@ export class PieSwitch extends FormControlMixin(RtlMixin(LitElement)) implements
 
         if (label) {
             return html`
-                <label
-                    for="switch"
-                    data-test-id="switch-label-${labelPlacement}">
+                <span data-test-id="switch-label-${labelPlacement}">
                     ${label}
-                </label>`;
+                </span>`;
         }
 
         return html``;
@@ -181,17 +179,16 @@ export class PieSwitch extends FormControlMixin(RtlMixin(LitElement)) implements
         const switchId = 'switch-description';
 
         return html`
-            <div
+            <label
                 class="c-switch-wrapper"
                 ?isRTL=${isRTL}
                 ?disabled=${disabled}>
                 ${labelPlacement === 'leading' ? this.renderSwitchLabel() : nothing}
-                <label
+                <div
                     data-test-id="switch-component"
                     class="c-switch"
                     ?checked=${checked}>
                     <input
-                        id="switch"
                         data-test-id="switch-input"
                         role="switch"
                         type="checkbox"
@@ -205,10 +202,10 @@ export class PieSwitch extends FormControlMixin(RtlMixin(LitElement)) implements
                     <div class="c-switch-control">
                         ${checked ? html`<icon-check></icon-check>` : nothing}
                     </div>
-                </label>
-                ${aria?.describedBy ? html`<div id="${switchId}" data-test-id="${switchId}" class="c-switch-description">${aria?.describedBy}</div>` : nothing}
+                </div>
                 ${labelPlacement === 'trailing' ? this.renderSwitchLabel() : nothing}
-            </div>
+                ${aria?.describedBy ? html`<div id="${switchId}" data-test-id="${switchId}" class="c-switch-description">${aria?.describedBy}</div>` : nothing}
+            </label>
         `;
     }
 }

--- a/packages/components/pie-switch/test/component/pie-switch.spec.ts
+++ b/packages/components/pie-switch/test/component/pie-switch.spec.ts
@@ -61,35 +61,6 @@ test.describe('Component: `Pie switch`', () => {
         expect(pieSwitchComponent).toBe(false);
     });
 
-    test('should have an `id` of `switch` on the input element', async ({ mount }) => {
-        // Arrange
-        const component = await mount(PieSwitch);
-
-        // Act
-        const pieSwitchInput = component.locator(inputSelector);
-
-        // Assert
-        await expect(pieSwitchInput).toHaveAttribute('id', 'switch');
-    });
-
-    test.describe('when the switch contains a label element', () => {
-        test('should set associated `for` value on the label', async ({ mount }) => {
-            // Arrange
-            const component = await mount(PieSwitch, {
-                props: {
-                    label: 'Label',
-                    labelPlacement: 'leading',
-                } as SwitchProps,
-            });
-
-            // Act
-            const pieSwitchLabel = component.locator(switchLabelSelector());
-
-            // Assert
-            await expect(pieSwitchLabel).toHaveAttribute('for', 'switch');
-        });
-    });
-
     test.describe('component interaction states', () => {
         test.describe('when the component is clicked', () => {
             test('should set `checked` to `true`', async ({ mount, page }) => {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- [Changed] - markup to remove the Input element's id
- [Removed] - redundant browser tests that relied on the element's id
- messages regarding duplicated ids are gone ✨
- tested the pie-aperture apps in iOS 14, 15, 16, and 17
- tested in Nuxt in development mode only, since we're having problems with SSR and the build/preview script
- added a Confluence page with some of my findings [here](https://justeattakeaway.atlassian.net/wiki/spaces/WPG/pages/6701187517/DSW-1758+-+Next.js+Hydration+value+mismatch+issue) and a troubleshooting page [here](https://justeattakeaway.atlassian.net/wiki/spaces/WPG/pages/6701613221/Next.js+Hydration+value+mismatch)
- kept the id for the `aria.describedBy` description element

## Author Checklist (complete before requesting a review)
- [X] I have performed a self-review of my code
- [X] If it is a component change, I have reviewed the Storybook preview

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] I have reviewed the PR preview

### Reviewer 2
- [ ] I have reviewed the PR preview
