### PR TITLE
fix(pie-notification): DSW-000 make sure custom and default icons work as expected

### DIFF
--- a/.changeset/red-mails-explain.md
+++ b/.changeset/red-mails-explain.md
@@ -2,4 +2,4 @@
 "@justeattakeaway/pie-notification": minor
 ---
 
-[Fixed] - make isDismissible set to false by default
+[Fixed] - make `isDismissible` false by default

--- a/.changeset/red-mails-explain.md
+++ b/.changeset/red-mails-explain.md
@@ -1,5 +1,6 @@
 ---
 "@justeattakeaway/pie-notification": minor
+"pie-docs": patch
 ---
 
 [Fixed] - make `isDismissible` false by default

--- a/.changeset/red-mails-explain.md
+++ b/.changeset/red-mails-explain.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-notification": minor
+---
+
+[Fixed] - make isDismissible set to false by default

--- a/.changeset/smart-horses-confess.md
+++ b/.changeset/smart-horses-confess.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": patch
+---
+
+[Fixed] - use storybook mapping to render different slot content

--- a/.changeset/ten-actors-guess.md
+++ b/.changeset/ten-actors-guess.md
@@ -2,5 +2,5 @@
 "@justeattakeaway/pie-notification": minor
 ---
 
-[Added] - `slotchange` event with `hasExternalIcon` local state to make sure that conditional icon rendering works as expected.
+[Fixed] - Make sure custom icons works as expected with default icons.
 

--- a/.changeset/ten-actors-guess.md
+++ b/.changeset/ten-actors-guess.md
@@ -1,7 +1,6 @@
 ---
 "@justeattakeaway/pie-notification": minor
-"@justeattakeaway/pie-storybook": minor
 ---
 
-[Fixed] - Make sure custom icons works as expected with default icons.
+[Fixed] - Make sure custom and default icons work as expected.
 

--- a/.changeset/ten-actors-guess.md
+++ b/.changeset/ten-actors-guess.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-notification": minor
+---
+
+[Added] - `slotchange` event with `hasExternalIcon` local state to make sure that conditional icon rendering works as expected.
+

--- a/.changeset/ten-actors-guess.md
+++ b/.changeset/ten-actors-guess.md
@@ -2,5 +2,5 @@
 "@justeattakeaway/pie-notification": minor
 ---
 
-[Fixed] - Make sure custom and default icons work as expected.
+[Fixed] - make sure custom and default icons work as expected.
 

--- a/.changeset/ten-actors-guess.md
+++ b/.changeset/ten-actors-guess.md
@@ -1,5 +1,6 @@
 ---
 "@justeattakeaway/pie-notification": minor
+"@justeattakeaway/pie-storybook": minor
 ---
 
 [Fixed] - Make sure custom icons works as expected with default icons.

--- a/apps/pie-docs/src/components/notification/code/props.json
+++ b/apps/pie-docs/src/components/notification/code/props.json
@@ -58,7 +58,7 @@
             "When true, allows dismissing the notification by clicking on the close button",
             {
                 "type": "code",
-                "item": ["true"]
+                "item": ["false"]
             }
         ],
         [

--- a/apps/pie-storybook/stories/pie-checkbox-group.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox-group.stories.ts
@@ -14,7 +14,7 @@ import '@justeattakeaway/pie-form-label';
 
 // Extending the props type definition to include storybook specific properties for controls
 type CheckboxGroupProps = CheckboxGroupBase & {
-    labelSlot: typeof slotOptions[number];
+    labelSlot: keyof typeof labelSlotOptions;
 };
 
 type CheckboxGroupStoryMeta = StoryMeta<CheckboxGroupProps>;
@@ -24,7 +24,10 @@ const defaultArgs: CheckboxGroupProps = {
     labelSlot: 'None',
 };
 
-const slotOptions = ['Checkbox Group Label', 'None'] as const;
+const labelSlotOptions = {
+    None: nothing,
+    Label: html`<pie-form-label slot="label">Checkbox Group Label</pie-form-label>`,
+};
 
 const checkboxGroupStoryMeta: CheckboxGroupStoryMeta = {
     title: 'Checkbox Group',
@@ -36,9 +39,10 @@ const checkboxGroupStoryMeta: CheckboxGroupStoryMeta = {
         },
         labelSlot: {
             name: 'Label Slot',
-            description: '<b>**Not a component Prop</b><br><br>Use the `label` slot to pass <pie-form-label> component with all the relevant props.',
+            options: Object.keys(labelSlotOptions),
+            description: '<b>**Not a component Prop</b><br><br>Use the `label` slot to pass a <pie-form-label> component with all relevant props.',
             control: 'select',
-            options: slotOptions,
+            mapping: labelSlotOptions,
         },
         isInline: {
             description: 'Inline (horizontal) positioning of checkbox items.',
@@ -88,15 +92,7 @@ const Template = ({
     status,
     disabled,
     labelSlot,
-}: CheckboxGroupProps) => {
-    function renderLabelSlot (slotValue: typeof slotOptions[number]) {
-        if (slotValue === slotOptions[0]) {
-            return html`<pie-form-label slot="label">Checkbox Group Label</pie-form-label>`;
-        }
-        return nothing;
-    }
-
-    return html`
+}: CheckboxGroupProps) => html`
         <div style="max-width: 400px">
             <p>Please note, the checkboxes are separate components. See
             <pie-link href="/?path=/story/checkbox--default">pie-checkbox</pie-link>.</p>
@@ -107,7 +103,7 @@ const Template = ({
                 status=${ifDefined(status)}
                 ?disabled="${disabled}"
             >
-                ${renderLabelSlot(labelSlot)}
+                ${labelSlot}
                 <pie-checkbox name="checkbox-one">checkbox 1</pie-checkbox>
                 <pie-checkbox name="checkbox-two">checkbox 2</pie-checkbox>
                 <pie-checkbox name="checkbox-three">checkbox 3 longer label</pie-checkbox>
@@ -118,6 +114,5 @@ const Template = ({
             </pie-checkbox-group>
         </div>
     `;
-};
 
 export const Default = createStory<CheckboxGroupProps>(Template, defaultArgs)();

--- a/apps/pie-storybook/stories/pie-notification.stories.ts
+++ b/apps/pie-storybook/stories/pie-notification.stories.ts
@@ -11,10 +11,15 @@ import {
 
 import '@justeattakeaway/pie-icons-webc/dist/IconPlaceholder.js';
 
-import { type StoryMeta, SlottedComponentProps } from '../types';
+import { type StoryMeta } from '../types';
 import { createStory, type TemplateFunction } from '../utilities';
 
-type NotificationProps = SlottedComponentProps<NotificationBaseProps>;
+// Extending the props type definition to include storybook specific properties for controls
+type NotificationProps = NotificationBaseProps & {
+    slot: string;
+    iconSlot: typeof slotOptions[number];
+};
+
 type NotificationStoryMeta = StoryMeta<NotificationProps>;
 
 const defaultArgs: NotificationProps = {
@@ -29,7 +34,10 @@ const defaultArgs: NotificationProps = {
         text: 'Cancel',
         ariaLabel: 'Descriptive cancellation text',
     },
+    iconSlot: 'None',
 };
+
+const slotOptions = ['PIE Placeholder Icon', 'None'] as const;
 
 const notificationStoryMeta: NotificationStoryMeta = {
     title: 'Notification',
@@ -111,6 +119,12 @@ const notificationStoryMeta: NotificationStoryMeta = {
             description: 'Content to place within the notification.',
             control: 'text',
         },
+        iconSlot: {
+            name: 'Icon Slot',
+            description: '<b>**Not a component Prop</b><br><br>Use the `icon` slot to pass PIE icon component different from the default ones.',
+            control: 'select',
+            options: slotOptions,
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -141,9 +155,16 @@ const Template : TemplateFunction<NotificationProps> = ({
     supportingAction,
     hasStackedActions,
     slot,
+    iconSlot,
 }) => {
     const shouldShowPlaceholderIcon = variant && ['neutral', 'neutral-alternative'].includes(variant);
 
+    function renderIconSlot (slotValue: typeof slotOptions[number]) {
+        if (slotValue === slotOptions[0]) {
+            return html`<icon-placeholder slot="icon"></icon-placeholder>`;
+        }
+        return nothing;
+    }
     return html`
     <pie-notification
         ?isOpen="${isOpen}"
@@ -162,7 +183,7 @@ const Template : TemplateFunction<NotificationProps> = ({
         @pie-notification-close="${pieNotificationClose}"
         @pie-notification-open="${pieNotificationOpen}"
         >
-            ${shouldShowPlaceholderIcon ? html`<icon-placeholder slot="icon"></icon-placeholder>` : nothing}
+            ${renderIconSlot(iconSlot)}
             ${slot}
     </pie-notification>`;
 };

--- a/apps/pie-storybook/stories/pie-notification.stories.ts
+++ b/apps/pie-storybook/stories/pie-notification.stories.ts
@@ -17,7 +17,7 @@ import { createStory, type TemplateFunction } from '../utilities';
 // Extending the props type definition to include storybook specific properties for controls
 type NotificationProps = NotificationBaseProps & {
     slot: string;
-    iconSlot: typeof slotOptions[number];
+    iconSlot: keyof typeof slotOptions;
 };
 
 type NotificationStoryMeta = StoryMeta<NotificationProps>;
@@ -37,7 +37,10 @@ const defaultArgs: NotificationProps = {
     iconSlot: 'None',
 };
 
-const slotOptions = ['PIE Placeholder Icon', 'None'] as const;
+const slotOptions = {
+    None: nothing,
+    Placeholder: html`<icon-placeholder slot="icon"></icon-placeholder>`,
+};
 
 const notificationStoryMeta: NotificationStoryMeta = {
     title: 'Notification',
@@ -121,9 +124,10 @@ const notificationStoryMeta: NotificationStoryMeta = {
         },
         iconSlot: {
             name: 'Icon Slot',
-            description: '<b>**Not a component Prop</b><br><br>Use the `icon` slot to pass PIE icon component different from the default ones.',
+            options: Object.keys(slotOptions),
+            description: '<b>**Not a component prop</b><br><br>Use the `icon` slot to pass a PIE icon component that differs from the default icon.',
             control: 'select',
-            options: slotOptions,
+            mapping: slotOptions,
         },
     },
     args: defaultArgs,
@@ -156,16 +160,7 @@ const Template : TemplateFunction<NotificationProps> = ({
     hasStackedActions,
     slot,
     iconSlot,
-}) => {
-    const shouldShowPlaceholderIcon = variant && ['neutral', 'neutral-alternative'].includes(variant);
-
-    function renderIconSlot (slotValue: typeof slotOptions[number]) {
-        if (slotValue === slotOptions[0]) {
-            return html`<icon-placeholder slot="icon"></icon-placeholder>`;
-        }
-        return nothing;
-    }
-    return html`
+}) => html`
     <pie-notification
         ?isOpen="${isOpen}"
         variant="${ifDefined(variant)}"
@@ -181,12 +176,10 @@ const Template : TemplateFunction<NotificationProps> = ({
         @pie-notification-leading-action-click="${pieNotificationLeadingActionClick}"
         @pie-notification-supporting-action-click="${pieNotificationSupportingActionClick}"
         @pie-notification-close="${pieNotificationClose}"
-        @pie-notification-open="${pieNotificationOpen}"
-        >
-            ${renderIconSlot(iconSlot)}
+        @pie-notification-open="${pieNotificationOpen}">
+            ${iconSlot}
             ${slot}
     </pie-notification>`;
-};
 
 const createNotificationStory = createStory<NotificationProps>(Template, defaultArgs);
 

--- a/apps/pie-storybook/stories/pie-text-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-text-input.stories.ts
@@ -24,8 +24,8 @@ import '@justeattakeaway/pie-icons-webc/dist/IconKey.js';
 
 // Extending the props type definition to include storybook specific properties for controls
 type TextInputProps = TextInputPropsBase & {
-    leadingSlot: typeof slotOptions[number];
-    trailingSlot: typeof slotOptions[number];
+    leadingSlot: keyof typeof leadingSlotOptions;
+    trailingSlot: keyof typeof trailingSlotOptions;
 };
 
 type TextInputStoryMeta = StoryMeta<TextInputProps>;
@@ -37,7 +37,17 @@ const defaultArgs: TextInputProps = {
     trailingSlot: 'None',
 };
 
-const slotOptions = ['Icon (Placeholder)', 'Short text (#)', 'None'] as const;
+const leadingSlotOptions = {
+    None: nothing,
+    'Icon (Placeholder)': html`<icon-placeholder slot="leadingIcon"></icon-placeholder>`,
+    'Short text (#)': html`<span slot="leadingText">#</span>`,
+};
+
+const trailingSlotOptions = {
+    None: nothing,
+    'Icon (Placeholder)': html`<icon-placeholder slot="trailingIcon"></icon-placeholder>`,
+    'Short text (#)': html`<span slot="trailingText">#</span>`,
+};
 
 const textInputStoryMeta: TextInputStoryMeta = {
     title: 'Text Input',
@@ -168,13 +178,15 @@ const textInputStoryMeta: TextInputStoryMeta = {
             name: 'Leading Slot',
             description: '<b>**Not a component Prop</b><br><br>Use the `leadingText` slot for alphanumeric content (wrap the text in a `<span>`) or `leadingIcon` for icons.',
             control: 'select',
-            options: slotOptions,
+            options: Object.keys(leadingSlotOptions),
+            mapping: leadingSlotOptions,
         },
         trailingSlot: {
             name: 'Trailing Slot',
             description: '<b>**Not a component Prop</b><br><br>Use the `trailingText` slot for alphanumeric content (wrap the text in a `<span>`) or `trailingIcon` for icons.',
             control: 'select',
-            options: slotOptions,
+            options: Object.keys(trailingSlotOptions),
+            mapping: trailingSlotOptions,
         },
         assistiveText: {
             description: 'An optional assistive text to display below the input element. Must be provided when the status is success or error.',
@@ -259,30 +271,6 @@ const Template = ({
         });
     }
 
-    function renderLeadingSlot (slotValue: typeof slotOptions[number]) {
-        if (slotValue === slotOptions[0]) {
-            return html`<icon-placeholder slot="leadingIcon"></icon-placeholder>`;
-        }
-
-        if (slotValue === slotOptions[1]) {
-            return html`<span slot="leadingText">#</span>`;
-        }
-
-        return nothing;
-    }
-
-    function renderTrailingSlot (slotValue: typeof slotOptions[number]) {
-        if (slotValue === slotOptions[0]) {
-            return html`<icon-placeholder slot="trailingIcon"></icon-placeholder>`;
-        }
-
-        if (slotValue === slotOptions[1]) {
-            return html`<span slot="trailingText">#</span>`;
-        }
-
-        return nothing;
-    }
-
     return html`
         <pie-text-input
             type="${ifDefined(type)}"
@@ -308,8 +296,8 @@ const Template = ({
             ?required="${required}"
             @input="${onInput}"
             @change="${onChange}">
-            ${renderLeadingSlot(leadingSlot)}
-            ${renderTrailingSlot(trailingSlot)}
+                ${leadingSlot}
+                ${trailingSlot}
         </pie-text-input>
     `;
 };

--- a/packages/components/pie-notification/src/defs.ts
+++ b/packages/components/pie-notification/src/defs.ts
@@ -121,7 +121,7 @@ export type DefaultProps = ComponentDefaultProps<NotificationProps, keyof Omit<N
 export const defaultProps: DefaultProps = {
     variant: 'neutral',
     position: 'inline-content',
-    isDismissible: true,
+    isDismissible: false,
     isCompact: false,
     headingLevel: 'h2',
     hideIcon: false,

--- a/packages/components/pie-notification/src/index.ts
+++ b/packages/components/pie-notification/src/index.ts
@@ -46,9 +46,6 @@ export * from './defs';
  * @slot icon - The icon slot
  */
 export class PieNotification extends LitElement implements NotificationProps {
-    @state()
-    private hasExternalIcon = false;
-
     @property({ type: Boolean })
     public isOpen = defaultProps.isOpen;
 
@@ -112,9 +109,13 @@ export class PieNotification extends LitElement implements NotificationProps {
     private renderFooter () {
         const { leadingAction, supportingAction } = this;
         return html`
-            <footer class="${componentClass}-footer" data-test-id="${componentSelector}-footer" ?isCompact="${this.isCompact}" ?isStacked="${this.hasStackedActions && !this.isCompact}">
-                ${supportingAction ? this.renderActionButton(supportingAction, 'supporting') : nothing}
-                ${leadingAction ? this.renderActionButton(leadingAction, 'leading') : nothing}
+            <footer    
+                class="${componentClass}-footer" 
+                data-test-id="${componentSelector}-footer" 
+                ?isCompact="${this.isCompact}" 
+                ?isStacked="${this.hasStackedActions && !this.isCompact}">
+                    ${supportingAction ? this.renderActionButton(supportingAction, 'supporting') : nothing}
+                    ${leadingAction ? this.renderActionButton(leadingAction, 'leading') : nothing}
             </footer>
         `;
     }
@@ -157,11 +158,6 @@ export class PieNotification extends LitElement implements NotificationProps {
         }
     }
 
-    handleSlotchange (e: { target: HTMLSlotElement; }) {
-        const childNodes = e.target.assignedNodes({ flatten: true });
-        this.hasExternalIcon = childNodes.length > 0;
-    }
-
     /**
      * Template for the heading icon area.
      * It can return an icon provided externally via named slot or it can return a default icon according to the chosen variant if defined.
@@ -170,10 +166,7 @@ export class PieNotification extends LitElement implements NotificationProps {
      * @private
      */
     private renderIcon (): TemplateResult | typeof nothing {
-        return html`
-                ${!this.hasExternalIcon ? this.getDefaultVariantIcon() : nothing}
-                <slot @slotchange=${this.handleSlotchange} name="icon"></slot>
-        `;
+        return html`<slot name="icon">${this.getDefaultVariantIcon()}</slot>`;
     }
 
     /**
@@ -202,21 +195,12 @@ export class PieNotification extends LitElement implements NotificationProps {
      * @private
      */
     private handleCloseButton () {
-        this.closeNotificationComponent();
+        this.isOpen = false;
         dispatchCustomEvent(this, ON_NOTIFICATION_CLOSE_EVENT, { targetNotification: this });
     }
 
     /**
-     * Util method responsible to close the component.
-     *
-     * @private
-     */
-    private closeNotificationComponent () {
-        this.isOpen = false;
-    }
-
-    /**
-     * It handle the action button action.
+     * It handles the action button action.
      * Also triggers an event according to its `actionType`.
      *
      * @param {'leading' | 'supporting'} actionType

--- a/packages/components/pie-notification/src/index.ts
+++ b/packages/components/pie-notification/src/index.ts
@@ -47,7 +47,7 @@ export * from './defs';
  */
 export class PieNotification extends LitElement implements NotificationProps {
     @state()
-        hasExternalIcon = false;
+    private hasExternalIcon = false;
 
     @property({ type: Boolean })
     public isOpen = defaultProps.isOpen;

--- a/packages/components/pie-notification/src/index.ts
+++ b/packages/components/pie-notification/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { defineCustomElement, validPropertyValues, dispatchCustomEvent } from '@justeattakeaway/pie-webc-core';
-import { property, queryAssignedElements, state } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import {
     type NotificationProps,

--- a/packages/components/pie-notification/src/index.ts
+++ b/packages/components/pie-notification/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { defineCustomElement, validPropertyValues, dispatchCustomEvent } from '@justeattakeaway/pie-webc-core';
-import { property, queryAssignedElements } from 'lit/decorators.js';
+import { property, queryAssignedElements, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import {
     type NotificationProps,
@@ -42,8 +42,13 @@ export * from './defs';
  * @event {CustomEvent} pie-notification-supporting-action-click - When the notification supporting action is clicked.
  * @event {CustomEvent} pie-notification-close - When the notification is closed.
  * @event {CustomEvent} pie-notification-open - When the notification is opened.
+ * @slot - Default slot
+ * @slot icon - The icon slot
  */
 export class PieNotification extends LitElement implements NotificationProps {
+    @state()
+        hasExternalIcon = false;
+
     @property({ type: Boolean })
     public isOpen = defaultProps.isOpen;
 
@@ -152,6 +157,11 @@ export class PieNotification extends LitElement implements NotificationProps {
         }
     }
 
+    handleSlotchange (e: { target: HTMLSlotElement; }) {
+        const childNodes = e.target.assignedNodes({ flatten: true });
+        this.hasExternalIcon = childNodes.length > 0;
+    }
+
     /**
      * Template for the heading icon area.
      * It can return an icon provided externally via named slot or it can return a default icon according to the chosen variant if defined.
@@ -160,11 +170,9 @@ export class PieNotification extends LitElement implements NotificationProps {
      * @private
      */
     private renderIcon (): TemplateResult | typeof nothing {
-        const hasExternalIcon = this._iconSlot.length > 0;
-
         return html`
-                ${!hasExternalIcon ? this.getDefaultVariantIcon() : nothing}
-                <slot name="icon"></slot>
+                ${!this.hasExternalIcon ? this.getDefaultVariantIcon() : nothing}
+                <slot @slotchange=${this.handleSlotchange} name="icon"></slot>
         `;
     }
 

--- a/packages/components/pie-notification/test/component/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/component/pie-notification.spec.ts
@@ -167,12 +167,10 @@ test.describe('PieNotification - Component tests', () => {
 
                 // Act
                 const notification = page.locator(componentSelector);
-                const iconClose = page.locator(iconCloseSelector);
                 const heading = page.locator(`h2${headingSelector}`);
 
                 // Assert
                 expect(notification).toBeVisible();
-                expect(iconClose).toBeVisible();
                 expect(heading).toBeVisible();
                 expect(heading).toHaveText('Title');
             });

--- a/packages/components/pie-notification/test/visual/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/visual/pie-notification.spec.ts
@@ -37,6 +37,7 @@ const props: PropObject = {
     isDismissible: [false, true],
     isCompact: [false, true],
     hideIcon: [false, true],
+    iconSlot: ['', '<icon-heart-filled slot="icon"></icon-heart-filled>'],
 };
 
 // Renders a <pie-notification> HTML string with the given prop values
@@ -45,7 +46,10 @@ const renderTestPieNotification = (propVals: WebComponentPropValues) => `<pie-no
         ${propVals.isCompact ? 'isCompact' : ''}
         ${propVals.isDismissible ? 'isDismissible' : ''}
         ${propVals.hideIcon ? 'hideIcon' : ''}
-        heading="${propVals.heading}">${slotContent}</pie-notification>`;
+        heading="${propVals.heading}">
+            ${propVals.iconSlot}
+            ${slotContent}
+        </pie-notification>`;
 
 const componentPropsMatrix: WebComponentPropValues[] = getAllPropCombinations(props);
 const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
@@ -71,7 +75,8 @@ componentVariants.forEach((variant) => test(`should render all prop variations f
             isCompact: ${testComponent.propValues.isCompact},
             isDismissible: ${testComponent.propValues.isDismissible},
             hideIcon: ${testComponent.propValues.hideIcon},
-            heading: ${testComponent.propValues.heading}
+            heading: ${testComponent.propValues.heading},
+            iconSlot: ${testComponent.propValues.iconSlot ? 'with an external icon' : 'no external icon'}
         `;
 
         const darkMode = ['neutral-alternative'].includes(variant);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

---
"@justeattakeaway/pie-notification": patch
---

[Fixed] - make sure custom and default icons work as expected.
[Fixed] - make `isDismissible` false by default
[Fixed] - use storybook mapping to render different slot content

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1 - @raoufswe 
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them