### PR TITLE
feat(pie-chip): DSW-2280 use classmap for styling

### DIFF
--- a/.changeset/perfect-pugs-speak.md
+++ b/.changeset/perfect-pugs-speak.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-chip": minor
+---
+
+[Changed] - Use classmap instead of custom attributes for styling component

--- a/packages/components/pie-chip/src/chip.scss
+++ b/packages/components/pie-chip/src/chip.scss
@@ -17,7 +17,7 @@
     }
 
     &:active:not([disabled]),
-    &[isLoading]:not([disabled]) {
+    .is-loading:not([disabled]) {
         @if $mode == 'inverse' {
             --active-modifier: var(--dt-color-active-02);
         } @else {
@@ -32,7 +32,6 @@
         }
     }
 }
-
 
 .c-chip {
     --chip-bg-color: var(--dt-color-interactive-secondary);
@@ -72,29 +71,29 @@
 
     @include chip-interactive-states('--dt-color-interactive-secondary');
 
-    &[variant='default'] {
+    &.c-chip--default {
         // same as default styles
     }
 
-    &[variant='outline']:not([disabled], [isSelected], [isLoading]) {
+    &.c-chip--outline:not([disabled], .c-chip--selected, .is-loading) {
         --chip-border-color: var(--dt-color-border-strong);
     }
 
-    &[variant='outline'],
-    &[variant='ghost'] {
+    &.c-chip--outline,
+    &.c-chip--ghost {
         --chip-bg-color: transparent;
 
         @include chip-interactive-states('--dt-color-black', 'transparent');
     }
 
-    &[isSelected] {
+    &.c-chip--selected {
         --chip-bg-color: var(--dt-color-interactive-primary);
         --chip-color: var(--dt-color-content-interactive-primary);
 
         @include chip-interactive-states('--dt-color-interactive-primary', 'inverse');
     }
 
-    &[isDismissible][isSelected] {
+    &.c-chip--dismissible.c-chip--selected {
         padding-inline-end: var(--chip-padding-dismissible);
         padding-block-start: var(--chip-padding-dismissible);
         padding-block-end: var(--chip-padding-dismissible);
@@ -113,7 +112,7 @@
         }
     }
 
-    &[isLoading] {
+    &.is-loading {
         & > *:not(.c-chip-spinner) {
             visibility: hidden;
         }

--- a/packages/components/pie-chip/src/chip.scss
+++ b/packages/components/pie-chip/src/chip.scss
@@ -17,7 +17,7 @@
     }
 
     &:active:not([disabled]),
-    .is-loading:not([disabled]) {
+    &.is-loading:not([disabled]) {
         @if $mode == 'inverse' {
             --active-modifier: var(--dt-color-active-02);
         } @else {

--- a/packages/components/pie-chip/src/index.ts
+++ b/packages/components/pie-chip/src/index.ts
@@ -3,6 +3,7 @@ import {
 } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 import {
     validPropertyValues, defineCustomElement, dispatchCustomEvent,
@@ -97,6 +98,14 @@ export class PieChip extends LitElement implements ChipProps {
             isDismissible,
         } = this;
 
+        const classes = {
+            'c-chip': true,
+            [`c-chip--${variant}`]: true,
+            'c-chip--selected': isSelected,
+            'c-chip--dismissible': isDismissible,
+            'is-loading': isLoading,
+        };
+
         return html`
             <div
                 aria-atomic="true"
@@ -104,15 +113,11 @@ export class PieChip extends LitElement implements ChipProps {
                 aria-current="${isSelected}"
                 aria-label="${ifDefined(this.aria?.label)}"
                 aria-live="polite"
-                class="c-chip"
+                class=${classMap(classes)}
                 data-test-id="pie-chip"
                 tabindex="0"
                 role="button"
-                variant="${variant}"
-                ?disabled="${disabled}"
-                ?isSelected="${isSelected}"
-                ?isLoading="${isLoading}"
-                ?isDismissible="${isDismissible}">
+                ?disabled="${disabled}">
                     <slot name="icon"></slot>
                     ${isLoading ? this.renderSpinner() : nothing}
                     <slot></slot>


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Switch from using custom HTML attributes to CSS `classmap` for styling the chip component

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Reviewer checklists (complete before approving)
### Reviewer 1 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview

### Reviewer 2 @kevinrodrigues 
- [x] I have reviewed the `PIE Storybook` PR preview
