### PR TITLE
feat(pie-text-input): DSW-2063 add aria-label  props

### DIFF
--- a/.changeset/breezy-books-argue.md
+++ b/.changeset/breezy-books-argue.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-text-input": minor
+"pie-storybook": minor
+---
+
+[Added] Add input area-label and area-labelledby properties

--- a/apps/pie-storybook/stories/pie-text-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-text-input.stories.ts
@@ -238,7 +238,6 @@ const Template = ({
     step,
     size,
     required,
-    aria,
 }: TextInputProps) => {
     const [, updateArgs] = UseArgs();
 

--- a/apps/pie-storybook/stories/pie-text-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-text-input.stories.ts
@@ -204,6 +204,20 @@ const textInputStoryMeta: TextInputStoryMeta = {
                 summary: false,
             },
         },
+        ariaLabel: {
+            description: 'The aria-label attribute defines a string value that labels an interactive element.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        ariaLabelledby: {
+            description: 'The aria-labelledby property enables authors to reference other elements on the page to define an accessible name. Must match the ID value of the referenced component.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -238,6 +252,8 @@ const Template = ({
     step,
     size,
     required,
+    ariaLabel,
+    ariaLabelledby,
 }: TextInputProps) => {
     const [, updateArgs] = UseArgs();
 
@@ -289,6 +305,8 @@ const Template = ({
             ?autoFocus="${autoFocus}"
             ?readonly="${readonly}"
             assistiveText="${ifDefined(assistiveText)}"
+            aria-label=${ifDefined(ariaLabel)}
+            aria-labelledby=${ifDefined(ariaLabelledby)}
             status=${ifDefined(status)}
             size="${ifDefined(size)}"
             ?required="${required}"
@@ -302,7 +320,7 @@ const Template = ({
 
 const WithLabelTemplate: TemplateFunction<TextInputProps> = (props: TextInputProps) => html`
         <p>Please note, the label is a separate component. See <pie-link href="/?path=/story/form-label">pie-form-field</pie-link>.</p>
-        <pie-form-label for="${props.name}">Label</pie-form-label>
+        <pie-form-label for="${props.name}" id="${props.name}">Label</pie-form-label>
         ${Template(props)}
     `;
 

--- a/apps/pie-storybook/stories/pie-text-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-text-input.stories.ts
@@ -204,20 +204,6 @@ const textInputStoryMeta: TextInputStoryMeta = {
                 summary: false,
             },
         },
-        ariaLabel: {
-            description: 'The aria-label attribute defines a string value that labels an interactive element.',
-            control: 'text',
-            defaultValue: {
-                summary: '',
-            },
-        },
-        ariaLabelledby: {
-            description: 'The aria-labelledby property enables authors to reference other elements on the page to define an accessible name. Must match the ID value of the referenced component.',
-            control: 'text',
-            defaultValue: {
-                summary: '',
-            },
-        },
     },
     args: defaultArgs,
     parameters: {
@@ -252,8 +238,7 @@ const Template = ({
     step,
     size,
     required,
-    ariaLabel,
-    ariaLabelledby,
+    aria,
 }: TextInputProps) => {
     const [, updateArgs] = UseArgs();
 
@@ -295,6 +280,7 @@ const Template = ({
             pattern="${ifDefined(pattern)}"
             minlength="${ifDefined(minlength)}"
             maxlength="${ifDefined(maxlength)}"
+            aria-label="Read my text"
             min="${ifDefined(min)}"
             max="${ifDefined(max)}"
             step="${ifDefined(step)}"
@@ -305,8 +291,6 @@ const Template = ({
             ?autoFocus="${autoFocus}"
             ?readonly="${readonly}"
             assistiveText="${ifDefined(assistiveText)}"
-            aria-label=${ifDefined(ariaLabel)}
-            aria-labelledby=${ifDefined(ariaLabelledby)}
             status=${ifDefined(status)}
             size="${ifDefined(size)}"
             ?required="${required}"

--- a/packages/components/pie-text-input/src/defs.ts
+++ b/packages/components/pie-text-input/src/defs.ts
@@ -110,12 +110,23 @@ export interface TextInputProps {
      * If true, the input is required to have a value before submitting the form. If there is no value, then the component validity state will be invalid.
      */
     required?: boolean;
+
+    /**
+     * The aria-label attribute defines a string value that labels an interactive element.
+     */
+    ariaLabel: string | null;
+
+    /**
+     * The aria-labelledby property enables authors to reference other elements on the page to define an accessible name.
+     */
+    ariaLabelledby?: string;
+
 }
 
 /**
  * The default values for the `TextInputProps` that are required (i.e. they have a fallback value in the component).
  */
-type DefaultProps = ComponentDefaultPropsGeneric<TextInputProps, 'type' | 'value' | 'size'>;
+type DefaultProps = ComponentDefaultPropsGeneric<TextInputProps, 'type' | 'value' | 'size' | 'ariaLabel'>;
 
 /**
  * Default values for optional properties that have default fallback values in the component.
@@ -124,4 +135,5 @@ export const defaultProps: DefaultProps = {
     type: 'text',
     value: '',
     size: 'medium',
+    ariaLabel: '',
 };

--- a/packages/components/pie-text-input/src/defs.ts
+++ b/packages/components/pie-text-input/src/defs.ts
@@ -111,22 +111,12 @@ export interface TextInputProps {
      */
     required?: boolean;
 
-    /**
-     * The aria-label attribute defines a string value that labels an interactive element.
-     */
-    ariaLabel: string | null;
-
-    /**
-     * The aria-labelledby property enables authors to reference other elements on the page to define an accessible name.
-     */
-    ariaLabelledby?: string;
-
 }
 
 /**
  * The default values for the `TextInputProps` that are required (i.e. they have a fallback value in the component).
  */
-type DefaultProps = ComponentDefaultPropsGeneric<TextInputProps, 'type' | 'value' | 'size' | 'ariaLabel'>;
+type DefaultProps = ComponentDefaultPropsGeneric<TextInputProps, 'type' | 'value' | 'size'>;
 
 /**
  * Default values for optional properties that have default fallback values in the component.
@@ -135,5 +125,4 @@ export const defaultProps: DefaultProps = {
     type: 'text',
     value: '',
     size: 'medium',
-    ariaLabel: '',
 };

--- a/packages/components/pie-text-input/src/index.ts
+++ b/packages/components/pie-text-input/src/index.ts
@@ -75,6 +75,12 @@ export class PieTextInput extends FormControlMixin(RtlMixin(LitElement)) impleme
     @property({ type: String })
     public assistiveText?: TextInputProps['assistiveText'];
 
+    @property({ type: String, reflect: true })
+    public ariaLabel: TextInputProps['ariaLabel'] = defaultProps.ariaLabel;
+
+    @property({ type: String })
+    public ariaLabelledby?: TextInputProps['ariaLabelledby'];
+
     @property({ type: String })
     @validPropertyValues(componentSelector, statusTypes, undefined)
     public status?: TextInputProps['status'];

--- a/packages/components/pie-text-input/src/index.ts
+++ b/packages/components/pie-text-input/src/index.ts
@@ -75,12 +75,6 @@ export class PieTextInput extends FormControlMixin(RtlMixin(LitElement)) impleme
     @property({ type: String })
     public assistiveText?: TextInputProps['assistiveText'];
 
-    @property({ type: String, reflect: true })
-    public ariaLabel: TextInputProps['ariaLabel'] = defaultProps.ariaLabel;
-
-    @property({ type: String })
-    public ariaLabelledby?: TextInputProps['ariaLabelledby'];
-
     @property({ type: String })
     @validPropertyValues(componentSelector, statusTypes, undefined)
     public status?: TextInputProps['status'];


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
added aria-label and aria-lebelledby props to pie-text-input component and to list of actions in pie-storybook

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook` PR preview
- [ ] If there are visual test updates, I have reviewed them
