### PR TITLE
docs(pie-docs): DSW-000 shorten yarn and npm installation examples

### DIFF
--- a/apps/pie-docs/src/components/button/code/code.md
+++ b/apps/pie-docs/src/components/button/code/code.md
@@ -45,7 +45,7 @@ yarn add @justeattakeaway/pie-button
   src="https://webc.pie.design/?path=/story/button--primary&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -54,7 +54,7 @@ yarn add @justeattakeaway/pie-button
   src="https://webc.pie.design/?path=/docs/button--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props
@@ -92,7 +92,7 @@ The `pie-button` provides a set of attributes to customize its behavior within f
   src="https://webc.pie.design/?path=/story/button--form-integration&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 {% notification {

--- a/apps/pie-docs/src/components/button/code/code.md
+++ b/apps/pie-docs/src/components/button/code/code.md
@@ -26,13 +26,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-button` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-button
+npm i @justeattakeaway/pie-button
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-button
+yarn add @justeattakeaway/pie-button
 ```
 
 {% notification {
@@ -143,7 +141,7 @@ import '@justeattakeaway/pie-button'
 <script type="module" src="/main.js"></script>
 ```
 
-For Native JS Applications, Vue, Angular, Svelte etc.: 
+For Native JS Applications, Vue, Angular, Svelte etc.:
 
 ```js
 // Vue templates (using Nuxt 3)

--- a/apps/pie-docs/src/components/card/code/code.md
+++ b/apps/pie-docs/src/components/card/code/code.md
@@ -26,13 +26,11 @@ This component can be easily integrated into a variety of frontend frameworks (o
 To install `pie-card` in your application, run one of the following on your command line:
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-card
+yarn add @justeattakeaway/pie-card
 ```
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-card
+npm i @justeattakeaway/pie-card
 ```
 
 {% notification {

--- a/apps/pie-docs/src/components/card/code/code.md
+++ b/apps/pie-docs/src/components/card/code/code.md
@@ -45,7 +45,7 @@ npm i @justeattakeaway/pie-card
   src="https://webc.pie.design/?path=/story/card--default&viewMode=story&shortcuts=false&singleStory=true"
   width="100%",
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/chip/code/code.md
+++ b/apps/pie-docs/src/components/chip/code/code.md
@@ -45,7 +45,7 @@ yarn add @justeattakeaway/pie-chip
   src="https://webc.pie.design/?path=/story/chip--default&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -54,7 +54,7 @@ yarn add @justeattakeaway/pie-chip
   src="https://webc.pie.design/?path=/docs/chip--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/chip/code/code.md
+++ b/apps/pie-docs/src/components/chip/code/code.md
@@ -26,13 +26,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-chip` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-chip
+npm i @justeattakeaway/pie-chip
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-chip
+yarn add @justeattakeaway/pie-chip
 ```
 
 {% notification {
@@ -101,7 +99,7 @@ import '@justeattakeaway/pie-chip'
 <script type="module" src="/main.js"></script>
 ```
 
-For Native JS Applications, Vue, Angular, Svelte etc.: 
+For Native JS Applications, Vue, Angular, Svelte etc.:
 
 ```js
 // Vue templates (using Nuxt 3)

--- a/apps/pie-docs/src/components/divider/code/code.md
+++ b/apps/pie-docs/src/components/divider/code/code.md
@@ -25,13 +25,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-divider` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-divider
+npm i @justeattakeaway/pie-divider
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-divider
+yarn add @justeattakeaway/pie-divider
 ```
 
 {% notification {
@@ -79,7 +77,7 @@ import '@justeattakeaway/pie-divider'
 <script type="module" src="/main.js"></script>
 ```
 
-For Native JS Applications, Vue, Angular, Svelte etc.: 
+For Native JS Applications, Vue, Angular, Svelte etc.:
 
 ```js
 // Vue templates (using Nuxt 3)

--- a/apps/pie-docs/src/components/divider/code/code.md
+++ b/apps/pie-docs/src/components/divider/code/code.md
@@ -44,7 +44,7 @@ yarn add @justeattakeaway/pie-divider
   src="https://webc.pie.design/?path=/story/divider--default&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -53,7 +53,7 @@ yarn add @justeattakeaway/pie-divider
   src="https://webc.pie.design/?path=/docs/divider--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/icon-button/code/code.md
+++ b/apps/pie-docs/src/components/icon-button/code/code.md
@@ -25,13 +25,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-icon-button` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-icon-button
+npm i @justeattakeaway/pie-icon-button
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-icon-button
+yarn add @justeattakeaway/pie-icon-button
 ```
 
 {% notification {

--- a/apps/pie-docs/src/components/icon-button/code/code.md
+++ b/apps/pie-docs/src/components/icon-button/code/code.md
@@ -44,7 +44,7 @@ yarn add @justeattakeaway/pie-icon-button
   src="https://webc.pie.design/?path=/story/icon-button--primary&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -53,7 +53,7 @@ yarn add @justeattakeaway/pie-icon-button
   src="https://webc.pie.design/?path=/docs/icon-button--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Importing Icons

--- a/apps/pie-docs/src/components/link/code/code.md
+++ b/apps/pie-docs/src/components/link/code/code.md
@@ -45,7 +45,7 @@ yarn add @justeattakeaway/pie-link
   src="https://webc.pie.design/?path=/story/link--default&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -54,7 +54,7 @@ yarn add @justeattakeaway/pie-link
   src="https://webc.pie.design/?path=/docs/link--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/link/code/code.md
+++ b/apps/pie-docs/src/components/link/code/code.md
@@ -26,13 +26,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-link` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-link
+npm i @justeattakeaway/pie-link
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-link
+yarn add @justeattakeaway/pie-link
 ```
 
 {% notification {
@@ -105,7 +103,7 @@ import '@justeattakeaway/pie-link'
 <script type="module" src="/main.js"></script>
 ```
 
-For Native JS Applications, Vue, Angular, Svelte etc.: 
+For Native JS Applications, Vue, Angular, Svelte etc.:
 
 ```js
 // Vue templates (using Nuxt 3)

--- a/apps/pie-docs/src/components/modal/code/code.md
+++ b/apps/pie-docs/src/components/modal/code/code.md
@@ -27,13 +27,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-modal` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-modal
+npm i @justeattakeaway/pie-modal
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-modal
+yarn add @justeattakeaway/pie-modal
 ```
 
 {% notification {

--- a/apps/pie-docs/src/components/modal/code/code.md
+++ b/apps/pie-docs/src/components/modal/code/code.md
@@ -48,7 +48,7 @@ yarn add @justeattakeaway/pie-modal
   src="https://webc.pie.design/?path=/story/modal--default&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ---

--- a/apps/pie-docs/src/components/notification/code/code.md
+++ b/apps/pie-docs/src/components/notification/code/code.md
@@ -46,7 +46,7 @@ yarn add @justeattakeaway/pie-notification
   src="https://webc.pie.design/?path=/story/notification--neutral&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -55,7 +55,7 @@ yarn add @justeattakeaway/pie-notification
   src="https://webc.pie.design/?path=/docs/notification--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/notification/code/code.md
+++ b/apps/pie-docs/src/components/notification/code/code.md
@@ -27,13 +27,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-notification` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-notification
+npm i @justeattakeaway/pie-notification
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-notification
+yarn add @justeattakeaway/pie-notification
 ```
 
 {% notification {
@@ -115,7 +113,7 @@ import '@justeattakeaway/pie-notification'
 <script type="module" src="/main.js"></script>
 ```
 
-For Native JS Applications, Vue, Angular, Svelte etc.: 
+For Native JS Applications, Vue, Angular, Svelte etc.:
 
 ```js
 // Vue templates (using Nuxt 3)

--- a/apps/pie-docs/src/components/switch/code/code.md
+++ b/apps/pie-docs/src/components/switch/code/code.md
@@ -25,13 +25,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-switch` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-switch
+npm i @justeattakeaway/pie-switch
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-switch
+yarn add @justeattakeaway/pie-switch
 ```
 
 {% notification {

--- a/apps/pie-docs/src/components/switch/code/code.md
+++ b/apps/pie-docs/src/components/switch/code/code.md
@@ -44,7 +44,7 @@ yarn add @justeattakeaway/pie-switch
   src="https://webc.pie.design/?path=/story/switch--default&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/tag/code/code.md
+++ b/apps/pie-docs/src/components/tag/code/code.md
@@ -45,7 +45,7 @@ yarn add @justeattakeaway/pie-tag
   src="https://webc.pie.design/?path=/story/tag--neutral&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Variants
@@ -54,7 +54,7 @@ yarn add @justeattakeaway/pie-tag
   src="https://webc.pie.design/?path=/docs/tag--variants&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="600px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 ## Props

--- a/apps/pie-docs/src/components/tag/code/code.md
+++ b/apps/pie-docs/src/components/tag/code/code.md
@@ -26,13 +26,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-tag` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-tag
+npm i @justeattakeaway/pie-tag
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-tag
+yarn add @justeattakeaway/pie-tag
 ```
 
 {% notification {
@@ -103,7 +101,7 @@ import '@justeattakeaway/pie-tag'
 <script type="module" src="/main.js"></script>
 ```
 
-For Native JS Applications, Vue, Angular, Svelte etc.: 
+For Native JS Applications, Vue, Angular, Svelte etc.:
 
 ```js
 // Vue templates (using Nuxt 3)

--- a/apps/pie-docs/src/patterns/cookie-banner/code/code.md
+++ b/apps/pie-docs/src/patterns/cookie-banner/code/code.md
@@ -49,7 +49,7 @@ yarn add @justeattakeaway/pie-cookie-banner
   src="https://webc.pie.design/?path=/story/cookie-banner--default&viewMode=story&shortcuts=true&singleStory=true"
   width="100%"
   height="900px"
-  style="border: none; margin-top: 32px;"
+  style="border: none; margin-top: var(--dt-spacing-f);"
 ></iframe>
 
 

--- a/apps/pie-docs/src/patterns/cookie-banner/code/code.md
+++ b/apps/pie-docs/src/patterns/cookie-banner/code/code.md
@@ -30,13 +30,11 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-cookie-banner` in your application, run the following on your command line:
 
 ```shell
-# npm
-$ npm i @justeattakeaway/pie-cookie-banner
+npm i @justeattakeaway/pie-cookie-banner
 ```
 
 ```shell
-# yarn
-$ yarn add @justeattakeaway/pie-cookie-banner
+yarn add @justeattakeaway/pie-cookie-banner
 ```
 
 {% notification {

--- a/packages/components/pie-assistive-text/README.md
+++ b/packages/components/pie-assistive-text/README.md
@@ -30,11 +30,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-assistive-text` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-assistive-text
+npm i @justeattakeaway/pie-assistive-text
 
-# yarn
-$ yarn add @justeattakeaway/pie-assistive-text
+yarn add @justeattakeaway/pie-assistive-text
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-button/README.md
+++ b/packages/components/pie-button/README.md
@@ -21,11 +21,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-button` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-button
+npm i @justeattakeaway/pie-button
 
-# yarn
-$ yarn add @justeattakeaway/pie-button
+yarn add @justeattakeaway/pie-button
 ```
 
 ## Documentation

--- a/packages/components/pie-card/README.md
+++ b/packages/components/pie-card/README.md
@@ -20,11 +20,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-card` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-card
+npm i @justeattakeaway/pie-card
 
-# yarn
-$ yarn add @justeattakeaway/pie-card
+yarn add @justeattakeaway/pie-card
 ```
 
 ## Documentation

--- a/packages/components/pie-checkbox/README.md
+++ b/packages/components/pie-checkbox/README.md
@@ -30,11 +30,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-checkbox` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-checkbox
+npm i @justeattakeaway/pie-checkbox
 
-# yarn
-$ yarn add @justeattakeaway/pie-checkbox
+yarn add @justeattakeaway/pie-checkbox
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-chip/README.md
+++ b/packages/components/pie-chip/README.md
@@ -20,11 +20,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-chip` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-chip
+npm i @justeattakeaway/pie-chip
 
-# yarn
-$ yarn add @justeattakeaway/pie-chip
+yarn add @justeattakeaway/pie-chip
 ```
 
 ## Documentation

--- a/packages/components/pie-cookie-banner/README.md
+++ b/packages/components/pie-cookie-banner/README.md
@@ -23,11 +23,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-cookie-banner` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-cookie-banner
+npm i @justeattakeaway/pie-cookie-banner
 
-# yarn
-$ yarn add @justeattakeaway/pie-cookie-banner
+yarn add @justeattakeaway/pie-cookie-banner
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-divider/README.md
+++ b/packages/components/pie-divider/README.md
@@ -20,11 +20,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-divider` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-divider
+npm i @justeattakeaway/pie-divider
 
-# yarn
-$ yarn add @justeattakeaway/pie-divider
+yarn add @justeattakeaway/pie-divider
 ```
 
 ## Documentation

--- a/packages/components/pie-form-label/README.md
+++ b/packages/components/pie-form-label/README.md
@@ -29,11 +29,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-form-label` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-form-label
+npm i @justeattakeaway/pie-form-label
 
-# yarn
-$ yarn add @justeattakeaway/pie-form-label
+yarn add @justeattakeaway/pie-form-label
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-icon-button/README.md
+++ b/packages/components/pie-icon-button/README.md
@@ -20,11 +20,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-icon-button` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-icon-button
+npm i @justeattakeaway/pie-icon-button
 
-# yarn
-$ yarn add @justeattakeaway/pie-icon-button
+yarn add @justeattakeaway/pie-icon-button
 ```
 
 ## Documentation

--- a/packages/components/pie-link/README.md
+++ b/packages/components/pie-link/README.md
@@ -20,11 +20,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-link` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-link
+npm i @justeattakeaway/pie-link
 
-# yarn
-$ yarn add @justeattakeaway/pie-link
+yarn add @justeattakeaway/pie-link
 ```
 
 ## Documentation

--- a/packages/components/pie-modal/README.md
+++ b/packages/components/pie-modal/README.md
@@ -21,11 +21,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-modal` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-modal
+npm i @justeattakeaway/pie-modal
 
-# yarn
-$ yarn add @justeattakeaway/pie-modal
+yarn add @justeattakeaway/pie-modal
 ```
 
 ## Documentation

--- a/packages/components/pie-notification/README.md
+++ b/packages/components/pie-notification/README.md
@@ -29,11 +29,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-notification` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-notification
+npm i @justeattakeaway/pie-notification
 
-# yarn
-$ yarn add @justeattakeaway/pie-notification
+yarn add @justeattakeaway/pie-notification
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-spinner/README.md
+++ b/packages/components/pie-spinner/README.md
@@ -29,11 +29,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-spinner` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-spinner
+npm i @justeattakeaway/pie-spinner
 
-# yarn
-$ yarn add @justeattakeaway/pie-spinner
+yarn add @justeattakeaway/pie-spinner
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-switch/README.md
+++ b/packages/components/pie-switch/README.md
@@ -17,11 +17,9 @@
 To install `pie-switch` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-switch
+npm i @justeattakeaway/pie-switch
 
-# yarn
-$ yarn add @justeattakeaway/pie-switch
+yarn add @justeattakeaway/pie-switch
 ```
 
 ## Documentation

--- a/packages/components/pie-tag/README.md
+++ b/packages/components/pie-tag/README.md
@@ -20,11 +20,9 @@ This component can be easily integrated into various frontend frameworks and cus
 To install `pie-tag` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-tag
+npm i @justeattakeaway/pie-tag
 
-# yarn
-$ yarn add @justeattakeaway/pie-tag
+yarn add @justeattakeaway/pie-tag
 ```
 
 ## Documentation

--- a/packages/components/pie-text-input/README.md
+++ b/packages/components/pie-text-input/README.md
@@ -33,11 +33,9 @@ To install `pie-text-input` in your application, run the following on your comma
 _Note: Versions of this component prior to v0.19.0 were named `pie-input`._
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-text-input
+npm i @justeattakeaway/pie-text-input
 
-# yarn
-$ yarn add @justeattakeaway/pie-text-input
+yarn add @justeattakeaway/pie-text-input
 ```
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).

--- a/packages/components/pie-webc/README.md
+++ b/packages/components/pie-webc/README.md
@@ -28,11 +28,9 @@ This means that after installing this package as a dependency, you can use as ma
 To install `pie-webc` in your application, run the following on your command line:
 
 ```bash
-# npm
-$ npm i @justeattakeaway/pie-webc
+npm i @justeattakeaway/pie-webc
 
-# yarn
-$ yarn add @justeattakeaway/pie-webc
+yarn add @justeattakeaway/pie-webc
 ```
 
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Replaced the yarn and npm installation code snippets with just the code needed so that the copy buttons work correctly
- Replace usage of `32px` with the design token `spacing-f` for Storybook iframe embeds

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

## Reviewer checklists (complete before approving)
### Reviewer 1 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
