### PR TITLE
fix(stylelint-config-pie): DSW-000 add js extension to rule imports for ESM compat

### DIFF
--- a/.changeset/tricky-ads-allow.md
+++ b/.changeset/tricky-ads-allow.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/stylelint-config-pie": minor
+---
+
+[Changed] - Add file extensions to rule imports

--- a/packages/tools/stylelint-config-pie/index.js
+++ b/packages/tools/stylelint-config-pie/index.js
@@ -1,6 +1,7 @@
-import baseRules from './rules/base';
-import strictRules from './rules/strict';
-import orderingRules from './rules/ordering';
+/* eslint-disable import/extensions */
+import baseRules from './rules/base.js';
+import strictRules from './rules/strict.js';
+import orderingRules from './rules/ordering.js';
 
 export default {
     extends: [


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- [Changed] - Add file extensions to rule imports

Fixes issue in native ESM environments, where without the prefix, it throws an error.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

