### PR TITLE
fix(pie-monorepo): DSW-2507 bundlewatch base branch diff tracking

### DIFF
--- a/.changeset/little-beans-count.md
+++ b/.changeset/little-beans-count.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": patch
+---
+
+[Fixed] - Bundlewatch base branch diff tracking

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,7 +38,8 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.GITHUB_REF_NAME,
+                  'pie-branch': process.env.PIE_BRANCH,
+                  'pie-pr-number': process.env.PIE_PR_NUMBER,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/.github/workflows/changeset-snapshot/test-aperture.js
+++ b/.github/workflows/changeset-snapshot/test-aperture.js
@@ -38,8 +38,7 @@ module.exports = async ({ github, context }, execa) => {
                 repo: 'pie-aperture',
                 event_type: 'pie-trigger',
                 client_payload: {
-                  'pie-branch': process.env.PIE_BRANCH,
-                  'pie-pr-number': process.env.PIE_PR_NUMBER,
+                  'pie-branch': process.env.GITHUB_REF_NAME,
                   'snapshot-version': snapshotVersion,
                   'snapshot-packages': packageNames.join(' ')
                 }

--- a/.github/workflows/install-build.yml
+++ b/.github/workflows/install-build.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-          CI_BRANCH_BASE: ${{ github.event.pull_request.base.ref }}
+          CI_BRANCH_BASE: 'main'

--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -185,5 +185,8 @@
       "maxSize": "0.41 KB"
     }
   ],
-  "defaultCompression": "gzip"
+  "defaultCompression": "gzip",
+  "ci": {
+    "trackBranches": ["main"]
+  }
 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
---
"pie-monorepo": patch
---

[Fixed] - Bundlewatch base branch diff tracking


**Before** -  bundlewatch was tracking the wrong branch
![Screenshot 2024-11-08 at 15 13 54](https://github.com/user-attachments/assets/0c8d2922-7ee0-4665-91b5-d054a6ff5d90)


*After** - Now bundlewatch is correctly trying to track main
![Screenshot 2024-11-08 at 15 14 12](https://github.com/user-attachments/assets/7eecd411-0d12-4372-98e1-7ea049a28f2f)

This diff should be fixed for future PR's once this is merged.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
