### PR TITLE
docs(pie-docs): DSW-000 fix typo on image name for tag

### DIFF
--- a/apps/pie-docs/src/components/tag/overview/overview.md
+++ b/apps/pie-docs/src/components/tag/overview/overview.md
@@ -324,7 +324,7 @@ Here are some examples of tags in left-to-right context:
 {% endcontentLayout %}
 
 {% contentPageImage {
-    src:"../../../assets/img/components/tag/example-ltr-restaurant-listing.svg",
+    src:"../../../assets/img/components/tag/ltr-example-restaurant-listing.svg",
     alt: "A left-to-right example of a tag used on a restaurant listing card.",
     width: "827px"
 } %}


### PR DESCRIPTION
Tag documentation was missing an image due to a typo in the name. The image is already provided in the assets folder.

Please click the `Preview` tab and select a different PR template if your change isn't for an                                            existing web component.

[PIE Docs Template](?expand=1&template=docs_template.md)
[New Web Component Template](?expand=1&template=new_component_template.md)

═══════════════════════════════════════════════════════════

## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
