### PR TITLE
feat(pie-checkbox): DSW-2280 use classmap for styling

### DIFF
--- a/.changeset/large-moose-travel.md
+++ b/.changeset/large-moose-travel.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-checkbox": minor
+---
+
+[Changed] - use ClassMap for styling with CSS classes rather than data attributes

--- a/packages/components/pie-checkbox/src/checkbox.scss
+++ b/packages/components/pie-checkbox/src/checkbox.scss
@@ -5,14 +5,12 @@
         width: 0;
         height: 0;
         border-color: #fff;
-
         transform: translate3d(0, 0, 0) rotate(45deg);
     }
 
     33% {
         width: 8px;
         height: 0;
-
         transform: translate3d(0, 0, 0) rotate(45deg);
     }
 
@@ -55,14 +53,10 @@
 .c-checkbox-tick {
     content: "";
     display: flex;
-
     flex: 0 0 auto;
-
     width: var(--checkbox-width);
     height: var(--checkbox-height);
-
     margin: var(--checkbox-margin);
-
     border: 1px solid var(--checkbox-border-color);
     border-radius: var(--checkbox-radius);
     background-color: var(--checkbox-bg-color);
@@ -71,48 +65,43 @@
         transition:
             background-color var(--dt-motion-timing-100) var(--checkbox-motion-easing),
             border-color var(--dt-motion-timing-100) var(--checkbox-motion-easing);
-
         animation: scaleDown var(--dt-motion-timing-100) var(--checkbox-motion-easing);
     }
 
-    &[data-pie-disabled] {
+    &.c-checkbox-tick--disabled {
         --checkbox-bg-color: var(--dt-color-container-strong);
         --checkbox-border-color: var(--dt-color-disabled-01);
     }
 
-    &[data-pie-status="error"] {
+    &.c-checkbox-tick--status-error {
         --checkbox-border-color: var(--dt-color-support-error);
     }
 
-    &[data-pie-checked] {
+    &.c-checkbox-tick--checked {
         @media (prefers-reduced-motion: no-preference) {
             animation: scaleUp var(--dt-motion-timing-100) var(--checkbox-motion-easing);
         }
 
-        &:not([data-pie-disabled]) {
+        &:not(.c-checkbox-tick--disabled) {
             --checkbox-bg-color: var(--dt-color-interactive-brand);
             --checkbox-border-color: var(--dt-color-interactive-brand);
         }
 
-        &[data-pie-status="error"] {
+        &.c-checkbox-tick--status-error {
             --checkbox-bg-color: var(--dt-color-support-error);
             --checkbox-border-color: var(--dt-color-support-error);
         }
     }
 
-    &[data-pie-checked]:before {
+    &.c-checkbox-tick--checked:before {
         content: "";
-
         position: relative;
         top: 55%;
         left: 14%;
-
         border-right: 2px solid transparent;
         border-bottom: 2px solid transparent;
-
         transform: rotate(45deg);
         transform-origin: 0% 100%;
-
         animation: checkboxCheck var(--dt-motion-timing-150) var(--checkbox-motion-easing) forwards;
 
         @media (prefers-reduced-motion: reduce) {
@@ -123,40 +112,37 @@
             height: 16px;
             border-color: #fff;
             border-bottom-right-radius: 2px;
-
             transform: translate3d(0, -16px, 0) rotate(45deg);
         }
 
         @media only percy {
             animation: none;
-
             width: 8px;
             height: 16px;
             border-color: #fff;
             border-bottom-right-radius: 2px;
-
             transform: translate3d(0, -16px, 0) rotate(45deg);
         }
     }
 
-    &[data-pie-checked][data-is-rtl]:before {
+    &.c-checkbox-tick--checked.c-checkbox-tick--rtl:before {
         left: unset;
         right: 50%;
     }
 
-    &[data-pie-indeterminate] {
-        &:not([data-pie-disabled]) {
+    &.c-checkbox-tick--indeterminate {
+        &:not(.c-checkbox-tick--disabled) {
             --checkbox-bg-color: var(--dt-color-interactive-brand);
             --checkbox-border-color: var(--dt-color-interactive-brand);
         }
 
-        &[data-pie-status="error"] {
-            --checkbox-border-color: var(--dt-color-support-error);
+        &.c-checkbox-tick--status-error {
             --checkbox-bg-color: var(--dt-color-support-error);
+            --checkbox-border-color: var(--dt-color-support-error);
         }
     }
 
-    &[data-pie-indeterminate]:after {
+    &.c-checkbox-tick--indeterminate:after {
         width: 16px;
 
         @media (prefers-reduced-motion: no-preference) {
@@ -177,10 +163,9 @@
     font-weight: var(--checkbox-font-weight);
 }
 
-// initial styles for indeterminate state
+// Initial styles for indeterminate state
 .c-checkbox-tick:after {
     content: "";
-
     position: relative;
     top: 47%;
     left: 14%;
@@ -189,7 +174,7 @@
     background-color: white;
 }
 
-.c-checkbox-tick[data-is-rtl]:after {
+.c-checkbox-tick.c-checkbox-tick--rtl:after {
     left: unset;
     right: 14%;
 }
@@ -230,7 +215,11 @@
 
     &:hover {
         .c-checkbox-tick {
-            --checkbox-bg-color: hsl(var(--dt-color-container-default-h), var(--dt-color-container-default-s), calc(var(--dt-color-container-default-l) + calc(-1 * var(--dt-color-hover-01))));
+            --checkbox-bg-color: hsl(
+                var(--dt-color-container-default-h),
+                var(--dt-color-container-default-s),
+                calc(var(--dt-color-container-default-l) - var(--dt-color-hover-01))
+            );
             transition:
                 background-color var(--dt-motion-timing-200) var(--checkbox-motion-easing),
                 border-color var(--dt-motion-timing-200) var(--checkbox-motion-easing);
@@ -239,15 +228,18 @@
 
     &:active {
         .c-checkbox-tick {
-            --checkbox-bg-color: hsl(var(--dt-color-container-default-h), var(--dt-color-container-default-s), calc(var(--dt-color-container-default-l) + calc(-1 * var(--dt-color-active-01))));
-
+            --checkbox-bg-color: hsl(
+                var(--dt-color-container-default-h),
+                var(--dt-color-container-default-s),
+                calc(var(--dt-color-container-default-l) - var(--dt-color-active-01))
+            );
             transition:
                 background-color var(--dt-motion-timing-100) var(--checkbox-motion-easing),
                 border-color var(--dt-motion-timing-100) var(--checkbox-motion-easing);
         }
     }
 
-    &[data-pie-disabled] {
+    &.c-checkbox--disabled {
         label {
             cursor: not-allowed;
         }
@@ -259,7 +251,7 @@
         }
     }
 
-    &[data-pie-disabled] {
+    &.c-checkbox--disabled {
         &:hover,
         &:active {
             .c-checkbox-tick {
@@ -269,47 +261,87 @@
         }
     }
 
-    &[data-pie-status="error"] {
+    &.c-checkbox--status-error {
         &:hover {
             .c-checkbox-tick {
-                --checkbox-bg-color: hsl(var(--dt-color-container-default-h), var(--dt-color-container-default-s), calc(var(--dt-color-container-default-l) + calc(-1 * var(--dt-color-hover-01))));
+                --checkbox-bg-color: hsl(
+                    var(--dt-color-container-default-h),
+                    var(--dt-color-container-default-s),
+                    calc(var(--dt-color-container-default-l) - var(--dt-color-hover-01))
+                );
             }
         }
 
         &:active {
             .c-checkbox-tick {
-                --checkbox-bg-color: hsl(var(--dt-color-container-default-h), var(--dt-color-container-default-s), calc(var(--dt-color-container-default-l) + calc(-1 * var(--dt-color-active-01))));
+                --checkbox-bg-color: hsl(
+                    var(--dt-color-container-default-h),
+                    var(--dt-color-container-default-s),
+                    calc(var(--dt-color-container-default-l) - var(--dt-color-active-01))
+                );
             }
         }
     }
 
-    &[data-pie-checked],
-    &[data-pie-indeterminate] {
-        &:not([data-pie-disabled]):hover {
+    &.c-checkbox--checked,
+    &.c-checkbox--indeterminate {
+        &:not(.c-checkbox--disabled):hover {
             .c-checkbox-tick {
-                --checkbox-bg-color: hsl(var(--dt-color-interactive-brand-h), var(--dt-color-interactive-brand-s), calc(var(--dt-color-interactive-brand-l) + calc(-1 * var(--dt-color-hover-01))));
-                --checkbox-border-color: hsl(var(--dt-color-interactive-brand-h), var(--dt-color-interactive-brand-s), calc(var(--dt-color-interactive-brand-l) + calc(-1 * var(--dt-color-hover-01))));
+                --checkbox-bg-color: hsl(
+                    var(--dt-color-interactive-brand-h),
+                    var(--dt-color-interactive-brand-s),
+                    calc(var(--dt-color-interactive-brand-l) - var(--dt-color-hover-01))
+                );
+                --checkbox-border-color: hsl(
+                    var(--dt-color-interactive-brand-h),
+                    var(--dt-color-interactive-brand-s),
+                    calc(var(--dt-color-interactive-brand-l) - var(--dt-color-hover-01))
+                );
             }
         }
 
-        &[data-pie-status="error"]:hover {
+        &.c-checkbox--status-error:hover {
             .c-checkbox-tick {
-                --checkbox-bg-color: hsl(var(--dt-color-support-error-h), var(--dt-color-support-error-s), calc(var(--dt-color-support-error-l) + calc(-1 * var(--dt-color-hover-01))));
-                --checkbox-border-color: hsl(var(--dt-color-support-error-h), var(--dt-color-support-error-s), calc(var(--dt-color-support-error-l) + calc(-1 * var(--dt-color-hover-01))));
+                --checkbox-bg-color: hsl(
+                    var(--dt-color-support-error-h),
+                    var(--dt-color-support-error-s),
+                    calc(var(--dt-color-support-error-l) - var(--dt-color-hover-01))
+                );
+                --checkbox-border-color: hsl(
+                    var(--dt-color-support-error-h),
+                    var(--dt-color-support-error-s),
+                    calc(var(--dt-color-support-error-l) - var(--dt-color-hover-01))
+                );
             }
         }
 
-        &:not([data-pie-disabled]):active {
+        &:not(.c-checkbox--disabled):active {
             .c-checkbox-tick {
-                --checkbox-bg-color: hsl(var(--dt-color-interactive-brand-h), var(--dt-color-interactive-brand-s), calc(var(--dt-color-interactive-brand-l) + calc(-1 * var(--dt-color-active-01))));
-                --checkbox-border-color: hsl(var(--dt-color-interactive-brand-h), var(--dt-color-interactive-brand-s), calc(var(--dt-color-interactive-brand-l) + calc(-1 * var(--dt-color-active-01))));
+                --checkbox-bg-color: hsl(
+                    var(--dt-color-interactive-brand-h),
+                    var(--dt-color-interactive-brand-s),
+                    calc(var(--dt-color-interactive-brand-l) - var(--dt-color-active-01))
+                );
+                --checkbox-border-color: hsl(
+                    var(--dt-color-interactive-brand-h),
+                    var(--dt-color-interactive-brand-s),
+                    calc(var(--dt-color-interactive-brand-l) - var(--dt-color-active-01))
+                );
             }
         }
 
-        &[data-pie-status="error"]:active {
+        &.c-checkbox--status-error:active {
             .c-checkbox-tick {
-                --checkbox-bg-color: hsl(var(--dt-color-support-error-h), var(--dt-color-support-error-s), calc(var(--dt-color-support-error-l) + calc(-1 * var(--dt-color-active-01))));
-                --checkbox-border-color: hsl(var(--dt-color-support-error-h), var(--dt-color-support-error-s), calc(var(--dt-color-support-error-l) + calc(-1 * var(--dt-color-active-01))));
+                --checkbox-bg-color: hsl(
+                    var(--dt-color-support-error-h),
+                    var(--dt-color-support-error-s),
+                    calc(var(--dt-color-support-error-l) - var(--dt-color-active-01))
+                );
+                --checkbox-border-color: hsl(
+                    var(--dt-color-support-error-h),
+                    var(--dt-color-support-error-s),
+                    calc(var(--dt-color-support-error-l) - var(--dt-color-active-01))
+                );
             }
         }
     }

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -1,6 +1,7 @@
 import {
     LitElement, html, unsafeCSS, nothing,
 } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -164,13 +165,26 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
 
         const componentDisabled = disabled || disabledByParent;
 
+        const checkboxClasses = {
+            'c-checkbox': true,
+            [`c-checkbox--status-${status}`]: !componentDisabled,
+            'c-checkbox--disabled': componentDisabled,
+            'c-checkbox--checked': checked,
+            'c-checkbox--indeterminate': indeterminate && !checked,
+        };
+
+        const labelClasses = {
+            'c-checkbox-tick': true,
+            [`c-checkbox-tick--status-${status}`]: !componentDisabled,
+            'c-checkbox-tick--disabled': componentDisabled,
+            'c-checkbox-tick--checked': checked,
+            'c-checkbox-tick--indeterminate': indeterminate && !checked,
+            'c-checkbox-tick--rtl': isRTL,
+        };
+
         return html`
         <div
-            class="c-checkbox"
-            data-pie-status=${!componentDisabled && status}
-            ?data-pie-disabled=${componentDisabled}
-            ?data-pie-checked=${checked}
-            ?data-pie-indeterminate=${indeterminate && !checked}>
+            class="${classMap(checkboxClasses)}">
             <input
                 type="checkbox"
                 id="inputId"
@@ -187,12 +201,7 @@ export class PieCheckbox extends FormControlMixin(RtlMixin(LitElement)) implemen
             />
             <label for="inputId" data-test-id="checkbox-component">
                 <span
-                    class="c-checkbox-tick"
-                    ?data-is-rtl=${isRTL}
-                    ?data-pie-checked=${checked}
-                    ?data-pie-disabled=${componentDisabled}
-                    data-pie-status=${!componentDisabled && status}
-                    ?data-pie-indeterminate=${indeterminate && !checked}></span>
+                    class="${classMap(labelClasses)}"></span>
                 <span class="c-checkbox-text">
                     <slot></slot>
                 </span>

--- a/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/component/pie-checkbox.spec.ts
@@ -3,7 +3,6 @@ import { setupFormDataExtraction, getFormDataObject } from '@justeattakeaway/pie
 import { test, expect } from '@sand4rt/experimental-ct-web';
 import { PieAssistiveText } from '@justeattakeaway/pie-assistive-text';
 import { PieCheckbox, CheckboxProps } from '../../src/index.ts';
-import { statusTypes } from '../../src/defs.ts';
 
 const inputSelector = '[data-test-id="checkbox-input"]';
 const labelSelector = '[data-test-id="checkbox-component"]';
@@ -328,45 +327,6 @@ test.describe('PieCheckbox - Component tests', () => {
 
                 // Assert
                 expect(assistiveText).not.toBeVisible();
-            });
-
-            test('should apply the "default" variant attribute if no status is provided', async ({ mount, page }) => {
-                // Arrange
-                await mount(PieCheckbox, {
-                    props: {
-                        assistiveText: 'Assistive text',
-                    } as PieCheckbox,
-                });
-
-                // Act
-                const assistiveText = page.locator(assistiveTextSelector);
-
-                // Assert
-                expect(assistiveText).toBeVisible();
-                expect(await assistiveText.getAttribute('variant')).toBe('default');
-                expect(assistiveText).toHaveText('Assistive text');
-            });
-
-            test.describe('Assistive text: Status', () => {
-                statusTypes.forEach((status) => {
-                    test(`should render the assistive text component with the ${status} variant`, async ({ mount, page }) => {
-                        // Arrange
-                        await mount(PieCheckbox, {
-                            props: {
-                                assistiveText: 'Assistive text',
-                                status,
-                            } as PieCheckbox,
-                        });
-
-                        // Act
-                        const assistiveText = page.locator(assistiveTextSelector);
-
-                        // Assert
-                        expect(assistiveText).toBeVisible();
-                        expect(assistiveText).toHaveAttribute('variant', status);
-                        expect(assistiveText).toHaveText('Assistive text');
-                    });
-                });
             });
 
             test.describe('Assistive test ID attribute', () => {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
---
"@justeattakeaway/pie-checkbox": minor
---

[Changed] - use ClassMap for styling with CSS classes rather than data attributes

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview

### Reviewer 2
- [x] I have reviewed the `PIE Storybook` PR preview
