### PR TITLE
chore(pie-monorepo): DSW-1868 add bundle visualiser to build scripts

### DIFF
--- a/.changeset/ninety-boats-yawn.md
+++ b/.changeset/ninety-boats-yawn.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+"@justeattakeaway/pie-components-config": minor
+"@justeattakeaway/pie-icons-webc": minor
+"pie-monorepo": minor
+---
+
+[Added] - Bundle visualiser that runs during build for webc icons, webc core and our components

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ build/**
 dist/
 custom-elements.json
 **/src/react.ts
+**/stats.html

--- a/configs/pie-components-config/vite.config.js
+++ b/configs/pie-components-config/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 import { deepmerge } from 'deepmerge-ts';
 
@@ -48,6 +49,10 @@ const sharedConfig = ({ build = {}, plugins = [], ...rest }) => defineConfig({
         insertTypesEntry: true,
         outputDir: 'dist',
         rollupTypes: true,
+    }),
+    visualizer({
+        gzipSize: true,
+        brotliSize: true,
     })], plugins),
 
     ...rest,

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "postcss": "8.4.32",
     "postcss-cli": "10.1.0",
     "rimraf": "5.0.5",
+    "rollup-plugin-visualizer": "5.12.0",
     "sass": "1.60.0",
     "stylelint": "16.2.1",
     "stylelint-config-standard-scss": "13.0.0",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -84,3 +84,6 @@ Sometimes when we are testing our components using Percy, we want to place the t
 We currently use  a `WebComponentTestWrapper` component to do this. The component takes a string representation of a component and renders it with some additional information about the props being used. This is the same concept as outlined in the Browser tests section above.
 
 As with the browser tests, it is vital that the component to test is mounted and unmounted in a `beforeEach` block. This ensures that the component is loaded in the browser before the test runs.
+
+## Bundling
+When we build a component, we run a plugin for Rollup named `rollup-plugin-visualizer`. This generates a file for each component named `stats.html` in the root of the component package. This file can be viewed in the browser to visualise the bundled Javascript and better understand what contributes to the size of the final build output.

--- a/packages/components/pie-webc-core/README.md
+++ b/packages/components/pie-webc-core/README.md
@@ -16,6 +16,7 @@
 4. [Dependencies](#dependencies)
 5. [Contributing](#contributing)
 6. [Testing](#testing)
+7. [Bundling](#bundling)
 
 ## Introduction
 
@@ -72,3 +73,6 @@ We write browser tests for functionality that requires a browser environment to 
 
 ### Naming and running tests
 Currently, for writing unit tests we simply name the file `**/*.spec.ts`. To write browser tests, we name the file `**/*.browser.spec.ts`. This allows us to run all unit tests using `yarn test --filter=pie-webc-core` and all browser tests using `yarn test:browsers --filter=pie-webc-core`.
+
+## Bundling
+When we build the package, we run a plugin for Rollup named `rollup-plugin-visualizer`. This generates a file named `stats.html` in the root of the package. This file can be viewed in the browser to visualise the bundled Javascript and better understand what contributes to the size of the final build output.

--- a/packages/components/pie-webc-core/vite.config.js
+++ b/packages/components/pie-webc-core/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
     build: {
@@ -22,4 +23,10 @@ export default defineConfig({
             '**/node_modules/**/*'
         ],
     },
+    plugins: [
+        visualizer({
+            gzipSize: true,
+            brotliSize: true,
+        })
+    ],
 });

--- a/packages/tools/pie-icons-webc/README.md
+++ b/packages/tools/pie-icons-webc/README.md
@@ -200,3 +200,6 @@ Run `yarn build --filter=pie-icons-webc` from the project level or `yarn turbo r
 ## Icon list
 
 You can check the list of all the icons on our [documentation site](https://pie.design/foundations/iconography/library/).
+
+## Bundling
+When we build the icons, we run a plugin for Rollup named `rollup-plugin-visualizer`. This generates a file named `stats.html` in the root of the package. This file can be viewed in the browser to visualise the bundled Javascript and better understand what contributes to the size of the final build output.

--- a/packages/tools/pie-icons-webc/vite.config.js
+++ b/packages/tools/pie-icons-webc/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import path from 'path';
 import fs from 'fs';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 /**
  * Recursively get all Icon TS files from the icons folder and its subfolders
@@ -65,4 +66,10 @@ export default defineConfig({
             '**/node_modules/**/*'
         ],
     },
+    plugins: [
+        visualizer({
+            gzipSize: true,
+            brotliSize: true,
+        })
+    ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -29185,6 +29185,7 @@ __metadata:
     postcss: 8.4.32
     postcss-cli: 10.1.0
     rimraf: 5.0.5
+    rollup-plugin-visualizer: 5.12.0
     sass: 1.60.0
     stylelint: 16.2.1
     stylelint-config-standard-scss: 13.0.0
@@ -33072,7 +33073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-visualizer@npm:^5.12.0, rollup-plugin-visualizer@npm:^5.9.0":
+"rollup-plugin-visualizer@npm:5.12.0, rollup-plugin-visualizer@npm:^5.12.0, rollup-plugin-visualizer@npm:^5.9.0":
   version: 5.12.0
   resolution: "rollup-plugin-visualizer@npm:5.12.0"
   dependencies:


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Adds a rollup bundle visualiser that runs during the build of our components, webc, webc-core and webc-icons packages. In future we may want to limit this to only run locally and not during CI. However it seemed like it would involve adding more environment context to our build process which I think is probably out of scope for this change.

### Example outputs

<img width="1727" alt="Screenshot 2024-04-11 at 13 19 25" src="https://github.com/justeattakeaway/pie/assets/16766185/9a912edd-4c9e-4942-8c54-a8d6953fc902">
<img width="1728" alt="Screenshot 2024-04-11 at 13 18 58" src="https://github.com/justeattakeaway/pie/assets/16766185/b667c6e6-5d60-43fe-a870-d79a830e4494">
<img width="1722" alt="Screenshot 2024-04-11 at 13 18 42" src="https://github.com/justeattakeaway/pie/assets/16766185/4b3f298b-1649-4911-ac4c-258629c5f2a7">

## Author Checklist (complete before requesting a review)
- [X] I have performed a self-review of my code
