### PR TITLE
ci(pie-monorepo): DSW-000 update turbo filter syntax

### DIFF
--- a/.changeset/lovely-ducks-sneeze.md
+++ b/.changeset/lovely-ducks-sneeze.md
@@ -1,0 +1,6 @@
+---
+"pie-monorepo": minor
+---
+
+[Changed] - Update turbo filter syntax for GitHub Actions
+[Changed] - Use the old UI for turbo console output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,19 +75,19 @@ jobs:
       - name: Verify if pie-docs has changes
         id: docs-check
         run: |
-          DOCS_CHANGE=$(npx -y turbo run build --filter=./apps/pie-docs...[origin/main] --dry=json | jq '.packages | length > 0')
+          DOCS_CHANGE=$(npx -y turbo run build --filter='./apps/pie-docs...[origin/main]' --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $DOCS_CHANGE"
           echo "docs-change=$DOCS_CHANGE" >> $GITHUB_OUTPUT
       - name: Verify if web components have changes
         id: component-check
         run: |
-          COMPONENT_CHANGE=$(npx -y turbo run build --filter=./packages/components/*...[origin/main] --dry=json | jq '.packages | length > 0')
+          COMPONENT_CHANGE=$(npx -y turbo run build --filter='./packages/components/*...[origin/main]' --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $COMPONENT_CHANGE"
           echo "web-components-change=$COMPONENT_CHANGE" >> $GITHUB_OUTPUT
       - name: Verify if storybook has changes
         id: storybook-check
         run: |
-          STORYBOOK_CHANGE=$(npx -y turbo run build --filter=./apps/pie-storybook...[origin/main] --dry=json | jq '.packages | length > 0')
+          STORYBOOK_CHANGE=$(npx -y turbo run build --filter='./apps/pie-storybook...[origin/main]' --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $STORYBOOK_CHANGE"
           echo "storybook-change=$STORYBOOK_CHANGE" >> $GITHUB_OUTPUT
 
@@ -198,7 +198,7 @@ jobs:
       - name: Run All System / Component /  a11y Tests
         uses: ./.github/actions/run-script
         with:
-          script-name: "test:browsers:ci --filter=./packages/components/*"
+          script-name: "test:browsers:ci --filter='./packages/components/*'"
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -210,13 +210,13 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter=./packages/components/*...[HEAD^1]"
+          script-name: "test:visual:ci --filter='./packages/components/*...[HEAD^1]'"
           concurrency: 1
       - name: Run Changed Package Visual Tests
         uses: ./.github/actions/run-script
         if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) && github.ref != 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter=./packages/components/*...[origin/main]"
+          script-name: "test:visual:ci --filter='./packages/components/*...[origin/main]'"
           concurrency: 1
       - uses: actions/upload-artifact@v3
         if: always()
@@ -287,7 +287,7 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter=pie-docs...[HEAD^1]"
+          script-name: "test:visual:ci --filter='pie-docs...[HEAD^1]'"
           concurrency: 1
       - name: Run Changed Package Visual Tests
         uses: ./.github/actions/run-script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,19 +75,19 @@ jobs:
       - name: Verify if pie-docs has changes
         id: docs-check
         run: |
-          DOCS_CHANGE=$(npx -y turbo run build --filter='{./apps/pie-docs}...[origin/main]' --dry=json | jq '.packages | length > 0')
+          DOCS_CHANGE=$(npx -y turbo run build --filter=./apps/pie-docs...[origin/main] --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $DOCS_CHANGE"
           echo "docs-change=$DOCS_CHANGE" >> $GITHUB_OUTPUT
       - name: Verify if web components have changes
         id: component-check
         run: |
-          COMPONENT_CHANGE=$(npx -y turbo run build --filter='{./packages/components/*}...[origin/main]' --dry=json | jq '.packages | length > 0')
+          COMPONENT_CHANGE=$(npx -y turbo run build --filter=./packages/components/*...[origin/main] --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $COMPONENT_CHANGE"
           echo "web-components-change=$COMPONENT_CHANGE" >> $GITHUB_OUTPUT
       - name: Verify if storybook has changes
         id: storybook-check
         run: |
-          STORYBOOK_CHANGE=$(npx -y turbo run build --filter='{./apps/pie-storybook}...[origin/main]' --dry=json | jq '.packages | length > 0')
+          STORYBOOK_CHANGE=$(npx -y turbo run build --filter=./apps/pie-storybook...[origin/main] --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $STORYBOOK_CHANGE"
           echo "storybook-change=$STORYBOOK_CHANGE" >> $GITHUB_OUTPUT
 
@@ -198,7 +198,7 @@ jobs:
       - name: Run All System / Component /  a11y Tests
         uses: ./.github/actions/run-script
         with:
-          script-name: "test:browsers:ci --filter='./packages/components/*'"
+          script-name: "test:browsers:ci --filter=./packages/components/*"
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -210,13 +210,13 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter='{./packages/components/*}...[HEAD^1]'"
+          script-name: "test:visual:ci --filter=./packages/components/*...[HEAD^1]"
           concurrency: 1
       - name: Run Changed Package Visual Tests
         uses: ./.github/actions/run-script
         if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) && github.ref != 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter='{./packages/components/*}...[origin/main]'"
+          script-name: "test:visual:ci --filter=./packages/components/*...[origin/main]"
           concurrency: 1
       - uses: actions/upload-artifact@v3
         if: always()
@@ -287,7 +287,7 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter='pie-docs...[HEAD^1]'"
+          script-name: "test:visual:ci --filter=pie-docs...[HEAD^1]"
           concurrency: 1
       - name: Run Changed Package Visual Tests
         uses: ./.github/actions/run-script

--- a/apps/pie-docs/src/404.njk
+++ b/apps/pie-docs/src/404.njk
@@ -6,3 +6,5 @@ notFoundNarrowImgSrc: '/assets/img/404_narrow.png'
 ---
 
 {% include "not-found.njk" %}
+
+Some docs site change

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -11,6 +11,8 @@
     --modal-size-m: 600px;
     --modal-size-l: 1080px;
 
+    // Some component change
+
     // The base modal defaults
     --modal-border-radius: var(--dt-radius-rounded-d);
     --modal-font: var(--dt-font-interactive-l-family);

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "ui": "tui",
+  "ui": "stream",
   "tasks": {
     "build": {
       "cache": true,


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Revert to the old turbo UI. Can we make this a user preference somehow?
- Update filter syntax to hopefully work on both Mac and Windows.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests where applicable (unit / component / visual)
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
