### PR TITLE
fix(pie-textarea): DSW-2539 replace label prop with a pie form label

### DIFF
--- a/apps/pie-storybook/stories/pie-textarea.stories.ts
+++ b/apps/pie-storybook/stories/pie-textarea.stories.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { action } from '@storybook/addon-actions';
 import { useArgs as UseArgs } from '@storybook/preview-api';
@@ -28,7 +28,6 @@ const Template = ({
     name,
     autocomplete,
     autoFocus,
-    label,
     maxLength,
     assistiveText,
     status,
@@ -67,7 +66,6 @@ const Template = ({
             ?readonly="${readonly}"
             ?required="${required}"
             maxLength="${ifDefined(maxLength)}"
-            label="${ifDefined(label)}"
             @input="${onInput}"
             @change="${onChange}"
             assistiveText="${ifDefined(assistiveText)}"
@@ -167,15 +165,8 @@ const textareaStoryMeta: TextareaStoryMeta = {
                 summary: 'off',
             },
         },
-        label: {
-            description: 'The label for the textarea field.',
-            control: 'text',
-            defaultValue: {
-                summary: defaultProps.label,
-            },
-        },
         maxLength: {
-            description: 'The maximum number of characters allowed in the textarea field. To apply a length restriction, you must also provide label text.',
+            description: 'The maximum number of characters allowed in the textarea field.',
             control: 'number',
             defaultValue: {
                 summary: 0,
@@ -234,14 +225,23 @@ const ExampleFormTemplate: TemplateFunction<TextareaProps> = () => html`
     </form>
 `;
 
+const WithLabelTemplate: TemplateFunction<TextareaProps> = (props: TextareaProps) => html`
+        <p>Please note, the label is a separate component. See <pie-link href="/?path=/story/form-label">pie-form-label</pie-link>.</p>
+        <pie-form-label for="${ifDefined(props.name)}" trailing="${props.maxLength ? `${props.value.length}/${props.maxLength}` : nothing}">Label</pie-form-label>
+        ${Template(props)}
+    `;
+
 const CreateTextareaStory = createStory<TextareaProps>(Template, defaultArgs);
 const CreateTextareaStoryWithForm = createStory<TextareaProps>(ExampleFormTemplate, defaultArgs);
+const createStoryWithLabel = (props: TextareaProps) => createStory<TextareaProps>(WithLabelTemplate, props);
 
 export const Default = CreateTextareaStory({}, {
     argTypes: {
         defaultValue: { table: { readonly: true }, description: 'This prop only works when the textarea is inside a form. To interact with this, view the Example Form story.' },
     },
 });
+
+export const WithLabel = createStoryWithLabel(defaultArgs)();
 
 export const ExampleForm = CreateTextareaStoryWithForm();
 

--- a/packages/components/pie-textarea/src/defs.ts
+++ b/packages/components/pie-textarea/src/defs.ts
@@ -72,13 +72,7 @@ export interface TextareaProps {
     required?: boolean;
 
     /**
-    * The label text for the textarea field.
-    */
-    label?: string;
-
-    /**
      * The maximum number of characters allowed in the textarea field.
-     * If the `label` property is not set, this property will have no effect.
      */
     maxLength?: number;
 
@@ -100,7 +94,6 @@ export const defaultProps: DefaultProps = {
     disabled: false,
     size: 'medium',
     resize: 'auto',
-    label: '',
     value: '',
     placeholder: '',
     status: 'default',

--- a/packages/components/pie-textarea/src/index.ts
+++ b/packages/components/pie-textarea/src/index.ts
@@ -8,7 +8,6 @@ import { live } from 'lit/directives/live.js';
 import throttle from 'lodash.throttle';
 
 import '@justeattakeaway/pie-assistive-text';
-import '@justeattakeaway/pie-form-label';
 import {
     validPropertyValues, RtlMixin, defineCustomElement, FormControlMixin, wrapNativeEvent, type PIEInputElement,
 } from '@justeattakeaway/pie-webc-core';
@@ -48,9 +47,6 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
     @property({ type: String })
     @validPropertyValues(componentSelector, resizeModes, defaultProps.resize)
     public resize = defaultProps.resize;
-
-    @property({ type: String })
-    public label = defaultProps.label;
 
     @property({ type: Number })
     public maxLength: TextareaProps['maxLength'];
@@ -122,7 +118,6 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
     }
 
     protected firstUpdated (): void {
-        this.restrictInputLength();
         this._internals.setFormValue(this.value);
 
         window.addEventListener('resize', () => this.handleResize());
@@ -131,16 +126,6 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
 
     private handleResize () {
         this._throttledResize();
-    }
-
-    private restrictInputLength () {
-        if (this.label.length && this.maxLength && this.value.length > this.maxLength) {
-            const trimmedValue = this.value.slice(0, this.maxLength);
-            // Ensures that the internal text area is correctly trimmed and synced with our value.
-            // The live() directive does not solve this for us.
-            this._textarea.value = trimmedValue;
-            this.value = trimmedValue;
-        }
     }
 
     protected updated (changedProperties: PropertyValues<this>) {
@@ -169,7 +154,6 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
             this.value = newValue;
         }
 
-        this.restrictInputLength();
         this._internals.setFormValue(this.value);
 
         this.handleResize();
@@ -194,14 +178,6 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
     public disconnectedCallback (): void {
         this._textarea.removeEventListener('keydown', this.handleKeyDown);
         window.removeEventListener('resize', () => this.handleResize());
-    }
-
-    renderLabel (label: string, maxLength?: number) {
-        const characterCount = maxLength ? `${this.value.length}/${maxLength}` : undefined;
-
-        return label?.length
-            ? html`<pie-form-label for="${componentSelector}" trailing=${ifDefined(characterCount)}>${label}</pie-form-label>`
-            : nothing;
     }
 
     renderAssistiveText () {
@@ -231,7 +207,6 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
             placeholder,
             value,
             required,
-            label,
             maxLength,
             status,
             assistiveText,
@@ -247,8 +222,7 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
         };
 
         return html`<div>
-            ${this.renderLabel(label, maxLength)}
-            <div
+                <div
                 class="${classMap(classes)}"
                 data-test-id="pie-textarea-wrapper">
                 <textarea
@@ -262,13 +236,14 @@ export class PieTextarea extends FormControlMixin(RtlMixin(LitElement)) implemen
                     ?readonly=${readonly}
                     ?required=${required}
                     ?disabled=${disabled}
+                    maxlength=${ifDefined(maxLength)}
                     aria-describedby=${ifDefined(assistiveText ? assistiveTextIdValue : undefined)}
                     aria-invalid=${status === 'error' ? 'true' : 'false'}
                     aria-errormessage="${ifDefined(status === 'error' ? assistiveTextIdValue : undefined)}"
                     @input=${this.handleInput}
                     @change=${this.handleChange}
                 ></textarea>
-            </div>
+                </div>
             ${this.renderAssistiveText()}
         </div>`;
     }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

This PR is a draft version of how we can replace the label prop in the `pie-textarea` component with an approach similar to the `pie-text-field`, where consumers are expected to import and use the `pie-form-label` component separately to render the label.

The following are some key points to consider outlined in the spike ticket with answers: 

- How should maxLength work if the label is no longer inside the textarea?
The presentation layer can be offloaded to the consumer, where they need to pass the text for displaying the total remaining characters to the `trailing` prop of the `form-label` component. The validation logic should be handled by browsers using the `maxlength` attribute ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength)) when it's passed as a prop. 

- Is it realistic to expect consumers to handle this including formatting and any RTL logic? (e.g., 0/50 should still appear the same in RTL, rather than 50/0).
I believe yes, consumers just need to listen to the change or input event and use the value prop's length to determine the current character count similar to how it's handled in the label story in this PR. About RTL, browsers automatically maintain the order of the text and won’t swap it

<img width="534" alt="Screenshot 2024-11-01 at 15 45 53" src="https://github.com/user-attachments/assets/e113f9f7-7ba8-41aa-b821-f31abd3502be">

- Should maxLength be removed from pie-textarea?
no, because we need to offload the max length validation to the browser by relying on the [maxlength](https://www.w3schools.com/tags/att_textarea_maxlength.asp) attribute 

Overall, the approach seems feasible and will simplify the component while providing a consistent API similar to other form elements.
 
## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests where applicable (unit / component / visual)
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
