### PR TITLE
feat(pie-cookie-banner): DSW-2562 add locales to package dist

### DIFF
--- a/.changeset/hot-buses-switch.md
+++ b/.changeset/hot-buses-switch.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-cookie-banner": minor
+---
+
+[Added] - Locale files to package `dist`

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,7 +38,8 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.GITHUB_REF_NAME,
+                  'pie-branch': process.env.PIE_BRANCH,
+                  'pie-pr-number': process.env.PIE_PR_NUMBER,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,8 +38,7 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.PIE_BRANCH,
-                  'pie-pr-number': process.env.PIE_PR_NUMBER,
+                  'pie-branch': process.env.GITHUB_REF_NAME,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/packages/components/pie-cookie-banner/package.json
+++ b/packages/components/pie-cookie-banner/package.json
@@ -10,7 +10,6 @@
     "custom-elements.json",
     "src",
     "dist",
-    "locales",
     "**/*.d.ts"
   ],
   "pieMetadata": {
@@ -40,7 +39,8 @@
     "@justeattakeaway/pie-components-config": "0.18.0",
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-wrapper-react": "0.14.2",
-    "cem-plugin-module-file-extensions": "0.0.5"
+    "cem-plugin-module-file-extensions": "0.0.5",
+    "vite-plugin-static-copy": "2.0.0"
   },
   "dependencies": {
     "@justeattakeaway/pie-button": "0.49.4",

--- a/packages/components/pie-cookie-banner/src/index.ts
+++ b/packages/components/pie-cookie-banner/src/index.ts
@@ -36,7 +36,7 @@ import {
 } from './defs';
 
 import { localiseText, localiseRichText } from './localisation-utils';
-import defaultLocale from '../dist/locales/en-gb.json' assert { type: 'json' };
+import defaultLocale from '../locales/en-gb.json' assert { type: 'json' };
 
 // Valid values available to consumers
 export * from './defs';
@@ -91,7 +91,7 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
     // Dynamically import locale JSON based on country and language
     private async _setLocaleBasedOnCountryAndLanguage (country: CountryCode, language: LanguageCode, fallback = false): Promise<void> {
         try {
-            this._locale = (await import(`../dist/locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, { assert: { type: 'json' } })).default;
+            this._locale = (await import(`../locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, { assert: { type: 'json' } })).default;
         } catch {
             // If loading fails, try using the default language, if that fails fall back to the global default locale
             if (!fallback) {

--- a/packages/components/pie-cookie-banner/src/index.ts
+++ b/packages/components/pie-cookie-banner/src/index.ts
@@ -36,7 +36,7 @@ import {
 } from './defs';
 
 import { localiseText, localiseRichText } from './localisation-utils';
-import defaultLocale from '../locales/en-gb.json' assert { type: 'json' };
+import defaultLocale from '../dist/locales/en-gb.json' assert { type: 'json' };
 
 // Valid values available to consumers
 export * from './defs';
@@ -91,7 +91,7 @@ export class PieCookieBanner extends LitElement implements CookieBannerProps {
     // Dynamically import locale JSON based on country and language
     private async _setLocaleBasedOnCountryAndLanguage (country: CountryCode, language: LanguageCode, fallback = false): Promise<void> {
         try {
-            this._locale = (await import(`../locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, { assert: { type: 'json' } })).default;
+            this._locale = (await import(`../dist/locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, { assert: { type: 'json' } })).default;
         } catch {
             // If loading fails, try using the default language, if that fails fall back to the global default locale
             if (!fallback) {

--- a/packages/components/pie-cookie-banner/test/component/pie-cookie-banner-locale.spec.ts
+++ b/packages/components/pie-cookie-banner/test/component/pie-cookie-banner-locale.spec.ts
@@ -8,7 +8,7 @@ function stripTags (str: string) {
     return str.replace(/<\/?[^>]+(>|$)/g, '');
 }
 
-const englishLocale = JSON.parse(await readFile(new URL('../../locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
+const englishLocale = JSON.parse(await readFile(new URL('../../dist/locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
 let pieCookieBannerComponent: CookieBannerComponent;
 let pieModalComponent: ModalComponent;
 
@@ -20,7 +20,7 @@ test.describe('PieCookieBanner - Country and Language Properties', () => {
 
     test('should render text in the default (uk - english) language when unset', async () => {
         // Arrange
-        const englishLocale = JSON.parse(await readFile(new URL('../../locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
+        const englishLocale = JSON.parse(await readFile(new URL('../../dist/locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
         await pieCookieBannerComponent.load();
 
         // Act
@@ -62,7 +62,7 @@ test.describe('PieCookieBanner - Country and Language Properties', () => {
         test(`should 'dynamically' update the locale when we reset the language-country from 'en-gb' to ${language}-${country}`, async () => {
             // Arrange
             await pieCookieBannerComponent.load(); // en-gb is the default locale
-            const locale = JSON.parse(await readFile(new URL(`../../locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
+            const locale = JSON.parse(await readFile(new URL(`../../dist/locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
 
             // Act
             await pieCookieBannerComponent.setProperty('country', country);
@@ -133,7 +133,7 @@ test.describe('PieCookieBanner - Country and Language Properties', () => {
     ].forEach((obj) => {
         test(`should fallback to the default language-country '${obj.fallbackLang}-${obj.country}' if the supplied language '${obj.unsupportedLang}' is unsupported`, async () => {
             // Arrange
-            const fallbackLocale = JSON.parse(await readFile(new URL(`../../locales/${obj.fallbackLang.toLowerCase()}-${obj.country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
+            const fallbackLocale = JSON.parse(await readFile(new URL(`../../dist/locales/${obj.fallbackLang.toLowerCase()}-${obj.country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
             await pieCookieBannerComponent.load({ country: obj.country, language: obj.unsupportedLang }); // supply an unsupported language
 
             // Act

--- a/packages/components/pie-cookie-banner/test/component/pie-cookie-banner-locale.spec.ts
+++ b/packages/components/pie-cookie-banner/test/component/pie-cookie-banner-locale.spec.ts
@@ -8,7 +8,7 @@ function stripTags (str: string) {
     return str.replace(/<\/?[^>]+(>|$)/g, '');
 }
 
-const englishLocale = JSON.parse(await readFile(new URL('../../dist/locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
+const englishLocale = JSON.parse(await readFile(new URL('../../locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
 let pieCookieBannerComponent: CookieBannerComponent;
 let pieModalComponent: ModalComponent;
 
@@ -20,7 +20,7 @@ test.describe('PieCookieBanner - Country and Language Properties', () => {
 
     test('should render text in the default (uk - english) language when unset', async () => {
         // Arrange
-        const englishLocale = JSON.parse(await readFile(new URL('../../dist/locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
+        const englishLocale = JSON.parse(await readFile(new URL('../../locales/en-gb.json', import.meta.url), { encoding: 'utf-8' }));
         await pieCookieBannerComponent.load();
 
         // Act
@@ -62,7 +62,7 @@ test.describe('PieCookieBanner - Country and Language Properties', () => {
         test(`should 'dynamically' update the locale when we reset the language-country from 'en-gb' to ${language}-${country}`, async () => {
             // Arrange
             await pieCookieBannerComponent.load(); // en-gb is the default locale
-            const locale = JSON.parse(await readFile(new URL(`../../dist/locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
+            const locale = JSON.parse(await readFile(new URL(`../../locales/${language.toLowerCase()}-${country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
 
             // Act
             await pieCookieBannerComponent.setProperty('country', country);
@@ -133,7 +133,7 @@ test.describe('PieCookieBanner - Country and Language Properties', () => {
     ].forEach((obj) => {
         test(`should fallback to the default language-country '${obj.fallbackLang}-${obj.country}' if the supplied language '${obj.unsupportedLang}' is unsupported`, async () => {
             // Arrange
-            const fallbackLocale = JSON.parse(await readFile(new URL(`../../dist/locales/${obj.fallbackLang.toLowerCase()}-${obj.country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
+            const fallbackLocale = JSON.parse(await readFile(new URL(`../../locales/${obj.fallbackLang.toLowerCase()}-${obj.country.toLowerCase()}.json`, import.meta.url), { encoding: 'utf-8' }));
             await pieCookieBannerComponent.load({ country: obj.country, language: obj.unsupportedLang }); // supply an unsupported language
 
             // Act

--- a/packages/components/pie-cookie-banner/vite.config.js
+++ b/packages/components/pie-cookie-banner/vite.config.js
@@ -1,3 +1,15 @@
 import viteConfig from '@justeattakeaway/pie-components-config/vite.config';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
-export default viteConfig;
+export default viteConfig({
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: './locales/*',
+          dest: './locales'
+        }
+      ]
+    })
+  ]
+});

--- a/packages/components/pie-cookie-banner/vite.config.js
+++ b/packages/components/pie-cookie-banner/vite.config.js
@@ -2,14 +2,14 @@ import viteConfig from '@justeattakeaway/pie-components-config/vite.config';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default viteConfig({
-  plugins: [
-    viteStaticCopy({
-      targets: [
-        {
-          src: './locales/*',
-          dest: './locales'
-        }
-      ]
-    })
-  ]
+    plugins: [
+        viteStaticCopy({
+            targets: [
+                {
+                    src: './locales/*',
+                    dest: './locales',
+                }
+            ],
+        })
+    ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4755,7 +4755,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-assistive-text@0.7.5, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
+"@justeattakeaway/pie-assistive-text@0.8.0, @justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-assistive-text@workspace:packages/components/pie-assistive-text"
   dependencies:
@@ -4768,14 +4768,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-button@0.49.3, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
+"@justeattakeaway/pie-button@0.49.4, @justeattakeaway/pie-button@workspace:packages/components/pie-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-button@workspace:packages/components/pie-button"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-spinner": 0.7.2
+    "@justeattakeaway/pie-spinner": 0.7.3
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
     cem-plugin-module-file-extensions: 0.0.5
@@ -4783,7 +4783,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-card@0.21.2, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
+"@justeattakeaway/pie-card@0.21.3, @justeattakeaway/pie-card@workspace:packages/components/pie-card":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-card@workspace:packages/components/pie-card"
   dependencies:
@@ -4796,13 +4796,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-checkbox-group@0.7.5, @justeattakeaway/pie-checkbox-group@workspace:packages/components/pie-checkbox-group":
+"@justeattakeaway/pie-checkbox-group@0.7.6, @justeattakeaway/pie-checkbox-group@workspace:packages/components/pie-checkbox-group":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-checkbox-group@workspace:packages/components/pie-checkbox-group"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.5
-    "@justeattakeaway/pie-checkbox": 0.13.5
+    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-checkbox": 0.13.6
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-webc-core": 0.24.2
@@ -4810,12 +4810,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-checkbox@0.13.5, @justeattakeaway/pie-checkbox@workspace:packages/components/pie-checkbox":
+"@justeattakeaway/pie-checkbox@0.13.6, @justeattakeaway/pie-checkbox@workspace:packages/components/pie-checkbox":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-checkbox@workspace:packages/components/pie-checkbox"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.5
+    "@justeattakeaway/pie-assistive-text": 0.8.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-webc-core": 0.24.2
@@ -4823,7 +4823,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-chip@0.9.1, @justeattakeaway/pie-chip@workspace:packages/components/pie-chip":
+"@justeattakeaway/pie-chip@0.9.2, @justeattakeaway/pie-chip@workspace:packages/components/pie-chip":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-chip@workspace:packages/components/pie-chip"
   dependencies:
@@ -4831,7 +4831,7 @@ __metadata:
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-spinner": 0.7.2
+    "@justeattakeaway/pie-spinner": 0.7.3
     "@justeattakeaway/pie-webc-core": 0.24.2
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
@@ -4849,22 +4849,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-cookie-banner@1.0.2, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
+"@justeattakeaway/pie-cookie-banner@1.0.3, @justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-cookie-banner@workspace:packages/components/pie-cookie-banner"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-button": 0.49.3
+    "@justeattakeaway/pie-button": 0.49.4
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-divider": 0.14.2
-    "@justeattakeaway/pie-icon-button": 0.29.1
-    "@justeattakeaway/pie-link": 0.18.2
-    "@justeattakeaway/pie-modal": 0.49.3
-    "@justeattakeaway/pie-switch": 0.30.5
+    "@justeattakeaway/pie-icon-button": 0.29.2
+    "@justeattakeaway/pie-link": 0.18.3
+    "@justeattakeaway/pie-modal": 0.49.4
+    "@justeattakeaway/pie-switch": 0.30.6
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
     cem-plugin-module-file-extensions: 0.0.5
+    vite-plugin-static-copy: 2.0.0
   languageName: unknown
   linkType: soft
 
@@ -4893,15 +4894,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-form-label@0.14.3, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
+"@justeattakeaway/pie-form-label@0.14.4, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-switch": 0.30.5
-    "@justeattakeaway/pie-text-input": 0.24.4
+    "@justeattakeaway/pie-switch": 0.30.6
+    "@justeattakeaway/pie-text-input": 0.24.5
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
     cem-plugin-module-file-extensions: 0.0.5
@@ -4914,7 +4915,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-icon-button@0.29.1, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
+"@justeattakeaway/pie-icon-button@0.29.2, @justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-icon-button@workspace:packages/components/pie-icon-button"
   dependencies:
@@ -4922,7 +4923,7 @@ __metadata:
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-spinner": 0.7.2
+    "@justeattakeaway/pie-spinner": 0.7.3
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
     cem-plugin-module-file-extensions: 0.0.5
@@ -5012,7 +5013,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-link@0.18.2, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
+"@justeattakeaway/pie-link@0.18.3, @justeattakeaway/pie-link@workspace:packages/components/pie-link":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-link@workspace:packages/components/pie-link"
   dependencies:
@@ -5026,7 +5027,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-lottie-player@0.0.4, @justeattakeaway/pie-lottie-player@workspace:packages/components/pie-lottie-player":
+"@justeattakeaway/pie-lottie-player@0.0.5, @justeattakeaway/pie-lottie-player@workspace:packages/components/pie-lottie-player":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-lottie-player@workspace:packages/components/pie-lottie-player"
   dependencies:
@@ -5039,19 +5040,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-modal@0.49.3, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
+"@justeattakeaway/pie-modal@0.49.4, @justeattakeaway/pie-modal@workspace:packages/components/pie-modal":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-modal@workspace:packages/components/pie-modal"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeat/pie-design-tokens": 6.5.0
-    "@justeattakeaway/pie-button": 0.49.3
+    "@justeattakeaway/pie-button": 0.49.4
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-icon-button": 0.29.1
+    "@justeattakeaway/pie-icon-button": 0.29.2
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-spinner": 0.7.2
-    "@justeattakeaway/pie-text-input": 0.24.4
+    "@justeattakeaway/pie-spinner": 0.7.3
+    "@justeattakeaway/pie-text-input": 0.24.5
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
     "@types/body-scroll-lock": 3.1.2
@@ -5061,14 +5062,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-notification@0.12.4, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
+"@justeattakeaway/pie-notification@0.12.5, @justeattakeaway/pie-notification@workspace:packages/components/pie-notification":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-notification@workspace:packages/components/pie-notification"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-icon-button": 0.29.1
+    "@justeattakeaway/pie-icon-button": 0.29.2
     "@justeattakeaway/pie-icons-webc": 1.1.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
@@ -5076,21 +5077,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio-group@0.2.1, @justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group":
+"@justeattakeaway/pie-radio-group@0.3.0, @justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.5
+    "@justeattakeaway/pie-assistive-text": 0.8.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-radio": 0.4.0
+    "@justeattakeaway/pie-radio": 0.5.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio@0.4.0, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
+"@justeattakeaway/pie-radio@0.5.0, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio@workspace:packages/components/pie-radio"
   dependencies:
@@ -5102,7 +5103,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-spinner@0.7.2, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
+"@justeattakeaway/pie-spinner@0.7.3, @justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-spinner@workspace:packages/components/pie-spinner"
   dependencies:
@@ -5115,7 +5116,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-switch@0.30.5, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
+"@justeattakeaway/pie-switch@0.30.6, @justeattakeaway/pie-switch@workspace:packages/components/pie-switch":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-switch@workspace:packages/components/pie-switch"
   dependencies:
@@ -5144,12 +5145,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-text-input@0.24.4, @justeattakeaway/pie-text-input@workspace:packages/components/pie-text-input":
+"@justeattakeaway/pie-text-input@0.24.5, @justeattakeaway/pie-text-input@workspace:packages/components/pie-text-input":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-text-input@workspace:packages/components/pie-text-input"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-assistive-text": 0.7.5
+    "@justeattakeaway/pie-assistive-text": 0.8.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
@@ -5160,14 +5161,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-textarea@0.11.0, @justeattakeaway/pie-textarea@workspace:packages/components/pie-textarea":
+"@justeattakeaway/pie-textarea@0.11.1, @justeattakeaway/pie-textarea@workspace:packages/components/pie-textarea":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-textarea@workspace:packages/components/pie-textarea"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-form-label": 0.14.3
+    "@justeattakeaway/pie-form-label": 0.14.4
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@types/lodash.throttle": 4.1.9
     cem-plugin-module-file-extensions: 0.0.5
@@ -5175,15 +5176,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-toast@0.4.2, @justeattakeaway/pie-toast@workspace:packages/components/pie-toast":
+"@justeattakeaway/pie-toast@0.4.3, @justeattakeaway/pie-toast@workspace:packages/components/pie-toast":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-toast@workspace:packages/components/pie-toast"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
-    "@justeattakeaway/pie-button": 0.49.3
+    "@justeattakeaway/pie-button": 0.49.4
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-icon-button": 0.29.1
+    "@justeattakeaway/pie-icon-button": 0.29.2
     "@justeattakeaway/pie-icons-webc": 1.1.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     cem-plugin-module-file-extensions: 0.0.5
@@ -5210,33 +5211,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.5.48, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.5.49, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.7.5
-    "@justeattakeaway/pie-button": 0.49.3
-    "@justeattakeaway/pie-card": 0.21.2
-    "@justeattakeaway/pie-checkbox": 0.13.5
-    "@justeattakeaway/pie-checkbox-group": 0.7.5
-    "@justeattakeaway/pie-chip": 0.9.1
+    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-button": 0.49.4
+    "@justeattakeaway/pie-card": 0.21.3
+    "@justeattakeaway/pie-checkbox": 0.13.6
+    "@justeattakeaway/pie-checkbox-group": 0.7.6
+    "@justeattakeaway/pie-chip": 0.9.2
     "@justeattakeaway/pie-components-config": 0.18.0
-    "@justeattakeaway/pie-cookie-banner": 1.0.2
+    "@justeattakeaway/pie-cookie-banner": 1.0.3
     "@justeattakeaway/pie-divider": 0.14.2
-    "@justeattakeaway/pie-form-label": 0.14.3
-    "@justeattakeaway/pie-icon-button": 0.29.1
-    "@justeattakeaway/pie-link": 0.18.2
-    "@justeattakeaway/pie-lottie-player": 0.0.4
-    "@justeattakeaway/pie-modal": 0.49.3
-    "@justeattakeaway/pie-notification": 0.12.4
-    "@justeattakeaway/pie-radio": 0.4.0
-    "@justeattakeaway/pie-radio-group": 0.2.1
-    "@justeattakeaway/pie-spinner": 0.7.2
-    "@justeattakeaway/pie-switch": 0.30.5
+    "@justeattakeaway/pie-form-label": 0.14.4
+    "@justeattakeaway/pie-icon-button": 0.29.2
+    "@justeattakeaway/pie-link": 0.18.3
+    "@justeattakeaway/pie-lottie-player": 0.0.5
+    "@justeattakeaway/pie-modal": 0.49.4
+    "@justeattakeaway/pie-notification": 0.12.5
+    "@justeattakeaway/pie-radio": 0.5.0
+    "@justeattakeaway/pie-radio-group": 0.3.0
+    "@justeattakeaway/pie-spinner": 0.7.3
+    "@justeattakeaway/pie-switch": 0.30.6
     "@justeattakeaway/pie-tag": 0.11.1
-    "@justeattakeaway/pie-text-input": 0.24.4
-    "@justeattakeaway/pie-textarea": 0.11.0
-    "@justeattakeaway/pie-toast": 0.4.2
+    "@justeattakeaway/pie-text-input": 0.24.5
+    "@justeattakeaway/pie-textarea": 0.11.1
+    "@justeattakeaway/pie-toast": 0.4.3
     chalk: 5.3.0
   bin:
     add-components: ./src/index.js
@@ -22676,31 +22677,31 @@ __metadata:
   resolution: "pie-storybook@workspace:apps/pie-storybook"
   dependencies:
     "@justeat/pie-design-tokens": 6.5.0
-    "@justeattakeaway/pie-assistive-text": 0.7.5
-    "@justeattakeaway/pie-button": 0.49.3
-    "@justeattakeaway/pie-card": 0.21.2
-    "@justeattakeaway/pie-checkbox": 0.13.5
-    "@justeattakeaway/pie-checkbox-group": 0.7.5
-    "@justeattakeaway/pie-chip": 0.9.1
-    "@justeattakeaway/pie-cookie-banner": 1.0.2
+    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-button": 0.49.4
+    "@justeattakeaway/pie-card": 0.21.3
+    "@justeattakeaway/pie-checkbox": 0.13.6
+    "@justeattakeaway/pie-checkbox-group": 0.7.6
+    "@justeattakeaway/pie-chip": 0.9.2
+    "@justeattakeaway/pie-cookie-banner": 1.0.3
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-divider": 0.14.2
-    "@justeattakeaway/pie-form-label": 0.14.3
-    "@justeattakeaway/pie-icon-button": 0.29.1
+    "@justeattakeaway/pie-form-label": 0.14.4
+    "@justeattakeaway/pie-icon-button": 0.29.2
     "@justeattakeaway/pie-icons-configs": 4.5.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-link": 0.18.2
-    "@justeattakeaway/pie-lottie-player": 0.0.4
-    "@justeattakeaway/pie-modal": 0.49.3
-    "@justeattakeaway/pie-notification": 0.12.4
-    "@justeattakeaway/pie-radio": 0.4.0
-    "@justeattakeaway/pie-radio-group": 0.2.1
-    "@justeattakeaway/pie-spinner": 0.7.2
-    "@justeattakeaway/pie-switch": 0.30.5
+    "@justeattakeaway/pie-link": 0.18.3
+    "@justeattakeaway/pie-lottie-player": 0.0.5
+    "@justeattakeaway/pie-modal": 0.49.4
+    "@justeattakeaway/pie-notification": 0.12.5
+    "@justeattakeaway/pie-radio": 0.5.0
+    "@justeattakeaway/pie-radio-group": 0.3.0
+    "@justeattakeaway/pie-spinner": 0.7.3
+    "@justeattakeaway/pie-switch": 0.30.6
     "@justeattakeaway/pie-tag": 0.11.1
-    "@justeattakeaway/pie-text-input": 0.24.4
-    "@justeattakeaway/pie-textarea": 0.11.0
-    "@justeattakeaway/pie-toast": 0.4.2
+    "@justeattakeaway/pie-text-input": 0.24.5
+    "@justeattakeaway/pie-textarea": 0.11.1
+    "@justeattakeaway/pie-toast": 0.4.3
     "@storybook/addon-a11y": 8.3.0
     "@storybook/addon-designs": 8.0.3
     "@storybook/addon-essentials": 8.3.0
@@ -29160,6 +29161,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-plugin-static-copy@npm:2.0.0":
+  version: 2.0.0
+  resolution: "vite-plugin-static-copy@npm:2.0.0"
+  dependencies:
+    chokidar: ^3.5.3
+    fast-glob: ^3.2.11
+    fs-extra: ^11.1.0
+    picocolors: ^1.0.0
+  peerDependencies:
+    vite: ^5.0.0
+  checksum: 6268bf22f472c7a8ceac8727db5aec5f27a8028ff6c0f7ae72172239f5f40140ed9b72a1764a66ff18a4b96d2a0ce73bf7a1827d4d130edc5b04d86e43df045c
+  languageName: node
+  linkType: hard
+
 "vite@npm:5.3.6":
   version: 5.3.6
   resolution: "vite@npm:5.3.6"
@@ -29588,7 +29603,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.48
+    "@justeattakeaway/pie-webc": 0.5.49
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -29602,7 +29617,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.48
+    "@justeattakeaway/pie-webc": 0.5.49
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -29617,7 +29632,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.48
+    "@justeattakeaway/pie-webc": 0.5.49
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -29637,7 +29652,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.48
+    "@justeattakeaway/pie-webc": 0.5.49
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -29657,7 +29672,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.48
+    "@justeattakeaway/pie-webc": 0.5.49
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
This PR adds the locales to the package dist, which will fix an underlying issue with the PIE Aperture vanilla app (and possibly other consumers) where Vite tries to resolve the locales from the wrong directory, resulting in the en-gb fallback always being used.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
