### PR TITLE
fix(pie-tag): DSW-2524 fix interactive tags don't use the pointer cursor

### DIFF
--- a/.changeset/pretty-dryers-sneeze.md
+++ b/.changeset/pretty-dryers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-tag": patch
+---
+
+[Fixed] - use pointer cursor for interactive tags

--- a/packages/components/pie-tag/src/tag.scss
+++ b/packages/components/pie-tag/src/tag.scss
@@ -45,6 +45,7 @@
     --tag-font-weight: var(--dt-font-body-s-weight);
     --tag-font-size: #{p.font-size(--dt-font-body-s-size)};
     --tag-line-height: #{p.line-height(--dt-font-body-s-line-height)};
+    --tag-cursor: text;
 
     // transparent to variable to function properly in component tests
     --tag-transparent-bg-color: transparent;
@@ -66,9 +67,13 @@
     font-weight: var(--tag-font-weight);
     font-size: var(--tag-font-size);
     line-height: var(--tag-line-height);
+    cursor: var(--tag-cursor);
 
     &.c-tag--interactive {
+        --tag-cursor: pointer;
+
         border: none;
+        user-select: none;
 
         &:focus-visible {
             @include p.focus;
@@ -199,7 +204,7 @@
     }
 
     &[disabled] {
-        cursor: not-allowed;
+        --tag-cursor: not-allowed;
     }
 }
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- adds cursor pointer to interactive tags

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [x] I have added thorough tests where applicable (unit / component / visual)
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Reviewer checklists (complete before approving)
### Reviewer 1 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

### Reviewer 2 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook` PR preview
