### PR TITLE
ci(pie-monorepo): DSW-2496 updated sub-domain-suffix requirements

### DIFF
--- a/.github/workflows/amplify-deploy.yml
+++ b/.github/workflows/amplify-deploy.yml
@@ -38,7 +38,7 @@ on:
         type: string
         default: '/'
       sub-domain-suffix:
-        required: true
+        required: false
         type: string
 
 env:

--- a/packages/tools/pie-monorepo-utils/changeset-snapshot/create-and-publish.js
+++ b/packages/tools/pie-monorepo-utils/changeset-snapshot/create-and-publish.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context }, execa) => {
 
     const newTags = Array
         .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
-        .map(([tag]) => tag)
+        .map(([, tag]) => tag)
         .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
 
     let body;

--- a/packages/tools/pie-monorepo-utils/changeset-snapshot/create-and-publish.js
+++ b/packages/tools/pie-monorepo-utils/changeset-snapshot/create-and-publish.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context }, execa) => {
 
     const newTags = Array
         .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
-        .map(([_, tag]) => tag)
+        .map(([tag]) => tag)
         .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
 
     let body;

--- a/packages/tools/pie-monorepo-utils/changeset-snapshot/test-aperture.js
+++ b/packages/tools/pie-monorepo-utils/changeset-snapshot/test-aperture.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context }, execa) => {
 
     const newTags = Array
         .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
-        .map(([tag]) => tag)
+        .map(([, tag]) => tag)
         .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
 
     // Extract the snapshot version from one of the tags

--- a/packages/tools/pie-monorepo-utils/changeset-snapshot/test-aperture.js
+++ b/packages/tools/pie-monorepo-utils/changeset-snapshot/test-aperture.js
@@ -9,10 +9,11 @@ module.exports = async ({ github, context }, execa) => {
 
     const newTags = Array
         .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
-        .map(([_, tag]) => tag)
+        .map(([tag]) => tag)
         .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
 
     // Extract the snapshot version from one of the tags
+    // eslint-disable-next-line prefer-destructuring
     const snapshotVersion = newTags[0].match(/\d{14}$/)[0];
 
     // Extract package names by removing version and scope from the tags


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Updated `sub-domain-suffix` requirements to `false`, as it's not used by the example app deploys and was causing the workflow to fail.

## Author Checklist (complete before requesting a review)
- [x] I have performed a self-review of my code
