### PR TITLE
feat(pie-monorepo): DSW-2056 integrate pie-webc package into wc-vanilla

### DIFF
--- a/.changeset/blue-dots-chew.md
+++ b/.changeset/blue-dots-chew.md
@@ -1,0 +1,5 @@
+---
+"wc-vanilla": minor
+---
+
+[Added] pie-webc integration to wc-vanilla example app

--- a/apps/examples/wc-vanilla/main.js
+++ b/apps/examples/wc-vanilla/main.js
@@ -1,7 +1,7 @@
 import '@justeattakeaway/pie-css';
-import '@justeattakeaway/pie-button';
-import '@justeattakeaway/pie-modal';
-import '@justeattakeaway/pie-icon-button';
+import '@justeattakeaway/pie-webc/components/button.js';
+import '@justeattakeaway/pie-webc/components/modal.js';
+import '@justeattakeaway/pie-webc/components/icon-button.js';
 import '@justeattakeaway/pie-icons-webc/dist/IconClose.js';
 import '@justeattakeaway/pie-icons-webc/dist/IconSearch.js';
 import './style.css';

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@justeat/pie-design-tokens": "6.3.1",
     "@justeattakeaway/pie-css": "0.12.1",
+    "@justeattakeaway/pie-icons-webc": "0.24.2",
     "@justeattakeaway/pie-webc": "0.5.12"
   },
   "installConfig": {

--- a/apps/examples/wc-vanilla/package.json
+++ b/apps/examples/wc-vanilla/package.json
@@ -13,11 +13,8 @@
   },
   "dependencies": {
     "@justeat/pie-design-tokens": "6.3.1",
-    "@justeattakeaway/pie-button": "0.47.8",
     "@justeattakeaway/pie-css": "0.12.1",
-    "@justeattakeaway/pie-icon-button": "0.28.9",
-    "@justeattakeaway/pie-icons-webc": "0.24.2",
-    "@justeattakeaway/pie-modal": "0.43.4"
+    "@justeattakeaway/pie-webc": "0.5.12"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"


### PR DESCRIPTION
Adds pie-webc integration to wc-vanilla examples app.

[PIE Docs Template](?expand=1&template=docs_template.md)
[New Web Component Template](?expand=1&template=new_component_template.md)

═══════════════════════════════════════════════════════════

## Screenshot

<img width="894" alt="Screenshot 2024-07-11 at 14 33 37" src="https://github.com/justeattakeaway/pie/assets/2299779/75909891-8f2f-4156-bfaf-51e1838ca0d4">




## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application
