### PR TITLE
test(pie-button): DSW-2226 Split PIE Button visual tests by sizes

### DIFF
--- a/.changeset/thin-lizards-listen.md
+++ b/.changeset/thin-lizards-listen.md
@@ -1,5 +1,0 @@
----
-"@justeattakeaway/pie-button": minor
----
-
-Updated visual testing split screenshots

--- a/.changeset/thin-lizards-listen.md
+++ b/.changeset/thin-lizards-listen.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": minor
+---
+
+Updated visual testing split screenshots

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -26,7 +26,7 @@ const props: PropObject<ButtonProps> = {
     isFullWidth: [true, false],
     disabled: [true, false],
     isLoading: [true, false],
-    iconPlacement: [undefined, ...iconPlacements],
+    iconPlacement: iconPlacements,
 };
 
 // Renders a <pie-button> HTML string with the given prop values
@@ -47,25 +47,34 @@ test.beforeEach(async ({ mount }, testInfo) => {
     await iconComponent.unmount();
 });
 
-componentVariants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page, mount }) => {
-    for (const combo of componentPropsMatrixByVariant[variant]) {
-        const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieButton);
-        const propKeyValues = `size: ${testComponent.propValues.size}, iconPlacement: ${testComponent.propValues.iconPlacement}, isFullWidth: ${testComponent.propValues.isFullWidth}, disabled: ${testComponent.propValues.disabled}, isLoading: ${testComponent.propValues.isLoading}`;
-        const darkMode = ['inverse', 'ghost-inverse', 'outline-inverse'].includes(variant);
+componentVariants.forEach((variant) => {
+    const componentPropsMatrixBySize = splitCombinationsByPropertyValue(componentPropsMatrixByVariant[variant], 'size');
+    const componentSizes: string[] = Object.keys(componentPropsMatrixBySize);
 
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues, darkMode },
-                slots: {
-                    component: testComponent.renderedString.trim(),
-                },
-            },
-        );
-    }
+    componentSizes.forEach((size) => {
+        test(`should render all prop variations for Variant: ${variant} and Size: ${size}`, async ({ page, mount }) => {
+            const combos = componentPropsMatrixBySize[size];
 
-    // Follow up to remove in Jan
-    await page.waitForTimeout(2500);
+            for (const combo of combos) {
+                const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieButton);
+                const propKeyValues = `size: ${testComponent.propValues.size}, iconPlacement: ${testComponent.propValues.iconPlacement}, isFullWidth: ${testComponent.propValues.isFullWidth}, disabled: ${testComponent.propValues.disabled}, isLoading: ${testComponent.propValues.isLoading}`;
+                const darkMode = ['inverse', 'ghost-inverse', 'outline-inverse'].includes(variant);
 
-    await percySnapshot(page, `PIE Button - Variant: ${variant}`, percyWidths);
-}));
+                await mount(
+                    WebComponentTestWrapper,
+                    {
+                        props: { propKeyValues, darkMode },
+                        slots: {
+                            component: testComponent.renderedString.trim(),
+                        },
+                    },
+                );
+            }
+
+            await page.waitForLoadState('domcontentloaded');
+
+            const snapshotName = `PIE Button - Variant: ${variant} - Size: ${size}`;
+            await percySnapshot(page, snapshotName, percyWidths);
+        });
+    });
+});


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Updated Pie Button tests to split the variations up by size.
- Screenshots should increase from **11** to **47** in number

This is to resolve issues such as:
- Screenshotted variations being cropped due to too large of a screenshot
- Improve screenshot readability and reviewability. 

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed visual test updates properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1 @maledr5 
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2 @kevinrodrigues 
- [x] If there are visual test updates, I have reviewed them
