### PR TITLE
ci(pie-monorepo): DSW-000 filter internal packages from /test-aperture

### DIFF
--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,8 +38,7 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.PIE_BRANCH,
-                  'pie-pr-number': process.env.PIE_PR_NUMBER,
+                  'pie-branch': process.env.GITHUB_REF_NAME,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context }, execa) => {
     const newTags = Array
         .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
         .map(([_, tag]) => tag)
-        .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
+        .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook|git-hooks-scripts|webc-core|webc-testing|icons-configs|wrapper-react)|generator-pie-component/.test(tag));
 
 
         // Extract the snapshot version from one of the tags
@@ -38,7 +38,8 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.GITHUB_REF_NAME,
+                  'pie-branch': process.env.PIE_BRANCH,
+                  'pie-pr-number': process.env.PIE_PR_NUMBER,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
This change to the /test-aperture logic ensures that packages that are no intended to be used by consuming applications don't be added as part of the automatically generated PR's.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
