### PR TITLE
chore(pie-monorepo): DSW-000 do not lint draft PR titles

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -2,10 +2,11 @@ name: Lint PR Title
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:
   pr-lint:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.0


### PR DESCRIPTION
Just prevents PR titles from being linted when the PR is in draft mode. This reduces unnecessary noise when opening PRs.