### PR TITLE
chore(pie-monorepo): DSW-000 auto updated lockfile and dangerjs check for missing lock file

### DIFF
--- a/.changeset/nice-clocks-prove.md
+++ b/.changeset/nice-clocks-prove.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Added] - CI step to automatically update the lockfile if it is a Pie bot PR and a DangerJS check that fails if regular PRs update dependencies but forget to commit a lockfile update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,50 @@ jobs:
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
 
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: github.actor == 'pie-design-system-bot'|| github.actor == 'renovate[bot]' || contains(github.ref_name, 'changeset-release/main')
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        # Setup Repo
+        - name: Setup Repo
+          uses: ./.github/actions/setup-repo
+          with:
+            node-version: 20
+            os: ubuntu-latest
+
+        # Check if yarn.lock has changed
+        - name: Check if yarn.lock was updated
+          id: yarn_lock_check
+          run: |
+            if git diff --quiet yarn.lock; then
+              echo "lockfile_changed=false" >> $GITHUB_ENV
+            else
+              echo "lockfile_changed=true" >> $GITHUB_ENV
+            fi
+
+        # Commit and push changes if yarn.lock was updated
+        - name: Commit and push changes
+          if: env.lockfile_changed == 'true'
+          uses: stefanzweifel/git-auto-commit-action@v5
+          with:
+            commit_message: "chore(pie-monorepo): DSW-000 auto update lockfile"
+          env:
+            HUSKY: 0  # Disable Husky hooks
+
   check-change-type:
     name: Get change type
+    needs: ['update-lockfile']
+    # Ensures this job runs even if 'update-lockfile' step is skipped
+    if: always()
     runs-on: ubuntu-latest
     outputs:
       pie-docs-change: ${{ steps.docs-check.outputs.docs-change }}
@@ -342,5 +384,5 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         # "allowed-skips" lists jobs that are optional but should not fail
-        allowed-skips: browser-tests-components, deploy-docs, deploy-storybook, browser-tests-docs
+        allowed-skips: browser-tests-components, deploy-docs, deploy-storybook, browser-tests-docs, build-ubuntu-node-20, unit-tests
         jobs: ${{ toJSON(needs) }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5547,7 +5547,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.25.0, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.25.1, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
@@ -5560,7 +5560,7 @@ __metadata:
     "@justeattakeaway/pie-icon-button": 0.28.10
     "@justeattakeaway/pie-link": 0.17.8
     "@justeattakeaway/pie-modal": 0.46.0
-    "@justeattakeaway/pie-switch": 0.29.12
+    "@justeattakeaway/pie-switch": 0.30.0
     "@justeattakeaway/pie-webc-core": 0.24.0
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
@@ -5599,7 +5599,7 @@ __metadata:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.17.0
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-switch": 0.29.12
+    "@justeattakeaway/pie-switch": 0.30.0
     "@justeattakeaway/pie-text-input": 0.23.4
     "@justeattakeaway/pie-webc-core": 0.24.0
     "@justeattakeaway/pie-wrapper-react": 0.14.1
@@ -5774,7 +5774,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-switch@0.29.12, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
+"@justeattakeaway/pie-switch@0.30.0, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
@@ -5869,7 +5869,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.5.23, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.5.24, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
@@ -5880,7 +5880,7 @@ __metadata:
     "@justeattakeaway/pie-checkbox-group": 0.6.1
     "@justeattakeaway/pie-chip": 0.7.2
     "@justeattakeaway/pie-components-config": 0.17.0
-    "@justeattakeaway/pie-cookie-banner": 0.25.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.1
     "@justeattakeaway/pie-divider": 0.13.9
     "@justeattakeaway/pie-form-label": 0.14.1
     "@justeattakeaway/pie-icon-button": 0.28.10
@@ -5888,7 +5888,7 @@ __metadata:
     "@justeattakeaway/pie-modal": 0.46.0
     "@justeattakeaway/pie-notification": 0.10.0
     "@justeattakeaway/pie-spinner": 0.6.7
-    "@justeattakeaway/pie-switch": 0.29.12
+    "@justeattakeaway/pie-switch": 0.30.0
     "@justeattakeaway/pie-tag": 0.9.9
     "@justeattakeaway/pie-text-input": 0.23.4
     "@justeattakeaway/pie-textarea": 0.7.0
@@ -26003,7 +26003,7 @@ __metadata:
     "@justeattakeaway/pie-checkbox": 0.12.1
     "@justeattakeaway/pie-checkbox-group": 0.6.1
     "@justeattakeaway/pie-chip": 0.7.2
-    "@justeattakeaway/pie-cookie-banner": 0.25.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.1
     "@justeattakeaway/pie-css": 0.12.1
     "@justeattakeaway/pie-divider": 0.13.9
     "@justeattakeaway/pie-form-label": 0.14.1
@@ -26014,7 +26014,7 @@ __metadata:
     "@justeattakeaway/pie-modal": 0.46.0
     "@justeattakeaway/pie-notification": 0.10.0
     "@justeattakeaway/pie-spinner": 0.6.7
-    "@justeattakeaway/pie-switch": 0.29.12
+    "@justeattakeaway/pie-switch": 0.30.0
     "@justeattakeaway/pie-tag": 0.9.9
     "@justeattakeaway/pie-text-input": 0.23.4
     "@justeattakeaway/pie-textarea": 0.7.0
@@ -33939,7 +33939,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -33956,7 +33956,7 @@ __metadata:
     "@babel/preset-env": 7.24.5
     "@babel/preset-react": 7.24.1
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     "@lit/react": 1.0.2
     babel-loader: 8
     eslint: 8.37.0
@@ -33973,7 +33973,7 @@ __metadata:
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
@@ -33996,7 +33996,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -34011,7 +34011,7 @@ __metadata:
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     "@types/node": 18
     nuxt: 3.4.3
     nuxt-ssr-lit: 1.6.5
@@ -34023,7 +34023,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -34043,7 +34043,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -34065,7 +34065,7 @@ __metadata:
     "@justeat/pie-design-tokens": 6.3.1
     "@justeattakeaway/pie-css": 0.12.1
     "@justeattakeaway/pie-icons-webc": 0.25.0
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     vite: 4.5.3
   languageName: unknown
   linkType: soft
@@ -34075,7 +34075,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.12.1
-    "@justeattakeaway/pie-webc": 0.5.23
+    "@justeattakeaway/pie-webc": 0.5.24
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
- Automatically commit the updated `yarn.lock` file if its a Version Packages PR
- Fail a danger check if the `yarn.lock` is missing after dependency updates if it is NOT a Version Packages PR

Example auto-commit:
<img width="1509" alt="Screenshot 2024-08-22 at 12 25 14" src="https://github.com/user-attachments/assets/5cc579a0-778b-43ad-9499-70db664e7088">

Example Danger message:
<img width="1159" alt="Screenshot 2024-08-22 at 12 25 52" src="https://github.com/user-attachments/assets/d06a4a9a-6ec8-4fa0-84df-4c8ad31dad6c">
