### PR TITLE
fix(pie-textarea): DSW-2470 allow resize on programmatic value change

### DIFF
--- a/.changeset/sweet-seahorses-dream.md
+++ b/.changeset/sweet-seahorses-dream.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-textarea": minor
+---
+
+[Fixed] - Ensure textarea resizing is triggered when value is programmatically updated

--- a/packages/components/pie-textarea/src/index.ts
+++ b/packages/components/pie-textarea/src/index.ts
@@ -145,8 +145,7 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
 
     protected updated (changedProperties: PropertyValues<this>) {
         if (changedProperties.has('value')) {
-            this.restrictInputLength();
-            this._internals.setFormValue(this.value);
+            this.handleInput(null, this.value);
         }
 
         if (this.resize === 'auto' && (changedProperties.has('resize') || changedProperties.has('size'))) {
@@ -158,8 +157,13 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
      * Handles data processing in response to the input event. The native input event is left to bubble up.
      * @param event - The input event.
      */
-    private handleInput = (event: InputEvent) => {
-        this.value = (event.target as HTMLTextAreaElement).value;
+    private handleInput = (event: InputEvent | null, newValue?: string) => {
+        if (event) {
+            this.value = (event.target as HTMLTextAreaElement).value;
+        } else if (newValue) {
+            this.value = newValue;
+        }
+
         this.restrictInputLength();
         this._internals.setFormValue(this.value);
 

--- a/packages/components/pie-textarea/src/index.ts
+++ b/packages/components/pie-textarea/src/index.ts
@@ -154,8 +154,13 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
     }
 
     /**
-     * Handles data processing in response to the input event. The native input event is left to bubble up.
-     * @param event - The input event.
+     * Handles input events and updates the component's value based on the input event or a provided new value.
+     *
+     * @param {InputEvent | null} event - The input event triggered by user interaction. If null, the `newValue` is used.
+     * @param {string} [newValue] - An optional new value to set if the event is not provided.
+     *
+     * @private
+     * @returns {void}
      */
     private handleInput = (event: InputEvent | null, newValue?: string) => {
         if (event) {

--- a/packages/components/pie-textarea/test/visual/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/visual/pie-textarea.spec.ts
@@ -159,6 +159,23 @@ test.describe('Resize mode:', () => {
             await percySnapshot(page, 'Textarea - resize: "auto" (multiline content)', percyWidths);
         });
 
+        test('should resize the textarea vertically when value updated programmatically - @mobile', async ({ page, mount }) => {
+            await mount(PieTextarea, {
+                props: {
+                    resize: 'auto',
+                } as PieTextarea,
+            });
+
+            await page.evaluate(() => {
+                const textarea = document.querySelector('pie-textarea') as PieTextarea;
+                textarea.value = 'The default height is enough for two lines of text, but it should grow if you type more.';
+            });
+
+            await page.waitForTimeout(250); // Wait for throttled resize event to fire.
+
+            await percySnapshot(page, 'Textarea - resize: "auto programmatic" (multiline content)', percyWidths);
+        });
+
         test('should overflow when content exceeds maximum height - @mobile', async ({ page, mount }) => {
             await mount(PieTextarea, {
                 props: {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Ensures that when the `value` property is updated programmatically (e.g., through a Storybook control), the text area resizes correctly, just as it would if a user were typing directly into the input.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1 - Fernando
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2 - @kevinrodrigues 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them
