### PR TITLE
docs(pie-cookie-banner): DSW-000 bump version to stable

### DIFF
--- a/packages/components/pie-cookie-banner/package.json
+++ b/packages/components/pie-cookie-banner/package.json
@@ -14,7 +14,7 @@
     "**/*.d.ts"
   ],
   "pieMetadata": {
-    "componentStatus": "beta"
+    "componentStatus": "stable"
   },
   "scripts": {
     "build": "run -T vite build",


### PR DESCRIPTION
- Just bumps the cookie banner version to `stable`