### PR TITLE
feat(stylelint-full-nested-class-modifiers): DSW-000 stylelint rule

### DIFF
--- a/.changeset/rude-clouds-care.md
+++ b/.changeset/rude-clouds-care.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/stylelint-full-nested-class-modifiers": minor
+"@justeattakeaway/stylelint-config-pie": minor
+"pie-monorepo": minor
+---
+
+[Added] - New stylelint rule: @justeattakeaway/stylelint-full-nested-class-modifiers which enforces full class selectors when using nested class modifiers

--- a/.changeset/violet-points-compare.md
+++ b/.changeset/violet-points-compare.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": patch
+---
+
+[Changed] - Changed modal scrollable css selector to align with linting rules (no visual change)

--- a/packages/components/pie-modal/src/modal.scss
+++ b/packages/components/pie-modal/src/modal.scss
@@ -257,7 +257,7 @@
           min-block-size: var(--modal-content-min-block-size);
         }
 
-        &--scrollable {
+        &.c-modal-content--scrollable {
             background:
                 // Scroll shadow cover
                 // A top-to-bottom opacity gradient from transparent to the component background colour

--- a/packages/tools/stylelint-config-pie/package.json
+++ b/packages/tools/stylelint-config-pie/package.json
@@ -23,6 +23,7 @@
     "stylelint-order": "6.x"
   },
   "dependencies": {
+    "@justeattakeaway/stylelint-full-nested-class-modifiers": "0.0.0",
     "@justeattakeaway/stylelint-no-logical-props-shorthands": "0.3.0"
   },
   "scripts": {

--- a/packages/tools/stylelint-config-pie/rules/base.js
+++ b/packages/tools/stylelint-config-pie/rules/base.js
@@ -2,9 +2,11 @@ export default {
     extends: 'stylelint-config-standard-scss',
     plugins: [
         '@justeattakeaway/stylelint-no-logical-props-shorthands',
+        '@justeattakeaway/stylelint-full-nested-class-modifiers',
     ],
     rules: {
         '@justeattakeaway/stylelint-no-logical-props-shorthands': true,
+        '@justeattakeaway/stylelint-full-nested-class-modifiers': true,
         'alpha-value-notation': 'number',
         'at-rule-empty-line-before': [
             'always',

--- a/packages/tools/stylelint-full-nested-class-modifiers/README.md
+++ b/packages/tools/stylelint-full-nested-class-modifiers/README.md
@@ -1,0 +1,64 @@
+# stylelint-full-class-name-modifiers
+
+[![npm version](https://badge.fury.io/js/@justeattakeaway%stylelint-full-class-name-modifiers.svg)](https://badge.fury.io/js/@justeattakeaway%stylelint-full-class-name-modifiers)
+
+A Stylelint plugin used in PIE – Just Eat Takeaway’s design system.
+
+This custom Stylelint rule is designed to ensure the use of full class names for modifiers rather than relying solely on nesting with the ampersand (`&`). It enforces two important principles in projects following the SUIT CSS naming methodology:
+
+1. **Improved Codebase Searchability**: By avoiding solely the use of the ampersand to define class names and instead using the full class name for modifiers, it becomes easier to locate and understand CSS classes across large codebases.
+
+2. **Enhanced Specificity**: Using the full class name within nesting improves CSS specificity. This ensures that the modifier styles only apply when the base class is also present, preventing unintentional overrides or application of styles.
+
+## Example:
+
+```scss
+/* ❌ Fails when omitting the full class name from the modifier */
+.foo {
+    &--bar {
+        color: red;
+    }
+}
+
+/* ✅ Works when the full class name is used */
+.foo {
+    &.foo--bar {
+        color: red;
+    }
+}
+```
+
+This usage ensures the full class name is explicit and that the modifier will only take effect when the base class is also applied.
+
+## Installation
+
+```bash
+npm install @justeattakeaway/stylelint-full-nested-class-modifiers --save-dev
+```
+
+## Usage
+
+Add the plugin to your Stylelint config `plugins` array, and also to the `rules` object.
+
+```js
+{
+  "plugins": [
+    "@justeattakeaway/stylelint-full-nested-class-modifiers"
+  ],
+  "rules": {
+    '@justeattakeaway/stylelint-full-nested-class-modifiers': true,
+  }
+}
+```
+
+Regular usage will show error messages in the console when you use nested class modifiers with just the ampersand.
+
+### Example output:
+
+```bash
+✖  Nested class modifier "&--bar" does not use the full class name. Use "&.foo--bar" instead.  @justeattakeaway/stylelint-full-nested-class-modifiers
+```
+
+### Fixing errors
+
+The plugin supports the `--fix` flag (autofix) and will automatically add the missing class name to the nested modifier.

--- a/packages/tools/stylelint-full-nested-class-modifiers/__tests__/__snapshots__/plugin.test.js.snap
+++ b/packages/tools/stylelint-full-nested-class-modifiers/__tests__/__snapshots__/plugin.test.js.snap
@@ -1,0 +1,31 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`stylelint-full-nested-class-modifiers > when given invalid CSS > when autofix is true > provides the expected autofixed code 1`] = `
+"
+            .component-element {
+                &.component-element--active {
+                    display: block;
+                }
+            }
+        "
+`;
+
+exports[`stylelint-full-nested-class-modifiers > when given more complicated invalid css > when autofix is true > provides the expected autofixed code 1`] = `
+"
+                .c-block-item {
+                    &.c-block-item--modifier-one {
+                        color: purple;
+                    }
+
+                    &.c-block-item--modifier-two {
+                        font-size: 12px;
+                    }
+                }
+
+                .component-element {
+                    &.component-element--active {
+                        display: block;
+                    }
+                }
+        "
+`;

--- a/packages/tools/stylelint-full-nested-class-modifiers/__tests__/plugin.test.js
+++ b/packages/tools/stylelint-full-nested-class-modifiers/__tests__/plugin.test.js
@@ -1,0 +1,127 @@
+import {
+    describe,
+    it,
+    expect,
+    beforeEach,
+} from 'vitest';
+
+import stylelint from 'stylelint';
+
+const config = {
+    extends: '@justeattakeaway/stylelint-config-pie/base',
+    plugins: [
+        '@justeattakeaway/stylelint-full-nested-class-modifiers',
+    ],
+    rules: {
+        '@justeattakeaway/stylelint-full-nested-class-modifiers': true,
+    },
+};
+
+describe('stylelint-full-nested-class-modifiers', () => {
+    let result;
+
+    describe('when given valid CSS', () => {
+        const validCSS = `
+.foo {
+    &.foo--bar {
+        color: red;
+    }
+}
+`;
+        beforeEach(() => {
+            result = stylelint.lint({
+                code: validCSS,
+                config,
+            });
+        });
+
+        it('does not raise an error', () => result.then((data) => {
+            expect(data.errored).toBeFalsy();
+        }));
+    });
+
+    describe('when given invalid CSS', () => {
+        const invalidCSS = `
+.foo {
+    &--bar {
+        color: red;
+    }
+}
+`;
+        beforeEach(() => {
+            result = stylelint.lint({
+                code: invalidCSS,
+                config,
+            });
+        });
+
+        it('raises an error', () => result.then((data) => {
+            expect(data.errored).toBeTruthy();
+        }));
+
+        it('provides the correct message', () => result.then((data) => {
+            const [firstResult] = data.results;
+            const { warnings } = firstResult;
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0].text).toContain('Nested class modifier');
+        }));
+
+        describe('when autofix is true', () => {
+            beforeEach(() => {
+                result = stylelint.lint({
+                    code: invalidCSS,
+                    config,
+                    fix: true,
+                });
+            });
+
+            it('provides the expected autofixed output', async () => {
+                const { output } = await result;
+                expect(output).toBe(`
+.foo {
+    &.foo--bar {
+        color: red;
+    }
+}
+`);
+            });
+        });
+
+        describe('when autofix is true with multiple nested modifiers', () => {
+            const invalidMultiCSS = `
+        .foo {
+            &--bar {
+                color: red;
+            }
+
+            &--baz {
+                color: blue;
+            }
+        }
+        `;
+
+            beforeEach(() => {
+                result = stylelint.lint({
+                    code: invalidMultiCSS,
+                    config,
+                    fix: true,
+                });
+            });
+
+            it('provides the expected autofixed output', async () => {
+                const { output } = await result;
+                expect(output).toBe(`
+        .foo {
+            &.foo--bar {
+                color: red;
+            }
+
+            &.foo--baz {
+                color: blue;
+            }
+        }
+        `);
+            });
+        });
+    });
+});

--- a/packages/tools/stylelint-full-nested-class-modifiers/index.js
+++ b/packages/tools/stylelint-full-nested-class-modifiers/index.js
@@ -1,0 +1,58 @@
+import stylelint from 'stylelint';
+
+const ruleName = '@justeattakeaway/stylelint-full-nested-class-modifiers';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    rejected: (selector, suggestedSelector) => `Nested class modifier "${selector}" does not use the full class name. Use "${suggestedSelector}" instead.`,
+});
+
+export const fullNestedClassModifiers = stylelint.createPlugin(ruleName, (primaryOption, secondaryOption, context) => (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, { actual: primaryOption });
+
+    if (!validOptions) return;
+
+    const isAutoFixing = Boolean(context.fix); // Check if autofixing is enabled
+
+    root.walkRules((rule) => {
+        // Match selectors like `&--modifier`
+        const nestedModifierRegex = /&--([a-zA-Z0-9-_]+)/;
+
+        if (nestedModifierRegex.test(rule.selector)) {
+            // Capture the parent selector (e.g., '.foo') from the parent rule
+            const parentRule = rule.parent;
+            const parentSelector = parentRule.selector;
+
+            if (parentSelector) {
+                // Ensure parentSelector starts with a valid class name and doesn't include '&'
+                const normalizedParentSelector = parentSelector.replace(/^&/, '').replace(/^(\.)*/, '.');
+
+                // Suggest the corrected syntax (e.g., '&.foo--modifier')
+                const suggestedSelector = `&${normalizedParentSelector}--${rule.selector.replace(/^&--/, '')}`;
+
+                if (isAutoFixing) {
+                    // Apply the fix by replacing the rule with the corrected selector
+                    const fixedRule = rule.clone({
+                        selector: suggestedSelector,
+                    });
+
+                    rule.replaceWith(fixedRule); // Replace the original rule with the fixed one
+                } else {
+                    // Report the error without fixing if autofix is not enabled
+                    stylelint.utils.report({
+                        message: messages.rejected(rule.selector, suggestedSelector),
+                        node: rule,
+                        result,
+                        ruleName,
+                    });
+                }
+            }
+        }
+    });
+});
+
+export const rule = {
+    ruleName,
+    messages,
+    fullNestedClassModifiers,
+};
+
+export default fullNestedClassModifiers;

--- a/packages/tools/stylelint-full-nested-class-modifiers/index.js
+++ b/packages/tools/stylelint-full-nested-class-modifiers/index.js
@@ -23,7 +23,8 @@ export const fullNestedClassModifiers = stylelint.createPlugin(ruleName, (primar
 
             if (parentSelector) {
                 // Ensure parentSelector starts with a valid class name and doesn't include '&'
-                const normalizedParentSelector = parentSelector.replace(/^&/, '').replace(/^(\.)*/, '.');
+                // Use a stricter replacement to avoid leading spaces or extraneous characters
+                const normalizedParentSelector = parentSelector.replace(/^&/, '').trim();
 
                 // Suggest the corrected syntax (e.g., '&.foo--modifier')
                 const suggestedSelector = `&${normalizedParentSelector}--${rule.selector.replace(/^&--/, '')}`;

--- a/packages/tools/stylelint-full-nested-class-modifiers/package.json
+++ b/packages/tools/stylelint-full-nested-class-modifiers/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@justeattakeaway/stylelint-full-nested-class-modifiers",
+  "version": "0.0.0",
+  "main": "index.js",
+  "type": "module",
+  "description": "Stylelint plugin for disallowing nested class modifiers that do not use the full class name.",
+  "license": "Apache-2.0",
+  "keywords": [
+    "PIE",
+    "stylelint",
+    "stylelint-plugin"
+  ],
+  "author": "Just Eat Takeaway.com - Design System Team",
+  "scripts": {
+    "lint:scripts": "run -T eslint .",
+    "lint:scripts:fix": "run -T eslint . --fix",
+    "test": "run -T vitest run --config ../../../vite.config.js --environment node",
+    "test:ci": "yarn test",
+    "test:watch": "run -T vitest"
+  },
+  "dependencies": {
+    "query-ast": "1.0.5",
+    "scss-parser": "1.0.6"
+  },
+  "volta": {
+    "extends": "../../../package.json"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5943,11 +5943,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/stylelint-config-pie@workspace:packages/tools/stylelint-config-pie"
   dependencies:
+    "@justeattakeaway/stylelint-full-nested-class-modifiers": 0.0.0
     "@justeattakeaway/stylelint-no-logical-props-shorthands": 0.3.0
   peerDependencies:
     stylelint: 16.x
     stylelint-config-standard-scss: 13.x
     stylelint-order: 6.x
+  languageName: unknown
+  linkType: soft
+
+"@justeattakeaway/stylelint-full-nested-class-modifiers@0.0.0, @justeattakeaway/stylelint-full-nested-class-modifiers@workspace:packages/tools/stylelint-full-nested-class-modifiers":
+  version: 0.0.0-use.local
+  resolution: "@justeattakeaway/stylelint-full-nested-class-modifiers@workspace:packages/tools/stylelint-full-nested-class-modifiers"
+  dependencies:
+    query-ast: 1.0.5
+    scss-parser: 1.0.6
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This custom Stylelint rule is designed to ensure the use of full class names for modifiers rather than relying solely on nesting with the ampersand (`&`). It enforces two important principles in projects following the SUIT CSS naming methodology:

1. **Improved Codebase Searchability**: By avoiding solely the use of the ampersand to define class names and instead using the full class name for modifiers, it becomes easier to locate and understand CSS classes across large codebases.

2. **Enhanced Specificity**: Using the full class name within nesting improves CSS specificity. This ensures that the modifier styles only apply when the base class is also present, preventing unintentional overrides or application of styles.

## Example:

```scss
/* ❌ Fails when omitting the full class name from the modifier */
.foo {
    &--bar {
        color: red;
    }
}

/* ✅ Works when the full class name is used */
.foo {
    &.foo--bar {
        color: red;
    }
}
```

This usage ensures the full class name is explicit and that the modifier will only take effect when the base class is also applied.

### Error Message:
When a violation occurs, the following error message will be shown:

```
Nested class modifier "&--bar" does not use the full class name. Use "&.foo--bar" instead.
```

## Examples:
### Running `yarn lint:style` with invalid SCSS
<img width="1151" alt="Screenshot 2024-09-11 at 15 35 41" src="https://github.com/user-attachments/assets/7ed645bf-88cf-4a4f-b2bd-b1a78f99f7d4">

<img width="276" alt="Screenshot 2024-09-11 at 15 35 53" src="https://github.com/user-attachments/assets/0781aec0-074f-41f3-9bc8-21a1183d4742">

### Running `yarn:lint:style:fix`
<img width="788" alt="Screenshot 2024-09-11 at 15 36 17" src="https://github.com/user-attachments/assets/b05e539b-77be-4cce-82ba-085bf695959a">

<img width="271" alt="Screenshot 2024-09-11 at 15 36 30" src="https://github.com/user-attachments/assets/6f239329-f7c7-45bb-a132-632ab64e5861">



## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
