### PR TITLE
fix(pie-card): DSW-2425 ensure the card is not interactive when it is disabled

### DIFF
--- a/.changeset/metal-crabs-develop.md
+++ b/.changeset/metal-crabs-develop.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-card": patch
+"pie-storybook": patch
+"pie-docs": patch
+---
+
+[Fixed] - Ensure the card is not interactive when `disabled` is passed

--- a/apps/pie-docs/src/components/card/code/props.json
+++ b/apps/pie-docs/src/components/card/code/props.json
@@ -58,7 +58,7 @@
                 "type": "code",
                 "item": ["true", "false"]
             },
-            "Whether or not the card should be disabled. This applies disabled styles and turns off interactivity. <br /> If the card is used as a link, the `href` attribute will be removed so the link can no longer be activated.",
+            "Whether or not the card should be disabled. This applies disabled styles and turns off interactivity. <br /> If the card is used as a link, the `href` attribute will be removed so the link can no longer be navigated.",
             {
                 "type": "code",
                 "item": ["false"]

--- a/apps/pie-docs/src/components/card/code/props.json
+++ b/apps/pie-docs/src/components/card/code/props.json
@@ -58,7 +58,7 @@
                 "type": "code",
                 "item": ["true", "false"]
             },
-            "Whether or not the card should be disabled. This applies disabled styles and turns off interactivity.",
+            "Whether or not the card should be disabled. This applies disabled styles and turns off interactivity. <br /> If the card is used as a link, the `href` attribute will be removed so the link can no longer be activated.",
             {
                 "type": "code",
                 "item": ["false"]

--- a/apps/pie-storybook/stories/pie-card.stories.ts
+++ b/apps/pie-storybook/stories/pie-card.stories.ts
@@ -2,6 +2,7 @@ import { nothing } from 'lit';
 import { html } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { type Meta } from '@storybook/web-components';
+import { action } from '@storybook/addon-actions';
 
 import '@justeattakeaway/pie-card';
 import {
@@ -112,6 +113,8 @@ const cardStoryMeta: CardStoryMeta = {
 
 export default cardStoryMeta;
 
+const clickAction = action('clicked');
+
 const Template: TemplateFunction<CardProps> = ({
     tag,
     href,
@@ -123,7 +126,10 @@ const Template: TemplateFunction<CardProps> = ({
     variant,
     padding,
     isDraggable,
-}) => html`
+}) => {
+    const isButton = tag === 'button';
+
+    return html`
         <pie-card
             tag="${ifDefined(tag)}"
             variant="${ifDefined(variant)}"
@@ -133,9 +139,11 @@ const Template: TemplateFunction<CardProps> = ({
             ?disabled="${disabled}"
             .aria="${aria}"
             padding="${padding || nothing}"
-            ?isDraggable="${isDraggable}">
+            ?isDraggable="${isDraggable}"
+            @click="${isButton ? clickAction : nothing}">
                 ${sanitizeAndRenderHTML(slot)}
             </pie-card>`;
+};
 
 const createCardStory = createStory<CardProps>(Template, defaultArgs);
 

--- a/packages/components/pie-card/src/card.scss
+++ b/packages/components/pie-card/src/card.scss
@@ -39,10 +39,6 @@
     outline: none;
     text-decoration: none;
 
-    &:focus-visible {
-        @include p.focus;
-    }
-
     &.c-card--disabled {
         --card-bg-color: var(--dt-color-disabled-01);
 
@@ -94,5 +90,9 @@
 
     &.c-card--draggable {
         @extend %has-grab-cursor;
+    }
+
+    &:focus-visible {
+        @include p.focus;
     }
 }

--- a/packages/components/pie-card/src/index.ts
+++ b/packages/components/pie-card/src/index.ts
@@ -56,6 +56,13 @@ export class PieCard extends LitElement implements CardProps {
     @queryAssignedElements({ flatten: true })
     private assignedElements?: HTMLElement[];
 
+    private onClickHandler (event: Event) {
+        if (this.disabled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
     /**
      * Renders the card as an anchor element.
      *
@@ -63,21 +70,22 @@ export class PieCard extends LitElement implements CardProps {
      */
     private renderAnchor (classes: ClassInfo): TemplateResult {
         const paddingCSS = this.generatePaddingCSS();
+        const {
+            href, rel, target, disabled, aria,
+        } = this;
 
         return html`
             <a
                 class="${classMap(classes)}"
                 data-test-id="pie-card"
-                ?disabled=${this.disabled}
-                href=${this.href || ''}
-                target=${this.target || nothing}
-                rel=${this.rel || nothing}
+                href=${ifDefined(href && !disabled ? href : undefined)}
+                target=${target || nothing}
+                rel=${rel || nothing}
                 role="link"
-                aria-label=${this.aria?.label || nothing}
-                aria-disabled=${this.disabled ? 'true' : 'false'}
+                aria-label=${aria?.label || nothing}
+                aria-disabled=${disabled ? 'true' : 'false'}
                 style=${ifDefined(paddingCSS)}>
-                    <slot></slot>
-                </div>
+                    <slot  @slotchange=${this.handleSlotChange}></slot>
             </a>`;
     }
 
@@ -196,10 +204,11 @@ export class PieCard extends LitElement implements CardProps {
                     class="${classMap(classes)}"
                     data-test-id="pie-card"
                     role="button"
-                    tabindex="0"
+                    tabindex=${disabled ? '-1' : '0'}
                     aria-label=${aria?.label || nothing}
                     aria-disabled=${disabled ? 'true' : 'false'}
-                    style=${paddingCSS || ''}>
+                    style=${paddingCSS || ''}
+                    @click=${this.onClickHandler}>
                         <slot @slotchange=${this.handleSlotChange}></slot>
                     </div>
                 </div>`;

--- a/packages/components/pie-card/src/index.ts
+++ b/packages/components/pie-card/src/index.ts
@@ -58,6 +58,7 @@ export class PieCard extends LitElement implements CardProps {
 
     private onClickHandler (event: Event) {
         if (this.disabled) {
+            // needed to intercept/prevent click events when the card is disabled.
             event.preventDefault();
             event.stopPropagation();
         }

--- a/packages/components/pie-card/test/component/pie-card.spec.ts
+++ b/packages/components/pie-card/test/component/pie-card.spec.ts
@@ -43,41 +43,63 @@ test.describe('PieCard - Component tests', () => {
         await expect(renderedSlotContent).toBeVisible();
     });
 
-    test.describe('PieCard with tag = "button"', () => {
-        test('should handle click events', async ({ mount }) => {
-            // Arrange
-            const tag = 'button';
-            const messages: string[] = [];
-            const expectedEventMessage = 'Native event dispatched';
+    test('should render the card as an anchor tag with the provided href, target and rel attributes if tag = a', async ({ mount, page }) => {
+        // Arrange
+        const tag = 'a';
+        const href = 'foo.com';
+        const rel = 'noopener noreferrer';
+        const target = '_blank';
 
-            const component = await mount(PieCard, {
-                props: {
-                    tag,
-                } as CardProps,
-                slots: {
-                    default: slotContent,
-                },
-                on: {
-                    click: () => {
-                        messages.push(expectedEventMessage);
-                    },
-                },
-            });
-
-            // Act
-            await component.click();
-
-            // Assert
-            expect(messages).toEqual([expectedEventMessage]);
+        await mount(PieCard, {
+            props: {
+                tag,
+                href,
+                rel,
+                target,
+            } as CardProps,
+            slots: {
+                default: slotContent,
+            },
         });
 
-        test('should have the correct attributes', async ({ mount, page }) => {
-            // Arrange
-            const tag = 'button';
+        // Act
+        const component = page.locator(componentSelector);
 
+        // Assert
+        await expect(component).toHaveAttribute('href', href);
+        await expect(component).toHaveAttribute('rel', rel);
+        await expect(component).toHaveAttribute('target', target);
+        await expect(component).not.toHaveAttribute('role', 'button');
+        await expect(component).not.toHaveAttribute('tabindex', '0');
+    });
+
+    test('should render the card as a div that behaves like a button if tag = "button"', async ({ mount, page }) => {
+        // Arrange
+        const tag = 'button';
+
+        await mount(PieCard, {
+            props: {
+                tag,
+            } as CardProps,
+            slots: {
+                default: slotContent,
+            },
+        });
+
+        // Act
+        const component = page.locator(componentSelector);
+
+        // Assert
+        await expect(component).toHaveAttribute('role', 'button');
+        await expect(component).toHaveAttribute('tabindex', '0');
+    });
+
+    [true, false].forEach((disabled) => {
+        test(`should add an aria-disabled attribute that matches the value of the disabled prop (${disabled})`, async ({ mount, page }) => {
+            // Arrange
             await mount(PieCard, {
                 props: {
-                    tag,
+                    disabled,
                 } as CardProps,
                 slots: {
                     default: slotContent,
@@ -88,9 +110,7 @@ test.describe('PieCard - Component tests', () => {
             const component = page.locator(componentSelector);
 
             // Assert
-            await expect(component).toHaveAttribute('role', 'button');
-            await expect(component).toHaveAttribute('tabindex', '0');
-            await expect(component).toHaveAttribute('aria-disabled', 'false');
+            await expect(component).toHaveAttribute('aria-disabled', disabled.toString());
         });
     });
 

--- a/packages/components/pie-card/test/component/pie-card.spec.ts
+++ b/packages/components/pie-card/test/component/pie-card.spec.ts
@@ -43,66 +43,55 @@ test.describe('PieCard - Component tests', () => {
         await expect(renderedSlotContent).toBeVisible();
     });
 
-    test('should render the card as an anchor tag with the provided href, target and rel attributes if tag = a', async ({ mount, page }) => {
-        // Arrange
-        const tag = 'a';
-        const href = 'foo.com';
-        const rel = 'noopener noreferrer';
-        const target = '_blank';
+    test.describe('PieCard with tag = "button"', () => {
+        test('should handle click events', async ({ mount }) => {
+            // Arrange
+            const tag = 'button';
+            const messages: string[] = [];
+            const expectedEventMessage = 'Native event dispatched';
 
-        await mount(PieCard, {
-            props: {
-                tag,
-                href,
-                rel,
-                target,
-            } as CardProps,
-            slots: {
-                default: slotContent,
-            },
-        });
-
-        // Act
-        const component = page.locator(componentSelector);
-
-        // Assert
-        await expect(component).toHaveAttribute('href', href);
-        await expect(component).toHaveAttribute('rel', rel);
-        await expect(component).toHaveAttribute('target', target);
-        await expect(component).toHaveAttribute('aria-disabled', 'false');
-        await expect(component).not.toHaveAttribute('role', 'button');
-        await expect(component).not.toHaveAttribute('tabindex', '0');
-    });
-
-    test('should render the card as a div that behaves like a button if tag = "button"', async ({ mount, page }) => {
-        // Arrange
-        const tag = 'button';
-        const messages: string[] = [];
-        const expectedEventMessage = 'Native event dispatched';
-
-        await mount(PieCard, {
-            props: {
-                tag,
-            } as CardProps,
-            slots: {
-                default: slotContent,
-            },
-            on: {
-                click: () => {
-                    messages.push(expectedEventMessage);
+            const component = await mount(PieCard, {
+                props: {
+                    tag,
+                } as CardProps,
+                slots: {
+                    default: slotContent,
                 },
-            },
+                on: {
+                    click: () => {
+                        messages.push(expectedEventMessage);
+                    },
+                },
+            });
+
+            // Act
+            await component.click();
+
+            // Assert
+            expect(messages).toEqual([expectedEventMessage]);
         });
 
-        // Act
-        const component = page.locator(componentSelector);
-        await component.click();
+        test('should have the correct attributes', async ({ mount, page }) => {
+            // Arrange
+            const tag = 'button';
 
-        // Assert
-        await expect(component).toHaveAttribute('role', 'button');
-        await expect(component).toHaveAttribute('tabindex', '0');
-        await expect(component).toHaveAttribute('aria-disabled', 'false');
-        expect(messages).toEqual([expectedEventMessage]);
+            await mount(PieCard, {
+                props: {
+                    tag,
+                } as CardProps,
+                slots: {
+                    default: slotContent,
+                },
+            });
+
+            // Act
+            const component = page.locator(componentSelector);
+
+            // Assert
+            await expect(component).toHaveAttribute('role', 'button');
+            await expect(component).toHaveAttribute('tabindex', '0');
+            await expect(component).toHaveAttribute('aria-disabled', 'false');
+        });
     });
 
     tags.forEach((tag) => {

--- a/packages/components/pie-card/test/component/pie-card.spec.ts
+++ b/packages/components/pie-card/test/component/pie-card.spec.ts
@@ -335,5 +335,114 @@ test.describe('PieCard - Component tests', () => {
                 await expect(image).not.toHaveCSS('opacity', '0.5');
             });
         });
+
+        test.describe('when the prop `tag` is set to `button`', () => {
+            test('should set `aria-disabled` to `true` when disabled', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieCard, {
+                    props: {
+                        tag: 'button',
+                        disabled: true,
+                    } as CardProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                });
+
+                // Act
+                const component = page.locator(componentSelector);
+
+                // Assert
+                await expect(component).toHaveAttribute('aria-disabled', 'true');
+            });
+
+            test('should set `tabindex` to `-1` when disabled', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieCard, {
+                    props: {
+                        tag: 'button',
+                        disabled: true,
+                    } as CardProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                });
+
+                // Act
+                const component = page.locator(componentSelector);
+
+                // Assert
+                await expect(component).toHaveAttribute('tabindex', '-1');
+            });
+
+            test('should not trigger the click event when the tag prop is set to `button` and is `disabled`', async ({ mount, page }) => {
+                // Arrange
+                const messages: string[] = [];
+
+                await mount(PieCard, {
+                    props: {
+                        tag: 'button',
+                        disabled: true,
+                    } as CardProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                    on: {
+                        click: () => messages.push('1'),
+                    },
+                });
+
+                // Act
+                const component = page.locator(componentSelector);
+                await page.evaluate(() => {
+                    const card = document.querySelector('pie-card');
+                    card?.shadowRoot?.querySelector('div')?.click();
+                });
+
+                // Assert
+                await expect(component).toBeDisabled();
+                expect(messages).toHaveLength(0);
+            });
+        });
+
+        test.describe('when the prop `tag` is set to `a`', () => {
+            test('should set `aria-disabled` to `true` when disabled', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieCard, {
+                    props: {
+                        tag: 'a',
+                        disabled: true,
+                    } as CardProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                });
+
+                // Act
+                const component = page.locator(componentSelector);
+
+                // Assert
+                await expect(component).toHaveAttribute('aria-disabled', 'true');
+            });
+
+            test('should not set the href attribute when disabled', async ({ mount, page }) => {
+                // Arrange
+                await mount(PieCard, {
+                    props: {
+                        tag: 'a',
+                        disabled: true,
+                    } as CardProps,
+                    slots: {
+                        default: slotContent,
+                    },
+                });
+
+                // Act
+                const component = page.locator(componentSelector);
+
+                // Assert
+                await expect(component).not.toHaveAttribute('href');
+            });
+        });
     });
 });

--- a/packages/components/pie-card/test/component/pie-card.spec.ts
+++ b/packages/components/pie-card/test/component/pie-card.spec.ts
@@ -69,6 +69,7 @@ test.describe('PieCard - Component tests', () => {
         await expect(component).toHaveAttribute('href', href);
         await expect(component).toHaveAttribute('rel', rel);
         await expect(component).toHaveAttribute('target', target);
+        await expect(component).toHaveAttribute('aria-disabled', 'false');
         await expect(component).not.toHaveAttribute('role', 'button');
         await expect(component).not.toHaveAttribute('tabindex', '0');
     });
@@ -76,6 +77,8 @@ test.describe('PieCard - Component tests', () => {
     test('should render the card as a div that behaves like a button if tag = "button"', async ({ mount, page }) => {
         // Arrange
         const tag = 'button';
+        const messages: string[] = [];
+        const expectedEventMessage = 'Native event dispatched';
 
         await mount(PieCard, {
             props: {
@@ -84,34 +87,22 @@ test.describe('PieCard - Component tests', () => {
             slots: {
                 default: slotContent,
             },
+            on: {
+                click: () => {
+                    messages.push(expectedEventMessage);
+                },
+            },
         });
 
         // Act
         const component = page.locator(componentSelector);
+        await component.click();
 
         // Assert
         await expect(component).toHaveAttribute('role', 'button');
         await expect(component).toHaveAttribute('tabindex', '0');
-    });
-
-    [true, false].forEach((disabled) => {
-        test(`should add an aria-disabled attribute that matches the value of the disabled prop (${disabled})`, async ({ mount, page }) => {
-            // Arrange
-            await mount(PieCard, {
-                props: {
-                    disabled,
-                } as CardProps,
-                slots: {
-                    default: slotContent,
-                },
-            });
-
-            // Act
-            const component = page.locator(componentSelector);
-
-            // Assert
-            await expect(component).toHaveAttribute('aria-disabled', disabled.toString());
-        });
+        await expect(component).toHaveAttribute('aria-disabled', 'false');
+        expect(messages).toEqual([expectedEventMessage]);
     });
 
     tags.forEach((tag) => {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] - Ensure the card is not interactive when `disabled` is passed

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1 @kevinrodrigues 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them
