### PR TITLE
fix(pie-modal): DSW-2218 stop esc closing modal (isDismissible=false)

### DIFF
--- a/.changeset/eleven-tigers-happen.md
+++ b/.changeset/eleven-tigers-happen.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Fixed] - Prevent esc key from closing modal when isDismissible is false

--- a/.changeset/tricky-apes-think.md
+++ b/.changeset/tricky-apes-think.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Fixed] - Prevent entire modal from re-rendering when the headingLevel property is changed

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -144,8 +144,6 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     }
 
     async firstUpdated (changedProperties: PropertyValues<this>): Promise<void> {
-        super.firstUpdated(changedProperties);
-
         const dialogPolyfill = await import('dialog-polyfill').then((module) => module.default);
         dialogPolyfill.registerDialog(this._dialog);
         const { signal } = this._abortController;
@@ -158,7 +156,6 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
     }
 
     updated (changedProperties: PropertyValues<this>): void {
-        super.updated(changedProperties);
         this._handleModalOpenStateChanged(changedProperties);
         this._handleIsDismissibleChanged(changedProperties);
     }

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -473,11 +473,24 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
             ${this.renderModalFooter()}`;
     }
 
+    /**
+     * Renders the modal heading content in the correct heading tag
+     * @private
+     */
+    private renderHeading (): TemplateResult {
+        const { heading, headingLevel } = this;
+        const headingTag = unsafeStatic(headingLevel);
+
+        return html`
+            <${headingTag} class="c-modal-heading">
+                ${heading}
+            </${headingTag}>
+        `;
+    }
+
     render () {
         const {
             aria,
-            heading,
-            headingLevel,
             isDismissible,
             isFooterPinned,
             isFullWidthBelowMid,
@@ -486,7 +499,6 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
             size,
         } = this;
 
-        const headingTag = unsafeStatic(headingLevel);
         const ariaLabel = (isLoading && aria?.loading) || undefined;
 
         const modalClasses = {
@@ -506,12 +518,9 @@ export class PieModal extends RtlMixin(LitElement) implements ModalProps {
             aria-busy="${isLoading ? 'true' : 'false'}"
             aria-label="${ifDefined(ariaLabel)}"
             data-test-id="pie-modal">
-            <header class="c-modal-header"
-            data-test-id="modal-header">
+            <header class="c-modal-header" data-test-id="modal-header">
                 ${this.renderBackButton()}
-                <${headingTag} class="c-modal-heading">
-                    ${heading}
-                </${headingTag}>
+                ${this.renderHeading()}
                 ${this.renderCloseButton()}
             </header>
             ${

--- a/packages/components/pie-modal/test/component/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/component/pie-modal.spec.ts
@@ -419,8 +419,7 @@ test.describe('modal', () => {
                 expect(isModalVisible).toBe(true);
             });
 
-            // To be addressed in ticket DSW-2218
-            test.skip('should NOT close the modal when the Escape key is pressed', async ({ mount, page }) => {
+            test('should NOT close the modal when the Escape key is pressed', async ({ mount, page }) => {
                 // Arrange
                 await mount(
                     PieModal,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5574,7 +5574,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio@0.2.2, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
+"@justeattakeaway/pie-radio@0.3.0, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio@workspace:packages/components/pie-radio"
   dependencies:
@@ -5694,7 +5694,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.5.41, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.5.42, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
@@ -5713,7 +5713,7 @@ __metadata:
     "@justeattakeaway/pie-lottie-player": 0.0.4
     "@justeattakeaway/pie-modal": 0.48.1
     "@justeattakeaway/pie-notification": 0.12.2
-    "@justeattakeaway/pie-radio": 0.2.2
+    "@justeattakeaway/pie-radio": 0.3.0
     "@justeattakeaway/pie-radio-group": 0.1.2
     "@justeattakeaway/pie-spinner": 0.7.2
     "@justeattakeaway/pie-switch": 0.30.3
@@ -26023,7 +26023,7 @@ __metadata:
     "@justeattakeaway/pie-lottie-player": 0.0.4
     "@justeattakeaway/pie-modal": 0.48.1
     "@justeattakeaway/pie-notification": 0.12.2
-    "@justeattakeaway/pie-radio": 0.2.2
+    "@justeattakeaway/pie-radio": 0.3.0
     "@justeattakeaway/pie-radio-group": 0.1.2
     "@justeattakeaway/pie-spinner": 0.7.2
     "@justeattakeaway/pie-switch": 0.30.3
@@ -33874,7 +33874,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -33891,7 +33891,7 @@ __metadata:
     "@babel/preset-env": 7.24.5
     "@babel/preset-react": 7.24.1
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     "@lit/react": 1.0.2
     babel-loader: 8
     eslint: 8.57.0
@@ -33908,7 +33908,7 @@ __metadata:
   resolution: "wc-next13@workspace:apps/examples/wc-next13"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
@@ -33931,7 +33931,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -33946,7 +33946,7 @@ __metadata:
   resolution: "wc-nuxt3@workspace:apps/examples/wc-nuxt3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     "@types/node": 18
     nuxt: 3.4.3
     nuxt-ssr-lit: 1.6.5
@@ -33958,7 +33958,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -33978,7 +33978,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -34000,7 +34000,7 @@ __metadata:
     "@justeat/pie-design-tokens": 6.5.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 0.25.3
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     vite: 5.3.6
   languageName: unknown
   linkType: soft
@@ -34010,7 +34010,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.41
+    "@justeattakeaway/pie-webc": 0.5.42
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Prevents `Escape` key presses from closing the modal when `iDismissible` is set to false
- Applies the same protection against reactive changes to the `isDismissible` property
- Enables the previously skipped test that captured the bug

### How to test
1. Go to the default Modal story in the Storybook preview deploy
2. Try pressing escape
3. The Modal should close
4. Now set the `isDismissible` control to `false`
5. Try pressing escape
6. The Modal should not close
7. Try various combinations to see if lifecycle changes affect the behaviour (they don't when I have tested but worth a second person checking)

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1 - Fernando
- [x] I have reviewed the `PIE Storybook` PR preview

### Reviewer 2 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview
