### PR TITLE
feat(pie-checkbox): DSW-1574 checkbox aria property

### DIFF
--- a/.changeset/fresh-otters-remain.md
+++ b/.changeset/fresh-otters-remain.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-checkbox": minor
+---
+
+[Added] - aria property to support aria-label, aria-labeledby and aria-describedby attributes.
+[Changed] - updated README to include component properties and events

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -69,6 +69,7 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
     },
     args: defaultArgs,
     parameters: {
+        layout: 'centered',
         design: {
             type: 'figma',
             url: 'https://www.figma.com/file/pPSC73rPin4csb8DiK1CRr/branch/aD4m0j97Ruw8Q4S5lED2Bl/%E2%9C%A8-[Core]-Web-Components-[PIE-3]?type=design&node-id=1998-6410&mode=design&t=udPtXte1WeCeFc1D-0',

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -69,7 +69,6 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
     },
     args: defaultArgs,
     parameters: {
-        layout: 'centered',
         design: {
             type: 'figma',
             url: 'https://www.figma.com/file/pPSC73rPin4csb8DiK1CRr/branch/aD4m0j97Ruw8Q4S5lED2Bl/%E2%9C%A8-[Core]-Web-Components-[PIE-3]?type=design&node-id=1998-6410&mode=design&t=udPtXte1WeCeFc1D-0',

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -18,6 +18,11 @@ const defaultArgs: CheckboxProps = {
     disabled: false,
     checked: false,
     indeterminate: false,
+    aria: {
+        label: '',
+        labelledby: '',
+        describedby: '',
+    },
 };
 
 const checkboxStoryMeta: CheckboxStoryMeta = {
@@ -66,6 +71,11 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
                 summary: false,
             },
         },
+
+        aria: {
+            description: 'ARIA object to pass label/labelledby/describedby aria attributes',
+            control: 'object',
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -85,6 +95,7 @@ const Template = ({
     checked,
     disabled,
     indeterminate,
+    aria,
 }: CheckboxProps) => {
     function onChange (event: CustomEvent) {
         action('change')({
@@ -100,6 +111,7 @@ const Template = ({
             ?checked="${checked}"
             ?disabled="${disabled}"
             ?indeterminate="${indeterminate}"
+            .aria="${aria}"
             @change="${onChange}">
         </pie-checkbox>
     `;

--- a/packages/components/pie-checkbox/README.md
+++ b/packages/components/pie-checkbox/README.md
@@ -15,7 +15,8 @@
 3. [Importing the component](#importing-the-component)
 4. [Peer Dependencies](#peer-dependencies)
 5. [Props](#props)
-6. [Contributing](#contributing)
+6. [Events](#events)
+7. [Contributing](#contributing)
 
 ## pie-checkbox
 
@@ -74,17 +75,35 @@ import { PieCheckbox } from '@justeattakeaway/pie-checkbox/dist/react';
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| - | - | - | - |
+| `name` | `string` | - | The name of the checkbox (used as a key/value pair with `value`). This is required in order to work properly with forms. |
+| `value` | `string` | 'on' | The value of the input (used as a key/value pair in HTML forms with `name`). If not passed falls back to the html default value "on". |
+| `required` | `boolean` | `false` | If true, the checkbox is required to be checked before submitting the form. If it is not in checked state, the component validity state will be invalid. |
+| `label` | `string` | '' | Text associated with the checkbox. If not passed make sure to either pass label or labeledby/describedby to aria object. |
+| `disabled` | `boolean` | `false` | Indicates whether or not the checkbox is disabled. |
+| `checked` | `boolean` | `false` | Indicates whether or not the checkbox is checked by default (when the page loads). |
+| `indeterminate` | `boolean` | `false` | Indicates whether the checkbox visually shows a horizontal line in the box instead of a check/tick. It has no impact on whether the checkbox's value is used in a form submission. That is decided by the checked state, regardless of the indeterminate state. |
+| `aria` | `object` | {} | accepts `label`, `labeledby` and `describedby` keys with string values. |
 
 In your markup or JSX, you can then use these to set the properties for the `pie-checkbox` component:
 
 ```html
 <!-- Native HTML -->
-<pie-checkbox></pie-checkbox>
+<pie-checkbox
+    name="mycheckbox"
+    label="Checkbox Label">
+</pie-checkbox>
 
 <!-- JSX -->
-<PieCheckbox></PieCheckbox>
+<PieCheckbox
+    name="mycheckbox"
+    label="Checkbox Label">
+</PieCheckbox>
 ```
+
+## Events
+| Event | Type | Description |
+|-------|------|-------------|
+| `change` | `CustomEvent` | Triggered after the checked state of a checkbox changes. |
 
 ## Contributing
 

--- a/packages/components/pie-checkbox/README.md
+++ b/packages/components/pie-checkbox/README.md
@@ -78,7 +78,7 @@ import { PieCheckbox } from '@justeattakeaway/pie-checkbox/dist/react';
 | `name` | `string` | - | The name of the checkbox (used as a key/value pair with `value`). This is required in order to work properly with forms. |
 | `value` | `string` | 'on' | The value of the input (used as a key/value pair in HTML forms with `name`). If not passed falls back to the html default value "on". |
 | `required` | `boolean` | `false` | If true, the checkbox is required to be checked before submitting the form. If it is not in checked state, the component validity state will be invalid. |
-| `label` | `string` | '' | Text associated with the checkbox. If not passed make sure to either pass label or labeledby/describedby to aria object. |
+| `label` | `string` | '' | Text associated with the checkbox. If there is no label to provide, make sure to pass label, labelledby or describedby to the aria property. |
 | `disabled` | `boolean` | `false` | Indicates whether or not the checkbox is disabled. |
 | `checked` | `boolean` | `false` | Indicates whether or not the checkbox is checked by default (when the page loads). |
 | `indeterminate` | `boolean` | `false` | Indicates whether the checkbox visually shows a horizontal line in the box instead of a check/tick. It has no impact on whether the checkbox's value is used in a form submission. That is decided by the checked state, regardless of the indeterminate state. |

--- a/packages/components/pie-checkbox/src/defs.ts
+++ b/packages/components/pie-checkbox/src/defs.ts
@@ -1,3 +1,8 @@
+export type AriaProps = {
+    label?: string;
+    labelledby?: string;
+    describedby?: string;
+};
 export interface CheckboxProps {
     /**
      * The value of the checkbox (used as a key/value pair in HTML forms with `name`).
@@ -34,4 +39,9 @@ export interface CheckboxProps {
      * If true, the checkbox must be checked for the form to be submittable.
      */
     required?: boolean;
+
+    /**
+     * Various ARIA attributes.
+     */
+    aria?: AriaProps;
 }

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -94,7 +94,7 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
                 ?required=${required}
                 .indeterminate=${indeterminate}
                 aria-label=${aria?.label || nothing}
-                aria-labelledby=${label ? nothing : aria?.labelledby}
+                aria-labelledby=${label ? nothing : aria?.labelledby || nothing}
                 aria-describedby= ${aria?.describedby || nothing}
                 @change=${this.handleChange}
                 data-test-id="pie-checkbox"

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -1,5 +1,5 @@
 import {
-    LitElement, html, unsafeCSS,
+    LitElement, html, unsafeCSS, nothing,
 } from 'lit';
 import {
     RtlMixin,
@@ -45,6 +45,9 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
     @property({ type: Boolean })
     public indeterminate?: CheckboxProps['indeterminate'] = false;
 
+    @property({ type: Object })
+    public aria: CheckboxProps['aria'];
+
     @query('input')
     private checkbox?: HTMLInputElement;
 
@@ -77,7 +80,9 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
             disabled,
             required,
             indeterminate,
+            aria,
         } = this;
+
         return html`
         <label>
             <input
@@ -88,6 +93,9 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
                 ?disabled=${disabled}
                 ?required=${required}
                 .indeterminate=${indeterminate}
+                aria-label=${aria?.label || nothing}
+                aria-labelledby=${label ? nothing : aria?.labelledby}
+                aria-describedby= ${aria?.describedby || nothing}
                 @change=${this.handleChange}
                 data-test-id="pie-checkbox"
             />


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

---
"@justeattakeaway/pie-checkbox": minor
---

[Added] - aria property to support aria-label, aria-labeledby and aria-describedby attributes.
[Changed] - updated README to include component properties and events

Feature url: https://pr1440-storybook.pie.design/?path=/story/checkbox--default

## Reviewer checklists (complete before approving)
### Reviewer 1 - Fernando
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview