### PR TITLE
fix(pie-modal): DSW-2213 add indent to pie-modal when footer isn't rendered

### DIFF
--- a/.changeset/new-poets-love.md
+++ b/.changeset/new-poets-love.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": patch
+---
+
+[Added] - indent to `pie-modal` when the footer isn’t rendered

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -311,7 +311,9 @@
         pie-spinner {
             position: absolute;
             left: 50%;
-            top: calc(50% - 10px); // The 10px compensates for the block-bottom padding, when footerActions aren't rendered
+
+            // Compensates different block paddings, when footerActions aren't rendered
+            top: calc(50% - (var(--modal-content-padding-block-end) - var(--modal-content-padding-block)) / 2);
             transform: translate(-50%, -50%);
         }
 

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -235,14 +235,14 @@
         --modal-content-line-height: calc(var(--dt-font-size-16-line-height) * 1px);
         --modal-content-padding-block: var(--dt-spacing-a);
         --modal-content-padding-inline: var(--dt-spacing-d);
-        --modal-content-margin-block-end: var(--dt-spacing-e);
+        --modal-content-padding-block-end: var(--dt-spacing-e);
 
         @media (min-width: $breakpoint-wide) {
             --modal-content-padding-inline: var(--dt-spacing-e);
         }
 
         position: relative;
-        min-block-size: var(--dt-spacing-j);
+        min-block-size: 128px;
 
         font-size: var(--modal-content-font-size);
         line-height: var(--modal-content-line-height);
@@ -251,12 +251,11 @@
         padding-inline-start: var(--modal-content-padding-inline);
         padding-inline-end: var(--modal-content-padding-inline);
         padding-block-start: var(--modal-content-padding-block);
-        margin-block-end: var(--modal-content-margin-block-end); // We require a bottom margin when there's no footer
+        padding-block-end: var(--modal-content-padding-block-end); // We require a larger bottom padding when there's no footer
         flex-grow: 1;
 
         &.c-modal-hasFooterActions {
           padding-block-end: var(--modal-content-padding-block);
-          margin-block-end: 0;
         }
 
         &--scrollable {
@@ -309,12 +308,16 @@
         pie-spinner {
             position: absolute;
             left: 50%;
-            top: 50%;
+            top: calc(50% - 10px);
             transform: translate(-50%, -50%);
         }
 
         & .c-modal-contentInner {
             display: none;
+        }
+
+        &.c-modal-hasFooterActions {
+          top: 50%;
         }
     }
 

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -242,7 +242,7 @@
         }
 
         position: relative;
-        min-block-size: 128px;
+        min-block-size: 128px; // The sum of the minimum height and block paddings, when footerActions aren't rendered
 
         font-size: var(--modal-content-font-size);
         line-height: var(--modal-content-line-height);
@@ -256,6 +256,7 @@
 
         &.c-modal-hasFooterActions {
           padding-block-end: var(--modal-content-padding-block);
+          min-block-size: var(--dt-spacing-j);
         }
 
         &--scrollable {
@@ -308,7 +309,7 @@
         pie-spinner {
             position: absolute;
             left: 50%;
-            top: calc(50% - 10px);
+            top: calc(50% - 10px); // The 10px compensates for the block-bottom padding, when footerActions aren't rendered
             transform: translate(-50%, -50%);
         }
 

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -235,6 +235,7 @@
         --modal-content-line-height: calc(var(--dt-font-size-16-line-height) * 1px);
         --modal-content-padding-block: var(--dt-spacing-a);
         --modal-content-padding-inline: var(--dt-spacing-d);
+        --modal-content-margin-block-end: var(--dt-spacing-e);
 
         @media (min-width: $breakpoint-wide) {
             --modal-content-padding-inline: var(--dt-spacing-e);
@@ -250,11 +251,12 @@
         padding-inline-start: var(--modal-content-padding-inline);
         padding-inline-end: var(--modal-content-padding-inline);
         padding-block-start: var(--modal-content-padding-block);
-        padding-block-end: var(--modal-content-padding-block-end); // We require a larger bottom padding when there's no footer
+        margin-block-end: var(--modal-content-margin-block-end); // We require a larger bottom padding when there's no footer
         flex-grow: 1;
 
         &.c-modal-hasFooterActions {
           padding-block-end: var(--modal-content-padding-block);
+          margin-block-end: 0;
         }
 
         &--scrollable {

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -251,7 +251,7 @@
         padding-inline-start: var(--modal-content-padding-inline);
         padding-inline-end: var(--modal-content-padding-inline);
         padding-block-start: var(--modal-content-padding-block);
-        margin-block-end: var(--modal-content-margin-block-end); // We require a larger bottom padding when there's no footer
+        margin-block-end: var(--modal-content-margin-block-end); // We require a bottom margin when there's no footer
         flex-grow: 1;
 
         &.c-modal-hasFooterActions {

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -236,13 +236,15 @@
         --modal-content-padding-block: var(--dt-spacing-a);
         --modal-content-padding-inline: var(--dt-spacing-d);
         --modal-content-padding-block-end: var(--dt-spacing-e);
+        --modal-content-min-block-size: var(--dt-spacing-j);
+
 
         @media (min-width: $breakpoint-wide) {
             --modal-content-padding-inline: var(--dt-spacing-e);
         }
 
         position: relative;
-        min-block-size: 128px; // The sum of the minimum height and block paddings, when footerActions aren't rendered
+        min-block-size: calc(var(--modal-content-min-block-size) + var(--modal-content-padding-block) + var(--modal-content-padding-block-end)); // The sum of the minimum height and block paddings, when footerActions aren't rendered
 
         font-size: var(--modal-content-font-size);
         line-height: var(--modal-content-line-height);
@@ -256,7 +258,7 @@
 
         &.c-modal-hasFooterActions {
           padding-block-end: var(--modal-content-padding-block);
-          min-block-size: var(--dt-spacing-j);
+          min-block-size: var(--modal-content-min-block-size);
         }
 
         &--scrollable {

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -318,7 +318,9 @@
         }
 
         &.c-modal-hasFooterActions {
-          top: 50%;
+          pie-spinner {
+            top: 50%;
+          }
         }
     }
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)}
**[Added] - indent to `pie-modal` when footer isn't rendered**


**1. Large text Content**

<img width="800" alt="Screenshot 2024-08-07 at 17 44 34" src="https://github.com/user-attachments/assets/46d38733-229e-47cd-9dea-2a8ba2b3b90f">
<img width="800" alt="Screenshot 2024-08-07 at 17 44 50" src="https://github.com/user-attachments/assets/2c442a59-fe71-4f7d-a39e-46e958f2dbd2">


**2. isLoading = true and footer is rendered**

<img width="800" alt="Screenshot 2024-08-07 at 17 42 42" src="https://github.com/user-attachments/assets/1d6b5b75-cc17-4469-b5f2-7a025252d1ff">
<img width="800" alt="Screenshot 2024-08-07 at 17 43 08" src="https://github.com/user-attachments/assets/0af6e769-cffe-4bd6-8096-d4c554f4ffdb">


**3. isLoading = true and footer isn't rendered**

<img width="800" alt="Screenshot 2024-08-07 at 17 43 33" src="https://github.com/user-attachments/assets/8e38d97b-c89a-4b54-a3fb-065a4c07f21b">
<img width="800" alt="Screenshot 2024-08-07 at 17 43 45" src="https://github.com/user-attachments/assets/ee0f117d-f832-4979-bf59-c7280ff9eea7">


## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Reviewer checklists (complete before approving)
### Reviewer 1 @kevinrodrigues 
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them
