### PR TITLE
fix(pie-storybook): DSW-2321 updated pre-load in the preview-head.html in storybook

### DIFF
--- a/apps/pie-storybook/.storybook/preview-head.html
+++ b/apps/pie-storybook/.storybook/preview-head.html
@@ -1,9 +1,34 @@
-<script>
-    window.global = window;
-</script>
+<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Bold-optimised.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-ExtraBold-optimised.woff2" as="font" type="font/woff2" crossorigin>
 <style>
+    @font-face {
+        font-family: JETSansDigital;
+        src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff2') format("woff2"),
+        url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Regular-optimised.woff') format("woff");
+        font-weight: 400;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: JETSansDigital;
+        src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Bold-optimised.woff2') format("woff2"),
+        url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-Bold-optimised.woff') format("woff");
+        font-weight: 700;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: JETSansDigital;
+        src: url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-ExtraBold-optimised.woff2') format("woff2"),
+        url('https://d30v2pzvrfyzpo.cloudfront.net/fonts/JETSansDigital-ExtraBold-optimised.woff') format("woff");
+        font-weight: 800;
+        font-display: swap;
+    }
     body {
+        font-feature-settings: "tnum"; /* Enable tabular numbers */
         color: var(--dt-color-content-default);
         font-family: var(--dt-font-interactive-l-family);
     }
 </style>
+<script>
+    window.global = window;
+</script>


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Added pre-loading on fonts in the `preview-head.html` file.
- This fixes a [future issue ](https://percy.io/4bc223d1/web/pie-divider/builds/37245666/changed/2029639200?browser=safari&browser_ids=59%2C60%2C63&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&test_case_ids=&viewLayout=overlay&viewMode=new&width=375&widths=375) of fonts not loading in storybook when Percy screenshots are made.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code

## Reviewer checklists (complete before approving)
### Reviewer 1 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
