### PR TITLE
fix(pie-tag): DSW-2465 update active and hover tokens for brand-06

### DIFF
--- a/.changeset/fluffy-pears-decide.md
+++ b/.changeset/fluffy-pears-decide.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-tag": patch
+---
+
+[Fixed] - hover and active state of brand-06 should use hover-02 and active-02 tokens

--- a/packages/components/pie-tag/src/tag.scss
+++ b/packages/components/pie-tag/src/tag.scss
@@ -162,7 +162,7 @@
     &.c-tag--brand-06 {
         --tag-bg-color: var(--dt-color-support-brand-06);
         --tag-color: var(--dt-color-content-light);
-        @include tag-interactive-states('--dt-color-support-brand-06');
+        @include tag-interactive-states('--dt-color-support-brand-06', 'inverse');
     }
 
     &.c-tag--brand {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] - hover and active state of brand-06 should use hover-02 and active-02 tokens

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] I have reviewed visual test updates properly before approving

## Reviewer checklists (complete before approving)
### Reviewer 1
- [x] I have reviewed the `PIE Storybook` PR preview
- [x] If there are visual test updates, I have reviewed them

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If there are visual test updates, I have reviewed them
