### PR TITLE
fix(pie-modal): DSW-2322 prevent page lock when modal closed

### DIFF
--- a/.changeset/old-eyes-itch.md
+++ b/.changeset/old-eyes-itch.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Fixed] - Ensure modals always remove any page scroll-locks when disconnected

--- a/yarn.lock
+++ b/yarn.lock
@@ -5250,83 +5250,83 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-assistive-text@0.7.1, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
+"@justeattakeaway/pie-assistive-text@0.7.2, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.49.1, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.49.2, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-spinner": 0.7.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-spinner": 0.7.1
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
     element-internals-polyfill: 1.3.11
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.20.1, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.21.1, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-checkbox-group@0.7.0, @justeattakeaway/pie-checkbox-group@workspace:packages/components/pie-checkbox-group":
+"@justeattakeaway/pie-checkbox-group@0.7.1, @justeattakeaway/pie-checkbox-group@workspace:packages/components/pie-checkbox-group":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-checkbox-group@workspace:packages/components/pie-checkbox-group"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.1
+    "@justeattakeaway/pie-assistive-text": 0.7.2
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-checkbox@0.13.0, @justeattakeaway/pie-checkbox@workspace:packages/components/pie-checkbox":
+"@justeattakeaway/pie-checkbox@0.13.1, @justeattakeaway/pie-checkbox@workspace:packages/components/pie-checkbox":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-checkbox@workspace:packages/components/pie-checkbox"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.1
+    "@justeattakeaway/pie-assistive-text": 0.7.2
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-chip@0.8.3, @justeattakeaway/pie-chip@workspace:packages/components/pie-chip":
+"@justeattakeaway/pie-chip@0.8.4, @justeattakeaway/pie-chip@workspace:packages/components/pie-chip":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-chip@workspace:packages/components/pie-chip"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-spinner": 0.7.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-spinner": 0.7.1
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
@@ -5343,20 +5343,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@0.26.5, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@0.26.6, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-button": 0.49.1
+    "@justeattakeaway/pie-button": 0.49.2
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-divider": 0.14.0
-    "@justeattakeaway/pie-icon-button": 0.28.12
-    "@justeattakeaway/pie-link": 0.18.0
-    "@justeattakeaway/pie-modal": 0.47.0
-    "@justeattakeaway/pie-switch": 0.30.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-divider": 0.14.1
+    "@justeattakeaway/pie-icon-button": 0.28.13
+    "@justeattakeaway/pie-link": 0.18.1
+    "@justeattakeaway/pie-modal": 0.47.1
+    "@justeattakeaway/pie-switch": 0.30.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -5374,29 +5374,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-divider@0.14.0, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
+"@justeattakeaway/pie-divider@0.14.1, @justeattakeaway/pie-divider@workspace:packages/components/pie-divider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-divider@workspace:packages/components/pie-divider"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.14.1, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.14.2, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-switch": 0.30.1
-    "@justeattakeaway/pie-text-input": 0.24.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-switch": 0.30.2
+    "@justeattakeaway/pie-text-input": 0.24.1
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -5408,16 +5408,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.28.12, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.28.13, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-spinner": 0.7.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-spinner": 0.7.1
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -5471,14 +5471,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icons-webc@0.25.1, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
+"@justeattakeaway/pie-icons-webc@0.25.2, @justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icons-webc@workspace:packages/tools/pie-icons-webc"
   dependencies:
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-icons": 4.19.1
     "@justeattakeaway/pie-icons-configs": 4.5.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@rollup/plugin-typescript": 11.1.6
     "@web/test-runner": 0.16.1
     just-kebab-case: 4.2.0
@@ -5506,46 +5506,46 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.18.0, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.18.1, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-lottie-player@0.0.2, @justeattakeaway/pie-lottie-player@workspace:packages/components/pie-lottie-player":
+"@justeattakeaway/pie-lottie-player@0.0.3, @justeattakeaway/pie-lottie-player@workspace:packages/components/pie-lottie-player":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-lottie-player@workspace:packages/components/pie-lottie-player"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
     lottie-web: 5.12.2
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.47.0, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.47.1, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeat/pie-design-tokens": 6.5.0
-    "@justeattakeaway/pie-button": 0.49.1
+    "@justeattakeaway/pie-button": 0.49.2
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icon-button": 0.28.12
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-spinner": 0.7.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icon-button": 0.28.13
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-spinner": 0.7.1
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     "@types/body-scroll-lock": 3.1.2
     body-scroll-lock: 3.1.5
@@ -5554,134 +5554,134 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-notification@0.12.0, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
+"@justeattakeaway/pie-notification@0.12.1, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icon-button": 0.28.12
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icon-button": 0.28.13
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio-group@0.1.0, @justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group":
+"@justeattakeaway/pie-radio-group@0.1.1, @justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio@0.1.0, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
+"@justeattakeaway/pie-radio@0.2.1, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio@workspace:packages/components/pie-radio"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-spinner@0.7.0, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
+"@justeattakeaway/pie-spinner@0.7.1, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-switch@0.30.1, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
+"@justeattakeaway/pie-switch@0.30.2, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
     element-internals-polyfill: 1.3.11
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-tag@0.10.0, @justeattakeaway/pie-tag@workspace:packages/components/pie-tag":
+"@justeattakeaway/pie-tag@0.10.1, @justeattakeaway/pie-tag@workspace:packages/components/pie-tag":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-tag@workspace:packages/components/pie-tag"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-text-input@0.24.0, @justeattakeaway/pie-text-input@workspace:packages/components/pie-text-input":
+"@justeattakeaway/pie-text-input@0.24.1, @justeattakeaway/pie-text-input@workspace:packages/components/pie-text-input":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-text-input@workspace:packages/components/pie-text-input"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.1
+    "@justeattakeaway/pie-assistive-text": 0.7.2
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@justeattakeaway/pie-wrapper-react": 0.14.1
     cem-plugin-module-file-extensions: 0.0.5
     element-internals-polyfill: 1.3.11
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-textarea@0.10.0, @justeattakeaway/pie-textarea@workspace:packages/components/pie-textarea":
+"@justeattakeaway/pie-textarea@0.10.1, @justeattakeaway/pie-textarea@workspace:packages/components/pie-textarea":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-textarea@workspace:packages/components/pie-textarea"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-form-label": 0.14.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-form-label": 0.14.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     "@types/lodash.throttle": 4.1.9
     cem-plugin-module-file-extensions: 0.0.5
     lodash.throttle: 4.1.1
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-toast@0.3.3, @justeattakeaway/pie-toast@workspace:packages/components/pie-toast":
+"@justeattakeaway/pie-toast@0.3.4, @justeattakeaway/pie-toast@workspace:packages/components/pie-toast":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-toast@workspace:packages/components/pie-toast"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-button": 0.49.1
+    "@justeattakeaway/pie-button": 0.49.2
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icon-button": 0.28.12
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-icon-button": 0.28.13
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc-core": 0.24.1
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc-core@0.24.0, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
+"@justeattakeaway/pie-webc-core@0.24.1, @justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc-core@workspace:packages/components/pie-webc-core"
   dependencies:
@@ -5701,33 +5701,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.5.36, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.5.38, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.7.1
-    "@justeattakeaway/pie-button": 0.49.1
-    "@justeattakeaway/pie-card": 0.20.1
-    "@justeattakeaway/pie-checkbox": 0.13.0
-    "@justeattakeaway/pie-checkbox-group": 0.7.0
-    "@justeattakeaway/pie-chip": 0.8.3
+    "@justeattakeaway/pie-assistive-text": 0.7.2
+    "@justeattakeaway/pie-button": 0.49.2
+    "@justeattakeaway/pie-card": 0.21.1
+    "@justeattakeaway/pie-checkbox": 0.13.1
+    "@justeattakeaway/pie-checkbox-group": 0.7.1
+    "@justeattakeaway/pie-chip": 0.8.4
     "@justeattakeaway/pie-components-config": 0.18.0
-    "@justeattakeaway/pie-cookie-banner": 0.26.5
-    "@justeattakeaway/pie-divider": 0.14.0
-    "@justeattakeaway/pie-form-label": 0.14.1
-    "@justeattakeaway/pie-icon-button": 0.28.12
-    "@justeattakeaway/pie-link": 0.18.0
-    "@justeattakeaway/pie-lottie-player": 0.0.2
-    "@justeattakeaway/pie-modal": 0.47.0
-    "@justeattakeaway/pie-notification": 0.12.0
-    "@justeattakeaway/pie-radio": 0.1.0
-    "@justeattakeaway/pie-radio-group": 0.1.0
-    "@justeattakeaway/pie-spinner": 0.7.0
-    "@justeattakeaway/pie-switch": 0.30.1
-    "@justeattakeaway/pie-tag": 0.10.0
-    "@justeattakeaway/pie-text-input": 0.24.0
-    "@justeattakeaway/pie-textarea": 0.10.0
-    "@justeattakeaway/pie-toast": 0.3.3
+    "@justeattakeaway/pie-cookie-banner": 0.26.6
+    "@justeattakeaway/pie-divider": 0.14.1
+    "@justeattakeaway/pie-form-label": 0.14.2
+    "@justeattakeaway/pie-icon-button": 0.28.13
+    "@justeattakeaway/pie-link": 0.18.1
+    "@justeattakeaway/pie-lottie-player": 0.0.3
+    "@justeattakeaway/pie-modal": 0.47.1
+    "@justeattakeaway/pie-notification": 0.12.1
+    "@justeattakeaway/pie-radio": 0.2.1
+    "@justeattakeaway/pie-radio-group": 0.1.1
+    "@justeattakeaway/pie-spinner": 0.7.1
+    "@justeattakeaway/pie-switch": 0.30.2
+    "@justeattakeaway/pie-tag": 0.10.1
+    "@justeattakeaway/pie-text-input": 0.24.1
+    "@justeattakeaway/pie-textarea": 0.10.1
+    "@justeattakeaway/pie-toast": 0.3.4
     chalk: 5.3.0
   bin:
     add-components: ./src/index.js
@@ -26070,31 +26070,31 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 6.5.0
-    "@justeattakeaway/pie-assistive-text": 0.7.1
-    "@justeattakeaway/pie-button": 0.49.1
-    "@justeattakeaway/pie-card": 0.20.1
-    "@justeattakeaway/pie-checkbox": 0.13.0
-    "@justeattakeaway/pie-checkbox-group": 0.7.0
-    "@justeattakeaway/pie-chip": 0.8.3
-    "@justeattakeaway/pie-cookie-banner": 0.26.5
+    "@justeattakeaway/pie-assistive-text": 0.7.2
+    "@justeattakeaway/pie-button": 0.49.2
+    "@justeattakeaway/pie-card": 0.21.1
+    "@justeattakeaway/pie-checkbox": 0.13.1
+    "@justeattakeaway/pie-checkbox-group": 0.7.1
+    "@justeattakeaway/pie-chip": 0.8.4
+    "@justeattakeaway/pie-cookie-banner": 0.26.6
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-divider": 0.14.0
-    "@justeattakeaway/pie-form-label": 0.14.1
-    "@justeattakeaway/pie-icon-button": 0.28.12
+    "@justeattakeaway/pie-divider": 0.14.1
+    "@justeattakeaway/pie-form-label": 0.14.2
+    "@justeattakeaway/pie-icon-button": 0.28.13
     "@justeattakeaway/pie-icons-configs": 4.5.1
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-link": 0.18.0
-    "@justeattakeaway/pie-lottie-player": 0.0.2
-    "@justeattakeaway/pie-modal": 0.47.0
-    "@justeattakeaway/pie-notification": 0.12.0
-    "@justeattakeaway/pie-radio": 0.1.0
-    "@justeattakeaway/pie-radio-group": 0.1.0
-    "@justeattakeaway/pie-spinner": 0.7.0
-    "@justeattakeaway/pie-switch": 0.30.1
-    "@justeattakeaway/pie-tag": 0.10.0
-    "@justeattakeaway/pie-text-input": 0.24.0
-    "@justeattakeaway/pie-textarea": 0.10.0
-    "@justeattakeaway/pie-toast": 0.3.3
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-link": 0.18.1
+    "@justeattakeaway/pie-lottie-player": 0.0.3
+    "@justeattakeaway/pie-modal": 0.47.1
+    "@justeattakeaway/pie-notification": 0.12.1
+    "@justeattakeaway/pie-radio": 0.2.1
+    "@justeattakeaway/pie-radio-group": 0.1.1
+    "@justeattakeaway/pie-spinner": 0.7.1
+    "@justeattakeaway/pie-switch": 0.30.2
+    "@justeattakeaway/pie-tag": 0.10.1
+    "@justeattakeaway/pie-text-input": 0.24.1
+    "@justeattakeaway/pie-textarea": 0.10.1
+    "@justeattakeaway/pie-toast": 0.3.4
     "@storybook/addon-a11y": 8.3.0
     "@storybook/addon-designs": 8.0.3
     "@storybook/addon-essentials": 8.3.0
@@ -33938,7 +33938,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -33955,7 +33955,7 @@ __metadata:
     "@babel/preset-env": 7.24.5
     "@babel/preset-react": 7.24.1
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     "@lit/react": 1.0.2
     babel-loader: 8
     eslint: 8.37.0
@@ -33972,7 +33972,7 @@ __metadata:
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
@@ -33995,7 +33995,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -34010,7 +34010,7 @@ __metadata:
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     "@types/node": 18
     nuxt: 3.4.3
     nuxt-ssr-lit: 1.6.5
@@ -34022,7 +34022,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -34042,7 +34042,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -34063,8 +34063,8 @@ __metadata:
   dependencies:
     "@justeat/pie-design-tokens": 6.5.0
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-icons-webc": 0.25.1
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-icons-webc": 0.25.2
+    "@justeattakeaway/pie-webc": 0.5.38
     vite: 5.3.6
   languageName: unknown
   linkType: soft
@@ -34074,7 +34074,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.0
-    "@justeattakeaway/pie-webc": 0.5.36
+    "@justeattakeaway/pie-webc": 0.5.38
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
**Validated in an internal application where the bug was first spotted - this seems to fix it!**

### Summary

This PR updates the modal's `disconnectedCallback` lifecycle method to ensure any scroll locks applied to the page are properly removed. Previously, scroll locks were only removed when the modal was closed via user interaction.

While this worked for most use cases, it introduced an edge-case bug: when a modal was destroyed directly, the scroll lock remained on the page because the reference to the destroyed element was lost, making it impossible to remove the lock.

With this update, modals will now reliably clean up scroll locks upon destruction.

### Additional improvements

- Utilised `AbortController` to simplify the cleanup of `EventListeners`, reducing code complexity.
- Ensured that `EventListeners` attached to the dialog element are also removed, though they were likely previously harmless due to the dialog being destroyed along with the modal.
- Used the `!` non-null assertion operator for the dialog property to remove unnecessary optional chaining. This is safe, as the modal always has the dialog element when running.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1 @raoufswe 
- [x] I have reviewed the `PIE Storybook` PR preview

### Reviewer 2 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview
