### PR TITLE
fix(pie-monorepo): DSW-000 Fix dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,40 +5,34 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-type: "major"
+      - update-types: ['version-update:semver-major']
     open-pull-requests-limit: 3
     commit-message:
       prefix: "deps(npm): DSW-000 update"
     groups:
       babel:
-        description: "Group Babel devDependencies from package.json within pie-monorepo"
         patterns:
           - "@babel/*"
           - "babel-*"
       justeattakeaway:
-        description: "Group JET devDependencies / dependencies from package.json within pie-monorepo"
         patterns:
           - "@justeat/*"
           - "@justeattakeaway/*"
       percy:
-        description: "Group Playwright / other testing related devDependencies from package.json within pie-monorepo"
         patterns:
           - "@axe-core/playwright"
           - "@percy/*"
           - "@playwright/*"
           - "@sand4rt/experimental-ct-web/*"
       vitest:
-        description: "Group Vitest devDependencies from package.json within pie-monorepo"
         patterns:
           - "vitest-*"
           - "@vitest"
       eleventy:
-        description: "Group Eleventy devDependencies from apps/pie-docs/package.json"
         patterns:
           - "@11ty/*"
           - "eleventy-*"
       storybook:
-        description: "Group Storybook dependencies from apps/pie-storybook/package.json"
         patterns:
           - "@storybook/*"
           - "storybook"
@@ -48,7 +42,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-type: "major"
+      - update-types: ['version-update:semver-major']
     open-pull-requests-limit: 3
     commit-message:
       prefix: "deps(github-actions): DSW-000 update"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      - dependency-name: "*"
       - update-types: ['version-update:semver-major']
     open-pull-requests-limit: 3
     commit-message:
@@ -43,6 +44,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      - dependency-name: "*"
       - update-types: ['version-update:semver-major']
     open-pull-requests-limit: 3
     commit-message:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
         "github.vscode-pull-request-github",
         "jamiemaguire.pie-design-system-vscode-prototype",
         "ms-playwright.playwright",
+        "redhat.vscode-yaml",
         "unem.lit-plugin",
         "yoavbls.pretty-ts-errors"
     ]


### PR DESCRIPTION
## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code


Fixes an issue where the renovate config didn't align with the schema. As part of this PR I have:

- Fixed the underlying issues with the config.
- Added YAML schema validation
- Included  `redhat.vscode-yaml` as a VS Code recommended extension


> [!NOTE]
> Dependabot check is still failing in this PR, as GitHub Actions is reading the config from main