### PR TITLE
test(pie-docs): DSW-000 exclude storybook previews from a11y testing

### DIFF
--- a/.changeset/thirty-carrots-heal.md
+++ b/.changeset/thirty-carrots-heal.md
@@ -2,4 +2,4 @@
 "pie-docs": patch
 ---
 
-[Changed] - solidify foundations page ordering
+[Fixed] - Conflict in ordering of pages in Foundations section

--- a/.changeset/thirty-carrots-heal.md
+++ b/.changeset/thirty-carrots-heal.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": patch
+---
+
+[Changed] - solidify foundations page ordering

--- a/apps/pie-docs/src/foundations/radius/radius.md
+++ b/apps/pie-docs/src/foundations/radius/radius.md
@@ -3,6 +3,6 @@ eleventyNavigation:
     key: Radius
     parent: Foundations
     url: /foundations/radius/
-    order: 5
+    order: 6
 permalink: false
 ---

--- a/apps/pie-docs/src/foundations/spacing/spacing.md
+++ b/apps/pie-docs/src/foundations/spacing/spacing.md
@@ -3,6 +3,6 @@ eleventyNavigation:
     key: Spacing
     parent: Foundations
     url: /foundations/spacing/
-    order: 6
+    order: 7
 permalink: false
 ---

--- a/apps/pie-docs/src/foundations/typography/typography.md
+++ b/apps/pie-docs/src/foundations/typography/typography.md
@@ -3,6 +3,6 @@ eleventyNavigation:
     key: Typography
     parent: Foundations
     url: /foundations/typography/
-    order: 7
+    order: 8
 permalink: false
 ---

--- a/apps/pie-docs/test/accessibility/accessibility.spec.js
+++ b/apps/pie-docs/test/accessibility/accessibility.spec.js
@@ -15,6 +15,7 @@ expectedRoutesJson.forEach((route) => {
 
         const results = await makeAxeBuilder()
             .include(`[data-test-id=${selector}]`)
+            .exclude('iframe')
             .analyze();
 
         expect(results.violations).toEqual([]);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Exclude `iframe` elements from accessibility tests
- Fix a conflict in the page ordering in the Foundations section (both Radius and Motion had `order: 5`)

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Docs` PR preview

## Reviewer checklists (complete before approving)
### Reviewer 1 @maledr5 
- [x] I have reviewed the `PIE Docs` PR preview

### Reviewer 2 - @jamieomaguire 
- [x] I have reviewed the `PIE Docs` PR preview
