### PR TITLE
feat(pie-spinner): DSW-000 add CSS variable for spinner

### DIFF
--- a/.changeset/popular-meals-hear.md
+++ b/.changeset/popular-meals-hear.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-spinner": patch
+---
+
+[Added] - CSS variable for spinner speed

--- a/packages/components/pie-spinner/src/spinner.scss
+++ b/packages/components/pie-spinner/src/spinner.scss
@@ -25,6 +25,7 @@
     --spinner-size: 24px;
     --spinner-left-color: hsl(var(--spinner-base-color-h), var(--spinner-base-color-s), var(--spinner-base-color-l), 1);
     --spinner-right-color: hsl(var(--spinner-base-color-h), var(--spinner-base-color-s), var(--spinner-base-color-l), 0.35);
+    --spinner-animation-speed: 1.15s;
 
     block-size: var(--spinner-size);
     inline-size: var(--spinner-size);
@@ -33,7 +34,7 @@
     border-style: solid;
     border-color: var(--spinner-left-color) var(--spinner-right-color) var(--spinner-right-color) var(--spinner-left-color);
     will-change: transform;
-    animation: rotate360 1.15s linear infinite;
+    animation: rotate360 var(--spinner-animation-speed) linear infinite;
 
     @include spinner-base-colors('--dt-color-content-brand');
 

--- a/packages/components/pie-spinner/test/visual/pie-spinner.spec.ts
+++ b/packages/components/pie-spinner/test/visual/pie-spinner.spec.ts
@@ -52,6 +52,9 @@ test.describe('PieSpinner - Visual tests`', () => {
             );
         }));
 
-        await percySnapshot(page, `PIE Spinner - Variant: ${variant}`, percyWidths);
+        await percySnapshot(page, `PIE Spinner - Variant: ${variant}`, {
+            ...percyWidths,
+            percyCSS: '--spinner-animation-speed: 999s;',
+        });
     }));
 });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Trying to fix a bugbear of mine where the visual regression tests for the spinner always show as changed because the animation is in a slightly different state.

Adding a variable allows for custom Percy CSS to be added, slowing down the animation to hopefully make it always render the same for the tests.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests where applicable (unit / component / visual)
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
