### PR TITLE
docs(pie-docs): DSW-000 doc site fixes

### DIFF
--- a/.changeset/shiny-bottles-explain.md
+++ b/.changeset/shiny-bottles-explain.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Fixed] Address issue of sub menu closing when selecting a child item.

--- a/.changeset/unlucky-hotels-call.md
+++ b/.changeset/unlucky-hotels-call.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Fixed] Avoid including the template route in browser tests

--- a/apps/pie-docs/src/_includes/nav.njk
+++ b/apps/pie-docs/src/_includes/nav.njk
@@ -58,7 +58,7 @@
                                     {% for subpage in category.children %}
                                         {% if subpage.url %}
                                             {% if subpage.children.length and subpage.subPageDropdown %}
-                                                <details {% if page.url and page.url.includes(subpage.key) %} open{% endif %}>
+                                                <details {% if page.url and page.url.includes(subpage.key.toLowerCase()) %} open{% endif %}>
                                                     {{ summary(subpage.title) }}
                                                     <ul class="c-nav-list">
                                                     {% for child in subpage.children %}

--- a/apps/pie-docs/test/helpers/routes-helper.js
+++ b/apps/pie-docs/test/helpers/routes-helper.js
@@ -16,7 +16,7 @@ exports.getNavigationRoutes = () => {
 */
 const readChildren = (childDirectories, result = []) => {
     // folders in the dist we want to ignore
-    const ignores = ['assets', 'node_modules'];
+    const ignores = ['assets', 'node_modules', 'template'];
 
     // Files we want to specifically include
     const includes = ['404.html'];


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

Added 2 commits that fix recent found issues. 
1. Our browser tests were failing because we were including a route for the `template` , which are
    documentation in draft mode that can be copied when starting a new component page. As it is not a
    production route it probably should not be tested. Added `template` to the ignore list.
2. When selecting items within the Motion menu, the submenu did not remain open. 
     It was an issue of checking against a url key that expected the same casing. As we do not have a standard 
     of using lowercase keys in our 11y pages, was better to fix it in navigation logic instead.

Changes expected in Docs site preview: When navigating to any of the `Foundations/Motion/` children, the sub-menu should remain open.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [ ] I have reviewed the Docs site preview
- [ ] If there are visual test updates, I have reviewed them properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the Docs site preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the Docs site preview
- [ ] If there are visual test updates, I have reviewed them
