### PR TITLE
fix(pie-chip): DSW-1912 loading state isn't centred correctly

### DIFF
--- a/.changeset/light-hounds-serve.md
+++ b/.changeset/light-hounds-serve.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-tag": patch
+---
+
+[Changed] - updated the component status to beta

--- a/.changeset/neat-geckos-end.md
+++ b/.changeset/neat-geckos-end.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-chip": minor
+"pie-monorepo": minor
+---
+
+[Fixed] - loading state is not centred correctly
+
+[Changed] - updated the component status to beta

--- a/.changeset/twenty-buttons-fetch.md
+++ b/.changeset/twenty-buttons-fetch.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Changed] - update the Chip and Tag component status to beta

--- a/apps/pie-docs/src/componentStatusData.js
+++ b/apps/pie-docs/src/componentStatusData.js
@@ -516,7 +516,7 @@ const rows = [
         {
             resource: resourceTypes.WEB_COMPONENTS,
             link: 'https://webc.pie.design/?path=/story/chip--default',
-            status: statusTypes.ALPHA,
+            status: statusTypes.BETA,
         },
         {
             resource: resourceTypes.VUE,
@@ -1989,7 +1989,8 @@ const rows = [
         },
         {
             resource: resourceTypes.WEB_COMPONENTS,
-            status: statusTypes.PLANNED,
+            link: 'https://webc.pie.design/?path=/story/tag--neutral',
+            status: statusTypes.BETA,
         },
         {
             resource: resourceTypes.VUE,

--- a/packages/components/pie-chip/package.json
+++ b/packages/components/pie-chip/package.json
@@ -13,7 +13,7 @@
     "**/*.d.ts"
   ],
   "pieMetadata": {
-    "componentStatus": "alpha"
+    "componentStatus": "beta"
   },
   "scripts": {
     "build": "run -T vite build",

--- a/packages/components/pie-chip/src/chip.scss
+++ b/packages/components/pie-chip/src/chip.scss
@@ -120,6 +120,9 @@
 
         .c-chip-spinner {
             position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
         }
     }
 

--- a/packages/components/pie-tag/package.json
+++ b/packages/components/pie-tag/package.json
@@ -13,7 +13,7 @@
     "**/*.d.ts"
   ],
   "pieMetadata": {
-    "componentStatus": "alpha"
+    "componentStatus": "beta"
   },
   "scripts": {
     "build": "run -T vite build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5549,7 +5549,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-assistive-text@0.3.3, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
+"@justeattakeaway/pie-assistive-text@0.3.4, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text"
   dependencies:
@@ -5660,7 +5660,7 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.16.0
-    "@justeattakeaway/pie-input": ^0.16.1
+    "@justeattakeaway/pie-input": ^0.18.0
     "@justeattakeaway/pie-switch": ^0.29.2
     "@justeattakeaway/pie-webc-core": 0.21.1
     "@justeattakeaway/pie-wrapper-react": 0.14.0
@@ -5774,12 +5774,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-input@0.16.1, @justeattakeaway/pie-input@^0.16.1, @justeattakeaway/pie-input@workspace:packages/components/pie-input":
+"@justeattakeaway/pie-input@0.18.0, @justeattakeaway/pie-input@^0.18.0, @justeattakeaway/pie-input@workspace:packages/components/pie-input":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-input@workspace:packages/components/pie-input"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.3.3
+    "@justeattakeaway/pie-assistive-text": 0.3.4
     "@justeattakeaway/pie-components-config": 0.16.0
     "@justeattakeaway/pie-icons-webc": 0.22.0
     "@justeattakeaway/pie-webc-core": 0.21.1
@@ -29190,7 +29190,7 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 6.0.0
-    "@justeattakeaway/pie-assistive-text": 0.3.3
+    "@justeattakeaway/pie-assistive-text": 0.3.4
     "@justeattakeaway/pie-button": 0.47.3
     "@justeattakeaway/pie-card": 0.19.3
     "@justeattakeaway/pie-chip": 0.5.3
@@ -29200,7 +29200,7 @@ __metadata:
     "@justeattakeaway/pie-form-label": 0.13.3
     "@justeattakeaway/pie-icon-button": 0.28.3
     "@justeattakeaway/pie-icons-webc": 0.22.0
-    "@justeattakeaway/pie-input": 0.16.1
+    "@justeattakeaway/pie-input": 0.18.0
     "@justeattakeaway/pie-link": 0.17.3
     "@justeattakeaway/pie-modal": 0.42.3
     "@justeattakeaway/pie-notification": 0.5.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- fixes a bug where the loading spinner is not centered correctly when `isDismissed` is true 

before: 

<img width="151" alt="Screenshot 2024-04-19 at 16 41 01" src="https://github.com/justeattakeaway/pie/assets/28605803/033401e2-f06e-4270-a148-797bd1177399">


after:

<img width="151" alt="Screenshot 2024-04-19 at 16 40 36" src="https://github.com/justeattakeaway/pie/assets/28605803/a749a766-34dd-4fdd-81f1-af600e0c4569">


- updates the status of the Tag and Chip components to `Beta`


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1 @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them
