### PR TITLE
feat(pie-textarea): DSW-2141 add assistive text and status properties

### DIFF
--- a/.changeset/light-badgers-sparkle.md
+++ b/.changeset/light-badgers-sparkle.md
@@ -1,7 +1,5 @@
 ---
 "@justeattakeaway/pie-textarea": minor
-"pie-storybook": minor
 ---
 
 [Added] - `assistiveText` property, `status` property with the possible values `default`, `success` and `error`
-[Added] - storybook controls for the `assistiveText` and `status` properties

--- a/.changeset/light-badgers-sparkle.md
+++ b/.changeset/light-badgers-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-textarea": minor
+"pie-storybook": minor
+---
+
+[Added] - `assistiveText` property, `status` property with the possible values `default`, `success` and `error`
+[Added] - storybook controls for the `assistiveText` and `status` properties

--- a/.changeset/popular-eggs-fetch.md
+++ b/.changeset/popular-eggs-fetch.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - storybook controls for the `assistiveText` and `status` properties

--- a/apps/pie-storybook/stories/pie-textarea.stories.ts
+++ b/apps/pie-storybook/stories/pie-textarea.stories.ts
@@ -6,7 +6,7 @@ import { useArgs as UseArgs } from '@storybook/preview-api';
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-textarea';
 import {
-    TextareaProps, defaultProps, resizeModes, sizes, statusTypes,
+    type TextareaProps, defaultProps, resizeModes, sizes, statusTypes,
 } from '@justeattakeaway/pie-textarea';
 /* eslint-enable import/no-duplicates */
 

--- a/apps/pie-storybook/stories/pie-textarea.stories.ts
+++ b/apps/pie-storybook/stories/pie-textarea.stories.ts
@@ -6,7 +6,7 @@ import { useArgs as UseArgs } from '@storybook/preview-api';
 /* eslint-disable import/no-duplicates */
 import '@justeattakeaway/pie-textarea';
 import {
-    TextareaProps, defaultProps, resizeModes, sizes,
+    TextareaProps, defaultProps, resizeModes, sizes, statusTypes,
 } from '@justeattakeaway/pie-textarea';
 /* eslint-enable import/no-duplicates */
 
@@ -32,6 +32,8 @@ const Template = ({
     autoFocus,
     label,
     maxLength,
+    assistiveText,
+    status,
 }: TextareaProps) => {
     const [, updateArgs] = UseArgs();
 
@@ -67,7 +69,9 @@ const Template = ({
             maxLength="${ifDefined(maxLength)}"
             label="${ifDefined(label)}"
             @input="${onInput}"
-            @change="${onChange}">
+            @change="${onChange}"
+            assistiveText="${ifDefined(assistiveText)}"
+            status=${ifDefined(status)}>
         </pie-textarea>
     `;
 };
@@ -97,6 +101,21 @@ const textareaStoryMeta: TextareaStoryMeta = {
             options: resizeModes,
             defaultValue: {
                 summary: defaultProps.resize,
+            },
+        },
+        assistiveText: {
+            description: 'An optional assistive text to display below the textarea element. Must be provided when the status is success or error.',
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        status: {
+            description: 'The status of the textarea component / assistive text. Can be default, success or error.',
+            control: 'select',
+            options: statusTypes,
+            defaultValue: {
+                summary: defaultProps.status,
             },
         },
         name: {

--- a/packages/components/pie-textarea/src/defs.ts
+++ b/packages/components/pie-textarea/src/defs.ts
@@ -2,6 +2,7 @@ import { type ComponentDefaultProps } from '@justeattakeaway/pie-webc-core';
 
 export const sizes = ['small', 'medium', 'large'] as const;
 export const resizeModes = ['auto', 'manual'] as const;
+export const statusTypes = ['default', 'success', 'error'] as const;
 
 export interface TextareaProps {
     /**
@@ -30,6 +31,16 @@ export interface TextareaProps {
      * An optional default value to use when the textarea is reset.
      */
     defaultValue?: string;
+
+    /**
+     * An optional assistive text to display below the textarea element. Must be provided when the status is success or error.
+     */
+    assistiveText?: string;
+
+    /**
+     * The status of the textarea component / assistive text. Can be default, success or error.
+     */
+    status?: typeof statusTypes[number];
 
     /**
      * The name of the textarea (used as a key/value pair with `value`). This is required in order to work properly with forms.
@@ -75,7 +86,7 @@ export interface TextareaProps {
 /**
  * The default values for the `TextareaProps` that are required (i.e. they have a fallback value in the component).
  */
-type DefaultProps = ComponentDefaultProps<TextareaProps, keyof Omit<TextareaProps, 'name' | 'autocomplete' | 'maxLength' | 'defaultValue'>>;
+type DefaultProps = ComponentDefaultProps<TextareaProps, keyof Omit<TextareaProps, 'name' | 'autocomplete' | 'maxLength' | 'assistiveText' | 'defaultValue'>>;
 
 /**
  * Default values for optional properties that have default fallback values in the component.
@@ -86,6 +97,7 @@ export const defaultProps: DefaultProps = {
     resize: 'auto',
     label: '',
     value: '',
+    status: 'default',
     autoFocus: false,
     readonly: false,
     required: false,

--- a/packages/components/pie-textarea/src/index.ts
+++ b/packages/components/pie-textarea/src/index.ts
@@ -13,15 +13,17 @@ import {
 import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './textarea.scss?inline';
 import {
-    TextareaProps, defaultProps, sizes, resizeModes,
+    TextareaProps, defaultProps, sizes, resizeModes, statusTypes,
 } from './defs';
 
 import '@justeattakeaway/pie-form-label';
+import '@justeattakeaway/pie-assistive-text';
 
 // Valid values available to consumers
 export * from './defs';
 
 const componentSelector = 'pie-textarea';
+const assistiveTextIdValue = 'assistive-text';
 
 /**
  * @tagname pie-textarea
@@ -62,6 +64,13 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
 
     @property({ type: Boolean })
     public required = defaultProps.required;
+
+    @property({ type: String })
+    @validPropertyValues(componentSelector, statusTypes, defaultProps.status)
+    public status = defaultProps.status;
+
+    @property({ type: String })
+    public assistiveText: TextareaProps['assistiveText'];
 
     @property({ type: String })
     public name?: TextareaProps['name'];
@@ -192,6 +201,8 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
             required,
             label,
             maxLength,
+            status,
+            assistiveText,
         } = this;
 
         return html`
@@ -213,8 +224,19 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
                     ?disabled=${disabled}
                     @input=${this.handleInput}
                     @change=${this.handleChange}
+                    aria-describedby=${ifDefined(assistiveText ? assistiveTextIdValue : undefined)}
+                    aria-invalid=${status === 'error' ? 'true' : 'false'}
+                    aria-errormessage="${ifDefined(status === 'error' ? assistiveTextIdValue : undefined)}"
                 ></textarea>
-            </div>`;
+            </div>
+            ${assistiveText ? html`
+                <pie-assistive-text
+                    id="${assistiveTextIdValue}"
+                    variant=${ifDefined(status)}
+                    data-test-id="pie-textarea-assistive-text">
+                    ${assistiveText}
+                </pie-assistive-text>
+            ` : nothing}`;
     }
 
     // Renders a `CSSResult` generated from SCSS by Vite

--- a/packages/components/pie-textarea/src/index.ts
+++ b/packages/components/pie-textarea/src/index.ts
@@ -225,6 +225,7 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
                 class="c-textareaWrapper"
                 data-test-id="pie-textarea-wrapper"
                 data-pie-size="${size}"
+                data-pie-status=${ifDefined(status)}
                 data-pie-resize="${resize}">
                 ${this.renderLabel(label, maxLength)}
                 <textarea

--- a/packages/components/pie-textarea/src/index.ts
+++ b/packages/components/pie-textarea/src/index.ts
@@ -188,6 +188,21 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
             : nothing;
     }
 
+    renderAssistiveText () {
+        if (!this.assistiveText) {
+            return nothing;
+        }
+
+        return html`
+            <pie-assistive-text
+                id="${assistiveTextIdValue}"
+                variant=${ifDefined(this.status)}
+                data-test-id="pie-textarea-assistive-text">
+                ${this.assistiveText}
+            </pie-assistive-text>
+        `;
+    }
+
     render () {
         const {
             disabled,
@@ -229,14 +244,7 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
                     aria-errormessage="${ifDefined(status === 'error' ? assistiveTextIdValue : undefined)}"
                 ></textarea>
             </div>
-            ${assistiveText ? html`
-                <pie-assistive-text
-                    id="${assistiveTextIdValue}"
-                    variant=${ifDefined(status)}
-                    data-test-id="pie-textarea-assistive-text">
-                    ${assistiveText}
-                </pie-assistive-text>
-            ` : nothing}`;
+            ${this.renderAssistiveText()}`;
     }
 
     // Renders a `CSSResult` generated from SCSS by Vite

--- a/packages/components/pie-textarea/src/textarea.scss
+++ b/packages/components/pie-textarea/src/textarea.scss
@@ -86,4 +86,8 @@
     // Minimum is two lines of text
     --textarea-min-height: var(--textarea-height);
   }
+
+  &[data-pie-status="error"] {
+    --textarea-border-color: var(--dt-color-support-error);
+  }
 }

--- a/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
@@ -6,8 +6,11 @@ import {
 import { PieFormLabel } from '@justeattakeaway/pie-form-label';
 import { PieTextarea, TextareaProps } from '../../src/index.ts';
 
+import { statusTypes } from '../../src/defs.ts';
+
 const componentSelector = '[data-test-id="pie-textarea"]';
 const componentWrapperSelector = '[data-test-id="pie-textarea-wrapper"]';
+const assistiveTextSelector = '[data-test-id="pie-textarea-assistive-text"]';
 
 test.describe('PieTextarea - Component tests', () => {
     // IMPORTANT: Mounting and Unmounting the component before each test ensures that any tests that do not explicitly
@@ -585,6 +588,75 @@ test.describe('PieTextarea - Component tests', () => {
                 await expect(label).toBeVisible();
             });
         });
+
+        test.describe('assistiveText', () => {
+            test('should NOT render the assistive-text component if this property is not provided', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieTextarea, {});
+
+                // Act
+                const assistiveText = page.locator(assistiveTextSelector);
+
+                // Assert
+                expect(assistiveText).not.toBeVisible();
+            });
+
+            test('should apply the `default` variant attribute if no status is provided', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieTextarea, {
+                    props: {
+                        assistiveText: 'Assistive text',
+                    } as TextareaProps,
+                });
+
+                // Act
+                const assistiveText = page.locator(assistiveTextSelector);
+
+                // Assert
+                expect(assistiveText).toBeVisible();
+                expect(await assistiveText.getAttribute('variant')).toBe('default');
+                expect(assistiveText).toHaveText('Assistive text');
+            });
+
+            test.describe('Assistive text: Status', () => {
+                statusTypes.forEach((status) => {
+                    test(`should render the assistive-text component with the ${status} variant`, async ({ mount, page }) => {
+                        // Arrange
+                        await mount(PieTextarea, {
+                            props: {
+                                assistiveText: 'Assistive text',
+                                status,
+                            } as TextareaProps,
+                        });
+
+                        // Act
+                        const assistiveText = page.locator(assistiveTextSelector);
+
+                        // Assert
+                        expect(assistiveText).toBeVisible();
+                        expect(assistiveText).toHaveAttribute('variant', status);
+                        expect(assistiveText).toHaveText('Assistive text');
+                    });
+                });
+            });
+
+            test.describe('Assistive text: ID attribute', () => {
+                test('should contain an ID associated the textarea element for a11y', async ({ mount, page }) => {
+                    // Arrange
+                    await mount(PieTextarea, {
+                        props: {
+                            assistiveText: 'Assistive text',
+                        } as TextareaProps,
+                    });
+
+                    // Act
+                    const assistiveText = page.locator(assistiveTextSelector);
+
+                    // Assert
+                    await expect(assistiveText).toHaveAttribute('id', 'assistive-text');
+                });
+            });
+        });
     });
 
     test.describe('Form integration', () => {
@@ -881,6 +953,126 @@ test.describe('PieTextarea - Component tests', () => {
 
                 // Assert
                 expect(messages).toStrictEqual(expectedMessages);
+            });
+        });
+    });
+
+    test.describe('Attributes', () => {
+        test.describe('aria-describedby', () => {
+            test.describe('when `assistiveText` is NOT defined', () => {
+                test('should not render the attribute', async ({ mount }) => {
+                    // Arrange
+                    const component = await mount(PieTextarea, {
+                        props: {} as TextareaProps,
+                    });
+
+                    // Act
+                    const textarea = component.locator('textarea');
+
+                    const componentAttribute = await textarea.getAttribute('aria-describedby');
+
+                    // Assert
+                    expect(componentAttribute).toBeNull();
+                });
+            });
+
+            test.describe('when `assistiveText` is defined', () => {
+                test('should render the attribute correctly with the correct value', async ({ mount }) => {
+                    // Arrange
+                    const component = await mount(PieTextarea, {
+                        props: {
+                            assistiveText: 'Some useful message',
+                        } as TextareaProps,
+                    });
+
+                    // Act
+                    const textarea = component.locator('textarea');
+
+                    const componentAttribute = await textarea.getAttribute('aria-describedby');
+
+                    // Assert
+                    expect(componentAttribute).toBe('assistive-text');
+                });
+            });
+        });
+
+        test.describe('aria-invalid', () => {
+            test.describe('when the component status is set to `error`', () => {
+                test('should render the `aria-invalid` attribute', async ({ mount }) => {
+                    // Arrange
+                    const component = await mount(PieTextarea, {
+                        props: {
+                            status: 'error',
+                        } as TextareaProps,
+                    });
+
+                    // Act
+                    const textarea = component.locator('textarea');
+
+                    const componentAttribute = await textarea.getAttribute('aria-invalid');
+
+                    // Assert
+                    expect(componentAttribute).toBeDefined();
+                });
+            });
+
+            statusTypes.filter((status) => status !== 'error').forEach((status) => {
+                test.describe(`when the component status is set to "${status}"`, () => {
+                    test('should render the `aria-invalid` with a value of `false`', async ({ mount }) => {
+                        // Arrange
+                        const component = await mount(PieTextarea, {
+                            props: { status } as TextareaProps,
+                        });
+
+                        // Act
+                        const textarea = component.locator('textarea');
+
+                        const componentAttribute = await textarea.getAttribute('aria-invalid');
+
+                        // Assert
+                        expect(componentAttribute).toBe('false');
+                    });
+                });
+            });
+        });
+
+        test.describe('aria-errormessage', () => {
+            test.describe('when the component status is set to `error`', () => {
+                test('should render the `aria-errormessage` attribute', async ({ mount }) => {
+                    // Arrange
+                    const component = await mount(PieTextarea, {
+                        props: {
+                            status: 'error',
+                        } as TextareaProps,
+                    });
+
+                    // Act
+                    const textarea = component.locator('textarea');
+
+                    const componentAttribute = await textarea.getAttribute('aria-errormessage');
+
+                    // Assert
+                    expect(componentAttribute).toBeDefined();
+                });
+            });
+
+            statusTypes.filter((status) => status !== 'error').forEach((status) => {
+                test.describe(`when the component status is set to "${status}"`, () => {
+                    test('should not render the `aria-errormessage` attribute', async ({ mount }) => {
+                        // Arrange
+                        const component = await mount(PieTextarea, {
+                            props: { status } as TextareaProps,
+                        });
+
+                        // Act
+                        const textarea = component.locator('textarea');
+
+                        const componentAttribute = await textarea.getAttribute('aria-errormessage');
+
+                        // Assert
+                        expect(componentAttribute).toBeNull();
+                    });
+                });
             });
         });
     });

--- a/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
@@ -726,7 +726,7 @@ test.describe('PieTextarea - Component tests', () => {
             expect(await page.evaluate(() => document.querySelector('pie-textarea')?.value)).toBe('');
         });
 
-        test('should correctly reset the textarea value to the `defaultValue` if one is provided when the form is reset', async ({ page }) => {
+        test('should correctly set the textarea value even if `defaultValue` is provided', async ({ page }) => {
             // Arrange
             await page.setContent(`
                     <form id="testForm" action="/foo" method="POST">
@@ -738,6 +738,19 @@ test.describe('PieTextarea - Component tests', () => {
             // Act & Assert
             await page.locator('pie-textarea').type('test');
             expect(await page.evaluate(() => document.querySelector('pie-textarea')?.value)).toBe('test');
+        });
+
+        test('should correctly reset the textarea value to the `defaultValue` if one is provided when the form is reset', async ({ page }) => {
+            // Arrange
+            await page.setContent(`
+                    <form id="testForm" action="/foo" method="POST">
+                        <pie-textarea defaultValue="foo"></pie-textarea>
+                        <button type="reset">Submit</button>
+                    </form>
+                `);
+
+            // Act & Assert
+            await page.locator('pie-textarea').type('test');
 
             await page.click('button[type="reset"]');
             expect(await page.evaluate(() => document.querySelector('pie-textarea')?.value)).toBe('foo');

--- a/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
@@ -235,6 +235,19 @@ test.describe('PieTextarea - Component tests', () => {
             });
         });
 
+        test.describe('defaultValue', () => {
+            test('should apply the `defaultValue` property to the rendered HTML textarea element', async ({ page }) => {
+                // Arrange
+                await page.setContent('<pie-textarea defaultValue="testDefaultValue"></pie-textarea>');
+
+                // Act
+                const textarea = page.locator('pie-textarea');
+
+                // Assert
+                expect((await textarea.getAttribute('defaultValue'))).toBe('testDefaultValue');
+            });
+        });
+
         test.describe('autocomplete', () => {
             test('should not render an autocomplete attribute on the textarea element if no autocomplete is provided', async ({ mount }) => {
                 // Arrange
@@ -726,20 +739,6 @@ test.describe('PieTextarea - Component tests', () => {
             expect(await page.evaluate(() => document.querySelector('pie-textarea')?.value)).toBe('');
         });
 
-        test('should correctly set the textarea value even if `defaultValue` is provided', async ({ page }) => {
-            // Arrange
-            await page.setContent(`
-                    <form id="testForm" action="/foo" method="POST">
-                        <pie-textarea defaultValue="foo"></pie-textarea>
-                        <button type="reset">Submit</button>
-                    </form>
-                `);
-
-            // Act & Assert
-            await page.locator('pie-textarea').type('test');
-            expect(await page.evaluate(() => document.querySelector('pie-textarea')?.value)).toBe('test');
-        });
-
         test('should correctly reset the textarea value to the `defaultValue` if one is provided when the form is reset', async ({ page }) => {
             // Arrange
             await page.setContent(`
@@ -1025,7 +1024,7 @@ test.describe('PieTextarea - Component tests', () => {
                     const componentAttribute = await textarea.getAttribute('aria-invalid');
 
                     // Assert
-                    expect(componentAttribute).toBeDefined();
+                    expect(componentAttribute).toBe('true');
                 });
             });
 

--- a/packages/components/pie-textarea/test/visual/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/visual/pie-textarea.spec.ts
@@ -175,3 +175,93 @@ test.describe('Label and Character count:', () => {
         await percySnapshot(page, 'Textarea RTL - with label and character count', percyWidths);
     });
 });
+
+test.describe('Assistive text and statuses:', () => {
+    test('Renders assistive text without status correctly', async ({ page, mount }) => {
+        await mount(PieTextarea, {
+            props: {
+                assistiveText: 'Assistive text',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea - assistive text with no status', percyWidths);
+    });
+
+    test('RTL - Renders assistive text without status correctly', async ({ page, mount }) => {
+        setRTL(page);
+
+        await mount(PieTextarea, {
+            props: {
+                assistiveText: 'Assistive text',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea RTL - assistive text with no status', percyWidths);
+    });
+
+    test('Renders assistive text with `error` status correctly', async ({ page, mount }) => {
+        await mount(PieTextarea, {
+            props: {
+                assistiveText: 'Error text',
+                status: 'error',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea - assistive text with `error` status', percyWidths);
+    });
+
+    test('RTL - Renders assistive text with `error` status correctly', async ({ page, mount }) => {
+        setRTL(page);
+
+        await mount(PieTextarea, {
+            props: {
+                assistiveText: 'Error text',
+                status: 'error',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea RTL - assistive text with `error` status', percyWidths);
+    });
+
+    test('Should NOT render assistive-text component with `error` status if assistive text is not provided', async ({ page, mount }) => {
+        await mount(PieTextarea, {
+            props: {
+                status: 'error',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea - `error` status and no assistive text', percyWidths);
+    });
+
+    test('Renders assistive text with `success` status correctly', async ({ page, mount }) => {
+        await mount(PieTextarea, {
+            props: {
+                assistiveText: 'Success text',
+                status: 'success',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea - assistive text with `success` status', percyWidths);
+    });
+
+    test('RTL - Renders assistive text with `success` status correctly', async ({ page, mount }) => {
+        setRTL(page);
+
+        await mount(PieTextarea, {
+            props: {
+                assistiveText: 'Success text',
+                status: 'success',
+                value: 'This is a test value',
+            } as PieTextarea,
+        });
+
+        await percySnapshot(page, 'Textarea RTL - assistive text with `success` status', percyWidths);
+    });
+});
+


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Added] - `assistiveText` property, `status` property with the possible values `default`, `success` and `error`
[Added] - storybook controls for the `assistiveText` and `status` properties

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Reviewer checklists (complete before approving)
### Reviewer 1 - Maryia
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 3 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them
