### PR TITLE
fix(pie-monorepo): DSW-000 Fix `repo_token` param from request-comment-branch action

### DIFF
--- a/.changeset/strong-chefs-doubt.md
+++ b/.changeset/strong-chefs-doubt.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Fixed] - Issue where comment-branch action was failing when GITHUB_TOKEN was provided

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,7 +38,8 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.GITHUB_REF_NAME,
+                  'pie-branch': process.env.PIE_BRANCH,
+                  'pie-pr-number': process.env.PIE_PR_NUMBER,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,8 +38,7 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.PIE_BRANCH,
-                  'pie-pr-number': process.env.PIE_PR_NUMBER,
+                  'pie-branch': process.env.GITHUB_REF_NAME,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/.github/workflows/test-aperture.yml
+++ b/.github/workflows/test-aperture.yml
@@ -90,6 +90,8 @@ jobs:
        # https://github.com/actions/checkout/issues/331#issuecomment-1242708547
       - uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout default branch
         uses: actions/checkout@v3

--- a/.github/workflows/test-aperture.yml
+++ b/.github/workflows/test-aperture.yml
@@ -90,8 +90,6 @@ jobs:
        # https://github.com/actions/checkout/issues/331#issuecomment-1242708547
       - uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
-        with:
-          repo_token: ${{ env.GITHUB_TOKEN }}
 
       - name: Checkout default branch
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR fixes an issue where the action wasn't working due to use of `env.` keyword instead of `secrets.` when accessing the GITHUB_TOKEN.