### PR TITLE
chore(pie-monorepo): DSW-000 add dangercheck for missing lock file

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,5 +1,6 @@
 import { danger, fail } from 'danger';
-import { execSync } from 'child_process';
+
+const { execSync } = require('child_process');
 
 const { pr } = danger.github;
 const validChangesetCategories = ['Added', 'Changed', 'Removed', 'Fixed'];

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -6,6 +6,16 @@ const validChangesetCategories = ['Added', 'Changed', 'Removed', 'Fixed'];
 const isRenovatePR = pr.user.login === 'renovate[bot]';
 const isDependabotPR = pr.user.login === 'dependabot[bot]';
 
+// Run `yarn` and check if the lockfile has changed
+danger.utils.exec('yarn').then(() => danger.git.diffForFile('yarn.lock')).then((diff) => {
+    if (diff && diff.modified) {
+        fail(':lock: It looks like your `yarn.lock` file has changed after running `yarn`. Please commit the updated lockfile.');
+    }
+}).catch((error) => {
+    console.error('Failed to run yarn or check lockfile changes', error);
+    fail(':exclamation: There was an error running `yarn` or checking for lockfile changes.');
+});
+
 // Check for correct Changeset formatting
 danger.git.created_files.filter((filepath) => filepath.includes('.changeset/') && !filepath.includes('.changeset/pre.json'))
     .forEach((filepath) => {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,4 +1,5 @@
 import { danger, fail } from 'danger';
+import { execSync } from 'child_process';
 
 const { pr } = danger.github;
 const validChangesetCategories = ['Added', 'Changed', 'Removed', 'Fixed'];
@@ -7,14 +8,20 @@ const isRenovatePR = pr.user.login === 'renovate[bot]';
 const isDependabotPR = pr.user.login === 'dependabot[bot]';
 
 // Run `yarn` and check if the lockfile has changed
-danger.utils.exec('yarn').then(() => danger.git.diffForFile('yarn.lock')).then((diff) => {
-    if (diff && diff.modified) {
+try {
+    // Run `yarn`
+    execSync('yarn', { stdio: 'inherit' });
+
+    // Check if the lockfile has changed
+    const lockfileDiff = execSync('git diff --name-only yarn.lock').toString().trim();
+
+    if (lockfileDiff) {
         fail(':lock: It looks like your `yarn.lock` file has changed after running `yarn`. Please commit the updated lockfile.');
     }
-}).catch((error) => {
+} catch (error) {
     console.error('Failed to run yarn or check lockfile changes', error);
     fail(':exclamation: There was an error running `yarn` or checking for lockfile changes.');
-});
+}
 
 // Check for correct Changeset formatting
 danger.git.created_files.filter((filepath) => filepath.includes('.changeset/') && !filepath.includes('.changeset/pre.json'))

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "postcss-cli": "10.1.0",
     "rimraf": "5.0.5",
     "rollup-plugin-visualizer": "5.12.0",
-    "sass": "1.77.8",
+    "sass": "1.60.0",
     "stylelint": "16.2.1",
     "stylelint-config-standard-scss": "13.0.0",
     "stylelint-order": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "postcss-cli": "10.1.0",
     "rimraf": "5.0.5",
     "rollup-plugin-visualizer": "5.12.0",
-    "sass": "1.60.0",
+    "sass": "1.77.8",
     "stylelint": "16.2.1",
     "stylelint-config-standard-scss": "13.0.0",
     "stylelint-order": "6.0.4",

--- a/packages/components/pie-webc-core/package.json
+++ b/packages/components/pie-webc-core/package.json
@@ -18,7 +18,7 @@
     "test:watch": "run -T vitest"
   },
   "dependencies": {
-    "lit": "3.1.3"
+    "lit": "3.2.0"
   },
   "devDependencies": {
     "@justeattakeaway/pie-components-config": "0.17.0"


### PR DESCRIPTION
Updates the `dangerfile.js` to fail if it detects dependency changes but the PR does not include an updated `yarn.lock` file.

[Example output](https://github.com/justeattakeaway/pie/pull/1722#issuecomment-2304222427)