### PR TITLE
chore(pie-monorepo): WCP-000 remove dependabot changeset action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,23 +53,6 @@ env:
   PERCY_NETWORK_IDLE_WAIT_TIMEOUT: ${{ vars.PERCY_NETWORK_IDLE_WAIT_TIMEOUT }}
 
 jobs:
-  dependency-changeset:
-    if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-    - name: Add Changeset to PR
-      uses: StafflinePeoplePlus/dependabot-changesets@4844c33bad364143ee39ef4150c60409f306ed21 # v0.1.5
-      with:
-        owner: justeattakeaway
-        repo: pie
-        pr-number: ${{ github.event.pull_request.number }}
-        token: ${{ secrets.CHANGESETS_TOKEN }}
-
   check-change-type:
     name: Get change type
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes the workflow job to automatically generate changesets for :dependabot: PR's, as I'm unable to find a way to get it working reliably.

Also, this functionality is solved by simply clicking the following button for any dependabot PR that bumps a package.json `dependency`.


![Screenshot 2024-11-25 at 10 14 30](https://github.com/user-attachments/assets/8477eb52-4966-4d94-acce-5dea355a9f8f)