### PR TITLE
feat(pie-text-input): DSW-000 add default status type to improve prop handling in Next apps

### DIFF
--- a/.changeset/green-mugs-pump.md
+++ b/.changeset/green-mugs-pump.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-text-input": minor
+---
+
+[Added] - Default status type

--- a/apps/pie-storybook/stories/pie-text-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-text-input.stories.ts
@@ -177,18 +177,18 @@ const textInputStoryMeta: TextInputStoryMeta = {
             options: slotOptions,
         },
         assistiveText: {
-            description: 'An optional assistive text to display below the input element.',
+            description: 'An optional assistive text to display below the input element. Must be provided when the status is success or error.',
             control: 'text',
             defaultValue: {
                 summary: '',
             },
         },
         status: {
-            description: 'Sets the status of the input component / assistive text.',
+            description: 'The status of the input component / assistive text. Can be default, success or error.',
             control: 'select',
-            options: [undefined, ...statusTypes],
+            options: statusTypes,
             defaultValue: {
-                summary: undefined,
+                summary: defaultProps.status,
             },
         },
         size: {

--- a/packages/components/pie-text-input/README.md
+++ b/packages/components/pie-text-input/README.md
@@ -88,7 +88,7 @@ import { PieTextInput } from '@justeattakeaway/pie-text-input/dist/react';
 | `type` | `'text'`, `'number'`, `'password'`, `'url'`, `'email'`, `'tel'` | `text` | The type of HTML input to render. |
 | `value` | `string` | `''` | The value of the input (used as a key/value pair in HTML forms with `name`). |
 | `assistiveText` | `string` | `''` | Allows assistive text to be displayed below the input element. |
-| `status` | `'error'`, `'success'` | `undefined` | The status of the input component / assistive text. If you use `status` you must provide an `assistiveText` prop value for accessibility purposes. |
+| `status` | `'default'`, `'error'`, `'success'` | `'default'` | The status of the input component / assistive text. If you use `status` you must provide an `assistiveText` prop value for accessibility purposes. |
 | `step` | `number` | - | An optional amount that value should be incremented or decremented by when using the up and down arrows in the input. Only applies when type is `number`. |
 | `min` | `number` | - | The minimum value of the input. Only applies when type is `number`. If the value provided is lower, the input is invalid. |
 | `max` | `number` | - | The maximum value of the input. Only applies when type is `number`. If the value provided is higher, the input is invalid. |

--- a/packages/components/pie-text-input/src/defs.ts
+++ b/packages/components/pie-text-input/src/defs.ts
@@ -2,7 +2,7 @@ import { type ComponentDefaultPropsGeneric } from '@justeattakeaway/pie-webc-cor
 
 export const types = ['text', 'number', 'password', 'url', 'email', 'tel'] as const;
 export const inputModes = ['none', 'text', 'tel', 'url', 'email', 'numeric', 'decimal', 'search'] as const;
-export const statusTypes = ['success', 'error'] as const;
+export const statusTypes = ['default', 'success', 'error'] as const;
 export const sizes = ['small', 'medium', 'large'] as const;
 
 export interface TextInputProps {
@@ -77,12 +77,12 @@ export interface TextInputProps {
     defaultValue?: string;
 
     /**
-     * An optional assistive text to display below the input element.
+     * An optional assistive text to display below the input element. Must be provided when the status is success or error.
      */
     assistiveText?: string;
 
     /**
-     * The status of the input component / assistive text such as error, success or default.
+     * The status of the input component / assistive text. Can be default, success or error.
      */
     status?: typeof statusTypes[number];
 
@@ -115,7 +115,7 @@ export interface TextInputProps {
 /**
  * The default values for the `TextInputProps` that are required (i.e. they have a fallback value in the component).
  */
-type DefaultProps = ComponentDefaultPropsGeneric<TextInputProps, 'type' | 'value' | 'size'>;
+type DefaultProps = ComponentDefaultPropsGeneric<TextInputProps, 'type' | 'value' | 'size' | 'status'>;
 
 /**
  * Default values for optional properties that have default fallback values in the component.
@@ -124,4 +124,5 @@ export const defaultProps: DefaultProps = {
     type: 'text',
     value: '',
     size: 'medium',
+    status: 'default',
 };

--- a/packages/components/pie-text-input/src/index.ts
+++ b/packages/components/pie-text-input/src/index.ts
@@ -78,8 +78,8 @@ export class PieTextInput extends FormControlMixin(RtlMixin(LitElement)) impleme
     public assistiveText?: TextInputProps['assistiveText'];
 
     @property({ type: String })
-    @validPropertyValues(componentSelector, statusTypes, undefined)
-    public status?: TextInputProps['status'];
+    @validPropertyValues(componentSelector, statusTypes, defaultProps.status)
+    public status?: TextInputProps['status'] = defaultProps.status;
 
     @property({ type: Number })
     public step?: TextInputProps['step'];
@@ -239,7 +239,14 @@ export class PieTextInput extends FormControlMixin(RtlMixin(LitElement)) impleme
                 <slot name="trailingIcon"></slot>
                 <slot name="trailingText"></slot>
             </div>
-            ${assistiveText ? html`<pie-assistive-text id="${assistiveTextIdValue}" variant=${ifDefined(status)} data-test-id="pie-text-input-assistive-text">${assistiveText}</pie-assistive-text>` : nothing}`;
+            ${assistiveText ? html`
+                <pie-assistive-text
+                    id="${assistiveTextIdValue}"
+                    variant=${ifDefined(status)}
+                    data-test-id="pie-text-input-assistive-text">
+                    ${assistiveText}
+                </pie-assistive-text>
+            ` : nothing}`;
     }
 
     // Renders a `CSSResult` generated from SCSS by Vite

--- a/packages/components/pie-text-input/test/component/pie-text-input.spec.ts
+++ b/packages/components/pie-text-input/test/component/pie-text-input.spec.ts
@@ -513,7 +513,7 @@ test.describe('PieTextInput - Component tests', () => {
                 expect(assistiveText).not.toBeVisible();
             });
 
-            test('should not apply a variant attribute if no status is provided', async ({ mount, page }) => {
+            test('should apply the "default" variant attribute if no status is provided', async ({ mount, page }) => {
                 // Arrange
                 await mount(PieTextInput, {
                     props: {
@@ -526,7 +526,7 @@ test.describe('PieTextInput - Component tests', () => {
 
                 // Assert
                 expect(assistiveText).toBeVisible();
-                expect(await assistiveText.getAttribute('variant')).toBe(null);
+                expect(await assistiveText.getAttribute('variant')).toBe('default');
                 expect(assistiveText).toHaveText('Assistive text');
             });
 
@@ -1263,22 +1263,22 @@ test.describe('PieTextInput - Component tests', () => {
                 });
             });
 
-            test.describe('when the component `status` is set to anything but `error`', () => {
-                test('should render the `aria-invalid` with a value of `false`', async ({ mount }) => {
-                    // Arrange
-                    const component = await mount(PieTextInput, {
-                        props: {
-                            status: 'success',
-                        } as TextInputProps,
+            statusTypes.filter((status) => status !== 'error').forEach((status) => {
+                test.describe(`when the component status is set to "${status}"`, () => {
+                    test('should render the `aria-invalid` with a value of `false`', async ({ mount }) => {
+                        // Arrange
+                        const component = await mount(PieTextInput, {
+                            props: { status } as TextInputProps,
+                        });
+
+                        // Act
+                        const input = component.locator('input');
+
+                        const componentAttribute = await input.getAttribute('aria-invalid');
+
+                        // Assert
+                        expect(componentAttribute).toBe('false');
                     });
-
-                    // Act
-                    const input = component.locator('input');
-
-                    const componentAttribute = await input.getAttribute('aria-invalid');
-
-                    // Assert
-                    expect(componentAttribute).toBe('false');
                 });
             });
         });
@@ -1303,22 +1303,22 @@ test.describe('PieTextInput - Component tests', () => {
                 });
             });
 
-            test.describe('when the component `status` is set to anything but `error`', () => {
-                test('should not render the `aria-errormessage` attribute', async ({ mount }) => {
-                    // Arrange
-                    const component = await mount(PieTextInput, {
-                        props: {
-                            status: 'success',
-                        } as TextInputProps,
+            statusTypes.filter((status) => status !== 'error').forEach((status) => {
+                test.describe(`when the component status is set to "${status}"`, () => {
+                    test('should not render the `aria-errormessage` attribute', async ({ mount }) => {
+                        // Arrange
+                        const component = await mount(PieTextInput, {
+                            props: { status } as TextInputProps,
+                        });
+
+                        // Act
+                        const input = component.locator('input');
+
+                        const componentAttribute = await input.getAttribute('aria-errormessage');
+
+                        // Assert
+                        expect(componentAttribute).toBeNull();
                     });
-
-                    // Act
-                    const input = component.locator('input');
-
-                    const componentAttribute = await input.getAttribute('aria-errormessage');
-
-                    // Assert
-                    expect(componentAttribute).toBeNull();
                 });
             });
         });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

---
"@justeattakeaway/pie-text-input": minor
---

[Added] - Default status type

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests where applicable (unit / component / visual)
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
