### PR TITLE
feat(pie-checkbox): DSW-1574 checkbox form integration

### DIFF
--- a/.changeset/fair-pants-drive.md
+++ b/.changeset/fair-pants-drive.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-text-input": patch
+---
+
+[Changed] - form helper test functions are moved to pie-webc-helpers

--- a/.changeset/gorgeous-seals-teach.md
+++ b/.changeset/gorgeous-seals-teach.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-testing": minor
+---
+
+[Added] - test form helper setupFormDataExtraction and getFormDataObject functions

--- a/.changeset/shy-tigers-hang.md
+++ b/.changeset/shy-tigers-hang.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-switch": patch
+---
+
+[Changed] - renames onChange to handleChange and makes it private

--- a/.changeset/twelve-carpets-applaud.md
+++ b/.changeset/twelve-carpets-applaud.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-checkbox": minor
+---
+
+[Added] - form support

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -80,7 +80,6 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
     },
     args: defaultArgs,
     parameters: {
-        layout: 'centered',
         design: {
             type: 'figma',
             url: 'https://www.figma.com/file/pPSC73rPin4csb8DiK1CRr/branch/aD4m0j97Ruw8Q4S5lED2Bl/%E2%9C%A8-[Core]-Web-Components-[PIE-3]?type=design&node-id=1998-6410&mode=design&t=udPtXte1WeCeFc1D-0',

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -7,18 +7,18 @@ import { CheckboxProps, defaultProps } from '@justeattakeaway/pie-checkbox';
 
 import { action } from '@storybook/addon-actions';
 import { type StoryMeta } from '../types';
-import { createStory } from '../utilities';
+import { createStory, type TemplateFunction } from '../utilities';
 
 type CheckboxStoryMeta = StoryMeta<CheckboxProps>;
 
 const defaultArgs: CheckboxProps = {
     ...defaultProps,
-    value: '',
     name: '',
     label: 'Label',
     disabled: false,
     checked: false,
     indeterminate: false,
+    required: false,
     aria: {
         label: '',
         labelledby: '',
@@ -33,9 +33,6 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
         value: {
             description: 'The value of the checkbox (used as a key/value pair in HTML forms with `name`).',
             control: 'text',
-            defaultValue: {
-                summary: defaultArgs.value,
-            },
         },
         name: {
             description: 'The name of the checkbox (used as a key/value pair with `value`). This is required in order to work properly with forms.',
@@ -52,7 +49,7 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
             },
         },
         checked: {
-            description: 'Indicates whether or not the checkbox is checked by default (when the page loads).',
+            description: 'Indicates whether or not the checkbox is checked.',
             control: 'boolean',
             defaultValue: {
                 summary: defaultArgs.checked,
@@ -70,6 +67,14 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
             control: 'boolean',
             defaultValue: {
                 summary: defaultProps.indeterminate,
+            },
+        },
+
+        required: {
+            description: 'If true, the checkbox must be checked for the form to be submittable.',
+            control: 'boolean',
+            defaultValue: {
+                summary: false,
             },
         },
 
@@ -96,6 +101,7 @@ const Template = ({
     checked,
     disabled,
     indeterminate,
+    required,
     aria,
 }: CheckboxProps) => {
     function onChange (event: CustomEvent) {
@@ -112,10 +118,61 @@ const Template = ({
             ?checked="${checked}"
             ?disabled="${disabled}"
             ?indeterminate="${indeterminate}"
+            ?required="${required}"
             .aria="${aria}"
             @change="${onChange}">
         </pie-checkbox>
     `;
 };
 
+const ExampleFormTemplate: TemplateFunction<CheckboxProps> = ({
+    value,
+    name,
+    checked,
+    disabled,
+    indeterminate,
+    required,
+    aria,
+}: CheckboxProps) => {
+    function onChange (event: CustomEvent) {
+        action('change')({
+            detail: event.detail,
+        });
+    }
+
+    return html`
+    <form id="testForm">
+        <pie-checkbox
+            .value="${ifDefined(value)}"
+            name="${ifDefined(name)}"
+            label="Pie Checkbox"
+            ?checked="${checked}"
+            ?disabled="${disabled}"
+            ?indeterminate="${indeterminate}"
+            ?required="${required}"
+            .aria="${aria}"
+            @change="${onChange}"></pie-checkbox>
+        <button type="reset">Reset</button>
+        <button type="submit">Submit</button>
+        <script>
+            const form = document.querySelector('#testForm');
+
+            form.addEventListener('submit', (e) => {
+                e.preventDefault();
+
+                // log out all form input values
+                const formData = new FormData(form);
+                console.log('All form elements:', form.elements);
+                console.log('All form element data keys and values submitted:');
+
+                for (const entry of formData.entries()) {
+                    console.table(entry);
+                };
+            });
+        </script>
+    </form>
+    `;
+};
+
 export const Default = createStory<CheckboxProps>(Template, defaultArgs)();
+export const ExampleForm = createStory<CheckboxProps>(ExampleFormTemplate, defaultArgs)();

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -80,6 +80,7 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
     },
     args: defaultArgs,
     parameters: {
+        layout: 'centered',
         design: {
             type: 'figma',
             url: 'https://www.figma.com/file/pPSC73rPin4csb8DiK1CRr/branch/aD4m0j97Ruw8Q4S5lED2Bl/%E2%9C%A8-[Core]-Web-Components-[PIE-3]?type=design&node-id=1998-6410&mode=design&t=udPtXte1WeCeFc1D-0',

--- a/packages/components/pie-checkbox/src/defs-react.ts
+++ b/packages/components/pie-checkbox/src/defs-react.ts
@@ -1,8 +1,3 @@
 import React from 'react';
-/**
- * TODO: Verify if ReactBaseType can be set as a more specific React interface
- * Use the React IntrinsicElements interface to find how to map standard HTML elements to existing React Interfaces
- * Example: an HTML button maps to `React.ButtonHTMLAttributes<HTMLButtonElement>`
- * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/react/index.d.ts#L2829
- */
-export type ReactBaseType = React.HTMLAttributes<HTMLElement>
+
+export type ReactBaseType = React.InputHTMLAttributes<HTMLInputElement>

--- a/packages/components/pie-checkbox/src/defs.ts
+++ b/packages/components/pie-checkbox/src/defs.ts
@@ -27,7 +27,7 @@ export interface CheckboxProps {
     disabled?: boolean;
 
     /**
-     * Same as the HTML checked attribute - indicates whether or not the checkbox is checked by default (when the page loads).
+     * Indicates whether or not the checkbox is checked.
      */
     checked?: boolean;
 
@@ -48,10 +48,14 @@ export interface CheckboxProps {
     aria?: AriaProps;
 }
 
-export type DefaultProps = ComponentDefaultPropsGeneric<CheckboxProps, 'required' | 'indeterminate'>;
+export type DefaultProps = ComponentDefaultPropsGeneric<CheckboxProps, 'value' | 'required' | 'indeterminate' | 'checked' >;
 
 export const defaultProps: DefaultProps = {
+    // a default value for the html <input type="checkbox" /> value attribute.
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value
+    value: 'on',
     required: false,
     indeterminate: false,
+    checked: false,
 };
 

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -7,6 +7,7 @@ import {
     wrapNativeEvent,
     FormControlMixin,
 } from '@justeattakeaway/pie-webc-core';
+import { live } from 'lit/directives/live.js';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
@@ -129,7 +130,7 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
             <input
                 type="checkbox"
                 .value=${value}
-                ?checked=${checked}
+                ?checked=${live(checked)}
                 name=${ifDefined(name)}
                 ?disabled=${disabled}
                 ?required=${required}

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -21,7 +21,7 @@ const componentSelector = 'pie-checkbox';
 
 /**
  * @tagname pie-checkbox
- *  * @event {CustomEvent} change - when checked state is changed.
+ * @event {CustomEvent} change - when checked state is changed.
  */
 export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implements CheckboxProps {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
@@ -52,11 +52,6 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
 
     @query('input[type="checkbox"]')
     private checkbox?: HTMLInputElement;
-
-    private onClick () {
-        this.checked = !this.checked;
-        this.indeterminate = false;
-    }
 
     /**
      * (Read-only) returns a ValidityState with the validity states that this element is in.
@@ -102,7 +97,7 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
      * Captures the native change event and wraps it in a custom event.
      * @param {Event} event - This should be the change event that was listened for on an input element with `type="checkbox"`.
      */
-    private handleChange = (event: Event) => {
+    private handleChange (event: Event) {
         const { checked } = event?.currentTarget as HTMLInputElement;
         this.checked = checked;
         // This is because some events set `composed` to `false`.
@@ -111,7 +106,7 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
         this.dispatchEvent(customChangeEvent);
 
         this.handleFormAssociation();
-    };
+    }
 
     render () {
         const {
@@ -138,7 +133,6 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
                 aria-label=${aria?.label || nothing}
                 aria-labelledby=${label ? nothing : aria?.labelledby || nothing}
                 aria-describedby= ${aria?.describedby || nothing}
-                @click=${this.onClick}
                 @change=${this.handleChange}
                 data-test-id="checkbox-input"
             />

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -1,10 +1,11 @@
 import {
-    LitElement, html, unsafeCSS, nothing,
+    LitElement, html, unsafeCSS, PropertyValues, nothing,
 } from 'lit';
 import {
     RtlMixin,
     defineCustomElement,
     wrapNativeEvent,
+    FormControlMixin,
 } from '@justeattakeaway/pie-webc-core';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -19,13 +20,13 @@ const componentSelector = 'pie-checkbox';
 
 /**
  * @tagname pie-checkbox
- * @slot - Default slot (checkbox label)
+ *  * @event {CustomEvent} change - when checked state is changed.
  */
-export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
+export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implements CheckboxProps {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
     @property({ type: String })
-    public value: CheckboxProps['value'];
+    public value = defaultProps.value;
 
     @property({ type: String })
     public label?: CheckboxProps['label'];
@@ -33,8 +34,8 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
     @property({ type: String })
     public name?: CheckboxProps['name'];
 
-    @property({ type: Boolean })
-    public checked?: CheckboxProps['checked'];
+    @property({ type: Boolean, reflect: true })
+    public checked = defaultProps.checked;
 
     @property({ type: Boolean, reflect: true })
     public disabled?: CheckboxProps['disabled'];
@@ -42,14 +43,19 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
     @property({ type: Boolean, reflect: true })
     public required?: CheckboxProps['required'] = defaultProps.required;
 
-    @property({ type: Boolean })
+    @property({ type: Boolean, reflect: true })
     public indeterminate?: CheckboxProps['indeterminate'] = defaultProps.indeterminate;
 
     @property({ type: Object })
     public aria: CheckboxProps['aria'];
 
-    @query('input')
+    @query('input[type="checkbox"]')
     private checkbox?: HTMLInputElement;
+
+    private onClick () {
+        this.checked = !this.checked;
+        this.indeterminate = false;
+    }
 
     /**
      * (Read-only) returns a ValidityState with the validity states that this element is in.
@@ -60,15 +66,50 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
     }
 
     /**
-     * The onChange function updates the checkbox state and emits an event for consumers.
+     * Ensures that the form value is in sync with the component.
+     */
+    private handleFormAssociation () : void {
+        const isFormAssociated = !!this._internals.form && !!this.name;
+        if (isFormAssociated) {
+            this._internals.setFormValue(this.checked ? this.value : null);
+        }
+    }
+
+    /**
+     * Called after the disabled state of the element changes,
+     * either because the disabled attribute of this element was added or removed;
+     * or because the disabled state changed on a <fieldset> that's an ancestor of this element.
+     * @param disabled - The latest disabled state of the input.
+     */
+    public formDisabledCallback (disabled: boolean): void {
+        this.disabled = disabled;
+    }
+
+    protected firstUpdated (_changedProperties: PropertyValues<this>): void {
+        super.firstUpdated(_changedProperties);
+
+        this.handleFormAssociation();
+    }
+
+    protected updated (_changedProperties: PropertyValues<this>): void {
+        super.updated(_changedProperties);
+
+        this.handleFormAssociation();
+    }
+
+    /**
+     * Captures the native change event and wraps it in a custom event.
      * @param {Event} event - This should be the change event that was listened for on an input element with `type="checkbox"`.
      */
     private handleChange = (event: Event) => {
+        const { checked } = event?.currentTarget as HTMLInputElement;
+        this.checked = checked;
         // This is because some events set `composed` to `false`.
         // Reference: https://javascript.info/shadow-dom-events#event-composed
         const customChangeEvent = wrapNativeEvent(event);
-
         this.dispatchEvent(customChangeEvent);
+
+        this.handleFormAssociation();
     };
 
     render () {
@@ -84,11 +125,11 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
         } = this;
 
         return html`
-        <label>
+        <label data-test-id="checkbox-component">
             <input
                 type="checkbox"
-                ?checked=${ifDefined(checked)}
-                .value=${ifDefined(value)}
+                .value=${value}
+                ?checked=${checked}
                 name=${ifDefined(name)}
                 ?disabled=${disabled}
                 ?required=${required}
@@ -96,8 +137,9 @@ export class PieCheckbox extends RtlMixin(LitElement) implements CheckboxProps {
                 aria-label=${aria?.label || nothing}
                 aria-labelledby=${label ? nothing : aria?.labelledby || nothing}
                 aria-describedby= ${aria?.describedby || nothing}
+                @click=${this.onClick}
                 @change=${this.handleChange}
-                data-test-id="pie-checkbox"
+                data-test-id="checkbox-input"
             />
             ${label}
         </label>`;

--- a/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
@@ -243,12 +243,13 @@ test.describe('PieCheckbox - Component tests', () => {
                 expect(messages).toStrictEqual(expectedMessages);
             });
         });
+
         test.describe('Form integration', () => {
             test('should correctly set the name and value of the checkbox in the FormData object when submitted', async ({ page }) => {
                 // Arrange
                 await page.setContent(`
                     <form id="testForm" action="/foo" method="POST">
-                    <pie-checkbox type="text" name="testName"></pie-checkbox>
+                        <pie-checkbox type="text" name="testName"></pie-checkbox>
                         <button type="submit">Submit</button>
                     </form>
                     <div id="formDataJson""></div>

--- a/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
@@ -221,7 +221,7 @@ test.describe('PieCheckbox - Component tests', () => {
 
     test.describe('Events', () => {
         test.describe('change', () => {
-            test('should dispatch a change event when checkbox is clicked that contains the original native event', async ({ mount, page }) => {
+            test('should dispatch a change event when checkbox is clicked that contains the original native event', async ({ mount }) => {
                 // Arrange
                 const messages: CustomEvent[] = [];
                 const expectedMessages = [{ sourceEvent: { isTrusted: true } }];

--- a/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
@@ -1,4 +1,5 @@
 
+import { setupFormDataExtraction, getFormDataObject } from '@justeattakeaway/pie-webc-testing/src/helpers/form-helpers.ts';
 import { test, expect } from '@sand4rt/experimental-ct-web';
 import { PieCheckbox, CheckboxProps } from '../../src/index.ts';
 
@@ -215,6 +216,124 @@ test.describe('PieCheckbox - Component tests', () => {
                 // Assert
                 expect(isValid).toBe(true);
             });
+        });
+    });
+
+    test.describe('Events', () => {
+        test.describe('change', () => {
+            test('should dispatch a change event when checkbox is clicked that contains the original native event', async ({ mount, page }) => {
+                // Arrange
+                const messages: CustomEvent[] = [];
+                const expectedMessages = [{ sourceEvent: { isTrusted: true } }];
+
+                const component = await mount(PieCheckbox, {
+                    props: {} as CheckboxProps,
+                    on: {
+                        change: (data: CustomEvent) => {
+                            messages.push(data);
+                        },
+                    },
+                });
+
+                // Act
+                await component.locator(componentSelector).click();
+
+                // Assert
+                expect(messages.length).toEqual(1);
+                expect(messages).toStrictEqual(expectedMessages);
+            });
+        });
+        test.describe('Form integration', () => {
+            test('should correctly set the name and value of the checkbox in the FormData object when submitted', async ({ page }) => {
+                // Arrange
+                await page.setContent(`
+                    <form id="testForm" action="/foo" method="POST">
+                    <pie-checkbox type="text" name="testName"></pie-checkbox>
+                        <button type="submit">Submit</button>
+                    </form>
+                    <div id="formDataJson""></div>
+                `);
+
+                await setupFormDataExtraction(page, '#testForm', '#formDataJson');
+
+                // Act
+                await page.locator('pie-checkbox').click();
+                await page.click('button[type="submit"]');
+                const formDataObj = await getFormDataObject(page, '#formDataJson');
+
+                // Assert
+                expect(formDataObj).toStrictEqual({ testName: 'on' });
+            });
+
+            test('should submit the updated checked state if the checked prop is changed programmatically', async ({ page }) => {
+                // Arrange
+                await page.setContent(`
+                    <form id="testForm" action="/foo" method="POST">
+                    <pie-checkbox type="text" name="testName"></pie-checkbox>
+                        <button type="submit">Submit</button>
+                    </form>
+                    <div id="formDataJson""></div>
+                `);
+
+                await setupFormDataExtraction(page, '#testForm', '#formDataJson');
+
+                // Act
+                await page.locator('pie-checkbox').click();
+
+                await page.evaluate(() => {
+                    const checkbox = document.querySelector('pie-checkbox') as PieCheckbox;
+                    checkbox.checked = false;
+                });
+
+                await page.click('button[type="submit"]');
+
+                const formDataObj = await getFormDataObject(page, '#formDataJson');
+
+                // Assert
+                expect(formDataObj).toStrictEqual({});
+            });
+        });
+
+        test('should not submit the value if checkbox is disabled', async ({ page }) => {
+            // Arrange
+            await page.setContent(`
+                <form id="testForm" action="/foo" method="POST">
+                    <pie-checkbox type="text" name="testName" disabled></pie-checkbox>
+                    <button type="submit">Submit</button>
+                </form>
+                <div id="formDataJson""></div>
+            `);
+            await setupFormDataExtraction(page, '#testForm', '#formDataJson');
+
+            // Act
+            await page.click('button[type="submit"]');
+            const formDataObj = await getFormDataObject(page, '#formDataJson');
+
+            // Assert
+            expect(formDataObj).toStrictEqual({});
+        });
+
+        test('should not submit the value inside a disabled fieldset', async ({ page }) => {
+            // Arrange
+            await page.setContent(`
+                <form id="testForm" action="/foo" method="POST">
+                    <fieldset disabled>
+                        <pie-checkbox type="text" name="testName"></pie-checkbox>
+                    </fieldset>
+                    <button type="submit">Submit</button>
+                </form>
+                <div id="formDataJson""></div>
+            `);
+
+            await setupFormDataExtraction(page, '#testForm', '#formDataJson');
+
+            // Act
+            await page.click('button[type="submit"]');
+
+            const formDataObj = await getFormDataObject(page, '#formDataJson');
+
+            // Assert
+            expect(formDataObj).toStrictEqual({});
         });
     });
 });

--- a/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
@@ -2,7 +2,7 @@
 import { test, expect } from '@sand4rt/experimental-ct-web';
 import { PieCheckbox, CheckboxProps } from '../../src/index.ts';
 
-const componentSelector = '[data-test-id="pie-checkbox"]';
+const componentSelector = '[data-test-id="checkbox-input"]';
 
 test.describe('PieCheckbox - Component tests', () => {
     // IMPORTANT: Mounting and Unmounting the component before each test ensures that any tests that do not explicitly

--- a/packages/components/pie-switch/src/index.ts
+++ b/packages/components/pie-switch/src/index.ts
@@ -91,10 +91,10 @@ export class PieSwitch extends FormControlMixin(RtlMixin(LitElement)) implements
     }
 
     /**
-     * The onChange function updates the checkbox state and emits an event for consumers.
+     * The handleChange function updates the checkbox state and emits an event for consumers.
      * @param {Event} event - This should be the change event that was listened for on an input element with `type="checkbox"`.
      */
-    onChange (event: Event) {
+    private handleChange (event: Event) {
         const { checked } = event?.currentTarget as HTMLInputElement;
         this.checked = checked;
         const changedEvent = wrapNativeEvent(event);
@@ -196,7 +196,7 @@ export class PieSwitch extends FormControlMixin(RtlMixin(LitElement)) implements
                         .required=${required}
                         .checked="${checked}"
                         .disabled="${disabled}"
-                        @change="${this.onChange}"
+                        @change="${this.handleChange}"
                         aria-label="${aria?.label || nothing}"
                         aria-describedby="${aria?.describedBy ? switchId : nothing}">
                     <div class="c-switch-control">

--- a/packages/components/pie-text-input/test/component/pie-text-input.spec.ts
+++ b/packages/components/pie-text-input/test/component/pie-text-input.spec.ts
@@ -1,6 +1,6 @@
 
+import { setupFormDataExtraction, getFormDataObject } from '@justeattakeaway/pie-webc-testing/src/helpers/form-helpers.ts';
 import { test, expect } from '@sand4rt/experimental-ct-web';
-import type { Page } from '@playwright/test';
 import { IconPlaceholder } from '@justeattakeaway/pie-icons-webc/dist/IconPlaceholder';
 import { PieAssistiveText } from '@justeattakeaway/pie-assistive-text';
 import { PieTextInput, TextInputProps } from '../../src/index.ts';
@@ -9,60 +9,6 @@ import { statusTypes } from '../../src/defs.ts';
 const componentSelector = '[data-test-id="pie-text-input"]';
 const assistiveTextSelector = '[data-test-id="pie-text-input-assistive-text"]';
 const componentShellSelector = '[data-test-id="pie-text-input-shell"]';
-
-/**
- * Sets up form data extraction for testing form submissions. This function expects a form element
- * and a designated output element to exist on the page. It intercepts the form submit event,
- * prevents the actual submission, and serializes the form data into JSON, which is then placed in
- * the output element.
- *
- * Expected HTML structure on the page:
- * <form id="form-selector" action="/foo" method="POST">
- *     <pie-text-input type="text" name="username"></pie-text-input>
- *     <!-- other form elements -->
- *     <button type="submit">Submit</button>
- * </form>
- * <div id="output-selector"></div>
- *
- * @param {Page} page - The Playwright Page object representing the browser page.
- * @param {string} formSelector - The CSS selector for the form element.
- * @param {string} outputSelector - The CSS selector for the output element where serialized form data will be set.
- * @returns {Promise<void>} A promise that resolves when the setup is complete.
- */
-async function setupFormDataExtraction (page: Page, formSelector: string, outputSelector: string): Promise<void> {
-    await page.evaluate((config) => {
-        const form = document.querySelector(config.formSelector) as HTMLFormElement;
-        const output = document.querySelector(config.outputSelector) as HTMLDivElement;
-
-        form.addEventListener('submit', (e) => {
-            e.preventDefault(); // Prevent the actual submission
-
-            const formData = new FormData(form);
-            const formDataObj: { [key: string]: FormDataEntryValue } = {};
-            formData.forEach((value, key) => {
-                formDataObj[key] = value;
-            });
-
-            // Serialize and set form data as JSON text in the output element
-            output.innerText = JSON.stringify(formDataObj);
-        });
-    }, { formSelector, outputSelector });
-}
-
-/**
- * Retrieves serialized form data from a specified output element and parses it into an object.
- * This function is typically used in conjunction with `setupFormDataExtraction` to test form submissions.
- *
- * @param {Page} page - The Playwright Page object representing the browser page.
- * @param {string} outputSelector - The CSS selector for the output element from which to retrieve the serialized form data.
- * @returns {Promise<{ [key: string]: FormDataEntryValue }>} A promise that resolves to an object representing the form data.
- * Each key-value pair in the object corresponds to a form field and its value.
- */
-async function getFormDataObject (page: Page, outputSelector: string): Promise<{ [key: string]: FormDataEntryValue }> {
-    const formDataJson = await page.$eval(outputSelector, (el) => (el as HTMLDivElement).innerText);
-
-    return JSON.parse(formDataJson || '{}');
-}
 
 test.describe('PieTextInput - Component tests', () => {
     // IMPORTANT: Mounting and Unmounting the component before each test ensures that any tests that do not explicitly

--- a/packages/components/pie-webc-testing/src/helpers/form-helpers.ts
+++ b/packages/components/pie-webc-testing/src/helpers/form-helpers.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Sets up form data extraction for testing form submissions. This function expects a form element
+ * and a designated output element to exist on the page. It intercepts the form submit event,
+ * prevents the actual submission, and serializes the form data into JSON, which is then placed in
+ * the output element.
+ *
+ * Expected HTML structure on the page:
+ * <form id="form-selector" action="/foo" method="POST">
+ *     <pie-text-input type="text" name="username"></pie-text-input>
+ *     <!-- other form elements -->
+ *     <button type="submit">Submit</button>
+ * </form>
+ * <div id="output-selector"></div>
+ *
+ * @param {Page} page - The Playwright Page object representing the browser page.
+ * @param {string} formSelector - The CSS selector for the form element.
+ * @param {string} outputSelector - The CSS selector for the output element where serialized form data will be set.
+ * @returns {Promise<void>} A promise that resolves when the setup is complete.
+ */
+export const setupFormDataExtraction = async (page:Page, formSelector:string, outputSelector:string): Promise<void> => {
+    await page.evaluate((config) => {
+        const form = document.querySelector(config.formSelector) as HTMLFormElement;
+        const output = document.querySelector(config.outputSelector) as HTMLDivElement;
+
+        form.addEventListener('submit', (e) => {
+            e.preventDefault(); // Prevent the actual submission
+
+            const formData = new FormData(form);
+            const formDataObj: { [key: string]: FormDataEntryValue } = {};
+            formData.forEach((value, key) => {
+                formDataObj[key] = value;
+            });
+
+            // Serialize and set form data as JSON text in the output element
+            output.innerText = JSON.stringify(formDataObj);
+        });
+    }, { formSelector, outputSelector });
+};
+
+/**
+ * Retrieves serialized form data from a specified output element and parses it into an object.
+ * This function is typically used in conjunction with `setupFormDataExtraction` to test form submissions.
+ *
+ * @param {Page} page - The Playwright Page object representing the browser page.
+ * @param {string} outputSelector - The CSS selector for the output element from which to retrieve the serialized form data.
+ * @returns {Promise<{ [key: string]: FormDataEntryValue }>} A promise that resolves to an object representing the form data.
+ * Each key-value pair in the object corresponds to a form field and its value.
+ */
+export const getFormDataObject = async (page:Page, outputSelector:string): Promise<{ [key: string]: FormDataEntryValue }> => {
+    const formDataJson = await page.$eval(outputSelector, (el) => (el as HTMLDivElement).innerText);
+
+    return JSON.parse(formDataJson || '{}');
+};


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

---
"@justeattakeaway/pie-checkbox": minor
---

[Added] - form support

---
"@justeattakeaway/pie-switch": patch
---

[Changed] - renames onChange to handleChange and makes it private

---
"@justeattakeaway/pie-webc-testing": minor
---

[Added] - test form helper setupFormDataExtraction and getFormDataObject functions

---
"@justeattakeaway/pie-text-input": patch
---

[Changed] - form helper test functions are moved to pie-webc-helpers



Aperture PR: https://github.com/justeattakeaway/pie-aperture/pull/133

**Note:** Reset form logic will be covered by a separate ticket 

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
