### PR TITLE
feat(pie-storybook): DSW-000 add isVisuallyHidden to the assistive text stories

### DIFF
--- a/.changeset/pink-trees-complain.md
+++ b/.changeset/pink-trees-complain.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": patch
+---
+
+[Added] - Added isVisuallyHidden control to the assistive text stories

--- a/apps/pie-storybook/stories/pie-assistive-text.stories.ts
+++ b/apps/pie-storybook/stories/pie-assistive-text.stories.ts
@@ -28,6 +28,13 @@ const assistiveTextStoryMeta: AssistiveTextStoryMeta = {
                 summary: defaultProps.variant,
             },
         },
+        isVisuallyHidden: {
+            description: 'If true, hides the component visually but leaves it accessible for a11y technologies.',
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.isVisuallyHidden,
+            },
+        },
         slot: {
             description: 'Content to place within the assistive-text',
             control: 'text',
@@ -46,10 +53,12 @@ export default assistiveTextStoryMeta;
 
 const Template : TemplateFunction<AssistiveTextProps> = ({
     variant,
+    isVisuallyHidden,
     slot,
 }) => html`
     <pie-assistive-text
-        variant="${ifDefined(variant)}">
+        variant="${ifDefined(variant)}"
+        ?isVisuallyHidden="${isVisuallyHidden}">
         ${sanitizeAndRenderHTML(slot)}
     </pie-assistive-text>
 `;

--- a/apps/pie-storybook/stories/pie-assistive-text.stories.ts
+++ b/apps/pie-storybook/stories/pie-assistive-text.stories.ts
@@ -29,7 +29,7 @@ const assistiveTextStoryMeta: AssistiveTextStoryMeta = {
             },
         },
         isVisuallyHidden: {
-            description: 'If true, hides the component visually but leaves it accessible for a11y technologies.',
+            description: 'If true, hides the component visually but leaves it accessible for screen readers.',
             control: 'boolean',
             defaultValue: {
                 summary: defaultProps.isVisuallyHidden,


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

While working on my radio ticket, I noticed that the `isVisuallyHidden` in the pie-assistive-text component stories wasn't bound / hooked correctly. This PR is to fix that. 

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

## Reviewer checklists (complete before approving)
### Reviewer 1 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
