### PR TITLE
docs(pie-textarea): DSW-2127 add textarea code page

### DIFF
--- a/.changeset/brave-stingrays-provide.md
+++ b/.changeset/brave-stingrays-provide.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": patch
+---
+
+[Changed] - `pie-textarea` `maxLength` prop description and fixed typo

--- a/.changeset/young-beers-arrive.md
+++ b/.changeset/young-beers-arrive.md
@@ -1,0 +1,5 @@
+---
+"pie-docs": minor
+---
+
+[Added] - code page for `pie-textarea` component

--- a/apps/pie-docs/src/components/textarea/code/code.md
+++ b/apps/pie-docs/src/components/textarea/code/code.md
@@ -1,0 +1,192 @@
+---
+eleventyNavigation:
+    key: Code
+    parent: Textarea
+    order: 2
+shouldShowContents: true
+eleventyComputed:
+    props: "{% include './props.json' %}"
+    events: "{% include './events.json' %}"
+---
+
+## Overview
+
+<p>
+  <a href="https://www.npmjs.com/@justeattakeaway/pie-textarea" style="text-decoration: none">
+    <img alt="GitHub Workflow Status" src="https://img.shields.io/npm/v/@justeattakeaway/pie-textarea.svg?label=pie-textarea">
+  </a>
+
+  <a href="https://www.npmjs.com/package/@justeattakeaway/pie-webc">
+    <img alt="GitHub Workflow Status" src="https://img.shields.io/npm/v/@justeattakeaway/pie-webc.svg?label=pie-webc">
+  </a>
+</p>
+
+`pie-textarea` is a Web Component built with [Lit](https://lit.dev/), providing users with a larger input space for writing and editing text that requires more than one line.
+
+This component integrates easily with various frontend frameworks and can be customised through a set of properties.
+
+{% notification {
+  type: "information",
+  iconName: "engineers",
+  message: "You can try out this component on our [Storybook](https://webc.pie.design/?path=/docs/textarea) instance!"
+} %}
+
+## Installation
+
+To install `pie-textarea` in your application via `npm` or `yarn`:
+
+```shell
+npm i @justeattakeaway/pie-webc
+```
+
+```shell
+yarn add @justeattakeaway/pie-webc
+```
+
+{% notification {
+  type: "neutral",
+  iconName: "link",
+  message: "For more information on using PIE components as part of an application, check out the [Getting Started Guide.](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components)."
+} %}
+
+## Props
+
+{% componentDetailsTable {
+  tableData: props
+} %}
+
+## Events
+
+{% componentDetailsTable {
+  tableData: events
+} %}
+
+## Importing and usage in templates
+For HTML and Vue:
+
+```js
+// import as module into a js file that will be loaded on the page where the component is used.
+import '@justeattakeaway/pie-webc/components/textarea.js';
+```
+
+```html
+<pie-textarea
+    name="my-textarea"
+    placeholder="Please enter a value"
+    autocomplete="on"
+    label="Label"
+    maxLength="50"
+    value=""
+    autoFocus
+    readonly>
+</pie-textarea>
+```
+
+For React Applications:
+
+```jsx
+import { PieTextarea } from '@justeattakeaway/pie-webc/react/textarea.js';
+
+<PieTextarea
+    name="my-textarea"
+    placeholder="Please enter a value"
+    autocomplete="on"
+    label="Label"
+    maxLength="50"
+    value=""
+    autoFocus
+    readonly>
+</PieTextarea>
+```
+
+```jsx
+// React templates (using Next 13 and SSR)
+import { PieTextarea } from '@justeattakeaway/pie-textarea/dist/react';
+
+<PieTextarea
+    name="my-textarea"
+    placeholder="Please enter a value"
+    autocomplete="on"
+    label="Label"
+    maxLength="50"
+    value=""
+    autoFocus
+    readonly>
+</PieTextarea>
+```
+
+## Forms usage
+{% notification {
+  type: "information",
+  iconName: "link",
+  message: "For general guidance on using our web components within forms, see [our wiki page](https://github.com/justeattakeaway/pie/wiki/Form-Controls#pie-forms-usage)."
+} %}
+
+It is essential that when using the textarea inside the form, you provide a `name` attribute. HTML forms create key/value pairs for textarea data based on the `name` attribute, which is crucial for native form submission.
+
+### Validation
+The textarea component utilizes the [constraint validation API](https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation) to provide a queryable validity state for consumers. This means that the component's validity can be checked via a `validity` getter.
+
+#### Example:
+```js
+const textarea = document.querySelector('pie-textarea');
+console.log(textarea.validity.valid);
+```
+
+This getter can be useful for reducing the amount of validation code in your application. For example, if you want to create a textarea that requires attention, you can set the `required` property on the component. You can then check the validity of the input in your application code:
+
+```html
+<pie-textarea
+  id="my-textarea"
+  required>
+</pie-textarea>
+```
+
+```js
+const textarea = document.querySelector('pie-textarea');
+const isValid = textarea.validity.valid;
+
+// We could use this to drive the status and assistiveText properties on our textarea (this would likely be inside a submit event handler in a real application)
+if (!isValid) {
+  textarea.status = 'error';
+  textarea.assistiveText = 'This textarea is required';
+}
+```
+
+These concepts work just as well inside a Vue or React application.
+
+{% notification {
+  type: "information",
+  message: "Using the constraint validation API we provide is completely optional. Feel free to use whatever form of validation best suits your application's needs. The validity state of a textarea will not interfere with the form submission or page behaviour."
+} %}
+
+#### Displaying error messages
+As mentioned earlier, we suggest consumers disable native HTML validation using the `novalidate` attribute on the form element. This will prevent the browser from displaying its own validation messages, allowing you to control the validation experience for your users.
+
+To display validation messages, you can use the `assistiveText` and `status` properties on the textarea component. The `assistiveText` property is used to display a message below the textarea, and the `status` property is used to set the visual state of the textarea. The `status` property can be set to `error` or `success`, or you can omit providing a `status` to display the `assistiveText` in a neutral state.
+
+```html
+<pie-textarea
+  name="details"
+  assistiveText="Please provide more details"
+  status="error">
+</pie-textarea>
+```
+
+Displaying success messages works in the same way, but with the `status` property set to `success`.
+
+```html
+<pie-textarea
+  name="details"
+  assistiveText="Please provide more details"
+  status="success">
+</pie-textarea>
+```
+
+## Changelog
+
+{% notification {
+  type: "neutral",
+  iconName: "link",
+  message: "See [here](https://github.com/justeattakeaway/pie/blob/main/packages/components/pie-textarea/CHANGELOG.md)."
+} %}

--- a/apps/pie-docs/src/components/textarea/code/events.json
+++ b/apps/pie-docs/src/components/textarea/code/events.json
@@ -1,0 +1,26 @@
+{
+  "headings": [
+    "Event",
+    "Description"
+  ],
+  "rows": [
+    [
+      {
+        "type": "code",
+        "item": [
+          "change"
+        ]
+      },
+      "Fires when the textarea loses focus after the value has been changed."
+    ],
+    [
+      {
+        "type": "code",
+        "item": [
+          "input"
+        ]
+      },
+      "Fires when the textarea value is changed."
+    ]
+  ]
+}

--- a/apps/pie-docs/src/components/textarea/code/props.json
+++ b/apps/pie-docs/src/components/textarea/code/props.json
@@ -1,0 +1,255 @@
+{
+  "headings": [
+    "Prop",
+    "Type",
+    "Description",
+    "Default"
+  ],
+  "rows": [
+    [
+      "assistiveText",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "Allows assistive text to be displayed below the textarea. Must be provided if using a non-default status.",
+      {
+        "type": "code",
+        "item": [
+          "undefined"
+        ]
+      }
+    ],
+    [
+      "autocomplete",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "Allows the user to enable or disable autocomplete functionality on the input field. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for more information and values.",
+      {
+        "type": "code",
+        "item": [
+          "undefined"
+        ]
+      }
+    ],
+    [
+      "autoFocus",
+      {
+        "type": "code",
+        "item": [
+          "boolean"
+        ]
+      },
+      "If true, the textarea will be focused on the first render. No more than one element in the document or dialog may have the autofocus attribute. If applied to multiple elements the first one will receive focus. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) for more information.",
+      {
+        "type": "code",
+        "item": [
+          "false"
+        ]
+      }
+    ],
+    [
+      "defaultValue",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "During a form reset, the default value will replace the current value. This prop is not normally needed.",
+      {
+        "type": "code",
+        "item": [
+          "undefined"
+        ]
+      }
+    ],
+    [
+      "disabled",
+      {
+        "type": "code",
+        "item": [
+          "boolean"
+        ]
+      },
+      "When true, the user cannot edit or interact with the control.",
+      {
+        "type": "code",
+        "item": [
+          "false"
+        ]
+      }
+    ],
+    [
+      "label",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "The label of the textarea field.",
+      {
+        "type": "code",
+        "item": [
+          "\"\""
+        ]
+      }
+    ],
+    [
+      "maxLength",
+      {
+        "type": "code",
+        "item": [
+          "number"
+        ]
+      },
+      "Maximum length (number of characters) of value. To apply a length restriction, you must also provide label text.",
+      {
+        "type": "code",
+        "item": [
+          "undefined"
+        ]
+      }
+    ],
+    [
+      "name",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "The name of the textarea (used as a key/value pair with `value`). This is required in order to work properly with forms.",
+      {
+        "type": "code",
+        "item": [
+          "undefined"
+        ]
+      }
+    ],
+    [
+      "placeholder",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "The placeholder text to display when the textarea is empty.",
+      {
+        "type": "code",
+        "item": [
+          "\"\""
+        ]
+      }
+    ],
+    [
+      "readonly",
+      {
+        "type": "code",
+        "item": [
+          "boolean"
+        ]
+      },
+      "When true, the user cannot edit the control. Not the same as disabled. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly) for more information.",
+      {
+        "type": "code",
+        "item": [
+          "false"
+        ]
+      }
+    ],
+    [
+      "required",
+      {
+        "type": "code",
+        "item": [
+          "boolean"
+        ]
+      },
+      "If true, the textarea is required to have a value before submitting the form. If there is no value, then the component validity state will be invalid. Important note: This will not prevent the form submission.",
+      {
+        "type": "code",
+        "item": [
+          "false"
+        ]
+      }
+    ],
+    [
+      "resize",
+      {
+        "type": "code",
+        "item": [
+          "\"auto\"",
+          "\"manual\""
+        ]
+      },
+      "Controls the resizing behaviour of the textarea. When set to `auto`, the textarea will resize vertically as needed. When set to `manual`, the textarea will not resize automatically but can be resized by the user.",
+      {
+        "type": "code",
+        "item": [
+          "\"auto\""
+        ]
+      }
+    ],
+    [
+      "size",
+      {
+        "type": "code",
+        "item": [
+          "\"small\"",
+          "\"medium\"",
+          "\"large\""
+        ]
+      },
+      "The size of the textarea field.",
+      {
+        "type": "code",
+        "item": [
+          "\"medium\""
+        ]
+      }
+    ],
+    [
+      "status",
+      {
+        "type": "code",
+        "item": [
+          "\"default\"",
+          "\"error\"",
+          "\"success\""
+        ]
+      },
+      "The status of the textarea component / assistive text. If you use a non-default `status` you must also provide `assistiveText` for accessibility purposes.",
+      {
+        "type": "code",
+        "item": [
+          "\"default\""
+        ]
+      }
+    ],
+    [
+      "value",
+      {
+        "type": "code",
+        "item": [
+          "string"
+        ]
+      },
+      "The value of the textarea (used as a key/value pair in HTML forms with `name`).",
+      {
+        "type": "code",
+        "item": [
+          "\"\""
+        ]
+      }
+    ]
+  ]
+}

--- a/apps/pie-docs/test/snapshots/expected-routes.snapshot.json
+++ b/apps/pie-docs/test/snapshots/expected-routes.snapshot.json
@@ -78,6 +78,7 @@
     "components/text-input",
     "components/text-input/code",
     "components/textarea",
+    "components/textarea/code",
     "components/thumbnail",
     "components/toast",
     "components/tooltip",

--- a/apps/pie-storybook/stories/pie-text-input.stories.ts
+++ b/apps/pie-storybook/stories/pie-text-input.stories.ts
@@ -301,7 +301,7 @@ const Template = ({
 };
 
 const WithLabelTemplate: TemplateFunction<TextInputProps> = (props: TextInputProps) => html`
-        <p>Please note, the label is a separate component. See <pie-link href="/?path=/story/form-label">pie-form-field</pie-link>.</p>
+        <p>Please note, the label is a separate component. See <pie-link href="/?path=/story/form-label">pie-form-label</pie-link>.</p>
         <pie-form-label for="${ifDefined(props.name)}">Label</pie-form-label>
         ${Template(props)}
     `;

--- a/apps/pie-storybook/stories/pie-textarea.stories.ts
+++ b/apps/pie-storybook/stories/pie-textarea.stories.ts
@@ -177,7 +177,7 @@ const textareaStoryMeta: TextareaStoryMeta = {
             },
         },
         maxLength: {
-            description: 'The maximum number of characters allowed in the textarea field.',
+            description: 'The maximum number of characters allowed in the textarea field. To apply a length restriction, you must also provide label text.',
             control: 'number',
             defaultValue: {
                 summary: 0,


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

**[Changed]** - `pie-textarea` `maxLength` prop description and fixed typo
**[Added]** - code page for `pie-textarea` component

**Feature url:**  https://pr1818-docs.pie.design/components/textarea/code/

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Reviewer checklists (complete before approving)
### Reviewer 1 @raoufswe 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them
