### PR TITLE
feat(pie-radio-group): DSW-2632 add keyboard navigation and focusing

### DIFF
--- a/.changeset/breezy-experts-hear.md
+++ b/.changeset/breezy-experts-hear.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-radio": minor
+---
+
+[Added] - Ensure focus is correctly delegated to the underlying input element

--- a/.changeset/ten-chefs-rescue.md
+++ b/.changeset/ten-chefs-rescue.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-radio-group": minor
+---
+
+[Added] - Keyboard navigation and tab/shift + tab focus behaviour

--- a/apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts
@@ -1,0 +1,72 @@
+import { html, nothing } from 'lit';
+import { type Meta } from '@storybook/web-components';
+
+import '@justeattakeaway/pie-radio-group';
+import {
+    defaultProps,
+    type RadioGroupProps as RadioGroupPropsBase,
+} from '@justeattakeaway/pie-radio-group';
+import '@justeattakeaway/pie-link';
+import '@justeattakeaway/pie-radio';
+import '@justeattakeaway/pie-form-label';
+import '@justeattakeaway/pie-button';
+
+import { createStory } from '../../utilities';
+
+type RadioGroupProps = RadioGroupPropsBase & {
+    labelSlot: keyof typeof labelSlotOptions;
+};
+
+type RadioGroupStoryMeta = Meta<RadioGroupProps>;
+
+const defaultArgs: RadioGroupProps = {
+    ...defaultProps,
+    labelSlot: 'None',
+};
+
+const labelSlotOptions = {
+    None: nothing,
+    Label: html`<pie-form-label slot="label">Radio Group Label</pie-form-label>`,
+};
+
+const radioGroupStoryMeta: RadioGroupStoryMeta = {
+    title: 'Radio Group',
+    component: 'pie-radio-group',
+    parameters: {
+        controls: {
+            disable: true,
+        },
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/pPSC73rPin4csb8DiK1CRr/branch/6u3sopt3trAp9wdJi7lUfY/%E2%9C%A8-%5BCore%5D-Web-Components-%5BPIE-3%5D?node-id=6369-3799&node-type=frame&t=pbk7ibGYRutGCO3z-0',
+        },
+    },
+};
+
+export default radioGroupStoryMeta;
+
+const KeyboardNavigationTemplate = () => html`
+    <h2>Radio group 1</h2>
+    <p><pie-button size="small-productive" data-test-id="btn-1">Button 1</pie-button></p>
+    <pie-radio-group data-test-id="radio-group-1">
+        <pie-radio data-test-id="radio-1" value="chinese">Chinese</pie-radio>
+        <pie-radio data-test-id="radio-2" value="shawarma">Shawarma</pie-radio>
+        <pie-radio data-test-id="radio-3" value="pizza">Pizza</pie-radio>
+        <pie-radio data-test-id="radio-4" value="fish-and-chips">Fish and Chips</pie-radio>
+        <pie-radio data-test-id="radio-5" value="indian">Indian</pie-radio>
+    </pie-radio-group>
+    <p><pie-button size="small-productive" variant="secondary" data-test-id="btn-2">Button 2</pie-button></p>
+
+    <h2>Radio group 2</h2>
+    <p><pie-button size="small-productive" data-test-id="btn-3">Button 3</pie-button></p>
+    <pie-radio-group data-test-id="radio-group-2" value="fish-and-chips">
+        <pie-radio data-test-id="radio-6" value="chinese">Chinese</pie-radio>
+        <pie-radio data-test-id="radio-7" value="shawarma">Shawarma</pie-radio>
+        <pie-radio data-test-id="radio-8" value="pizza">Pizza</pie-radio>
+        <pie-radio data-test-id="radio-9" value="fish-and-chips">Fish and Chips</pie-radio>
+        <pie-radio data-test-id="radio-10" value="indian">Indian</pie-radio>
+    </pie-radio-group>
+    <p><pie-button size="small-productive" variant="secondary" data-test-id="btn-4">Button 4</pie-button></p>
+    `;
+
+export const KeyboardNavigation = createStory<RadioGroupProps>(KeyboardNavigationTemplate, defaultArgs)();

--- a/apps/pie-storybook/turbo.json
+++ b/apps/pie-storybook/turbo.json
@@ -15,7 +15,7 @@
       "cache": false,
       "dependsOn": [
         "^build",
-        "generate:component-statuses"
+        "^generate:component-statuses"
       ]
     },
     "build": {

--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -130,7 +130,7 @@
     },
     {
       "path": "./packages/components/pie-radio-group/dist/index.js",
-      "maxSize": "2.5 KB"
+      "maxSize": "5 KB"
     },
     {
       "path": "./packages/components/pie-radio-group/dist/react.js",

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -162,6 +162,8 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
     protected firstUpdated (): void {
         // Make all radios impossible to tab to
+        // This is because by default, we are able to tab to each individual radio button.
+        // This is not the behaviour we want, so applying -1 tabindex prevents it.
         this._slottedChildren.forEach((radio) => radio.setAttribute('tabindex', '-1'));
     }
 

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -73,11 +73,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
     /**
      * Tracks whether the `Shift` key was held during the last `Tab` key press.
      *
-     * This static property is updated whenever a `Tab` key press is detected. It is used
-     * to determine navigation direction when the radio group gains focus:
-     * - `true`: Indicates that the user pressed `Shift+Tab` for backward navigation.
-     * - `false`: Indicates that the user pressed `Tab` alone for forward navigation.
-     *
      * The property is static because it needs to be shared across all instances of the
      * `PieRadioGroup` component on the same page, ensuring consistent behavior.
      */
@@ -186,17 +181,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
     /**
      * Updates the state of `_wasShiftTabPressed` based on the last `Tab` key press.
-     *
-     * When a `Tab` key press is detected, this method updates the static property
-     * `wasShiftTabPressed` to indicate whether the `Shift` key was also held during
-     * the event. This information is used to manage focus direction when the radio
-     * group gains focus.
-     *
-     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
-     *
-     * Example Usage:
-     * - If `Shift+Tab` is pressed, `_wasShiftTabPressed` is set to `true` to signal backward navigation.
-     * - If `Tab` alone is pressed, `_wasShiftTabPressed` is set to `false` for forward navigation.
      */
     private _updateShiftTabState (event: KeyboardEvent): void {
         if (event.key === 'Tab') {
@@ -210,21 +194,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
      * This method determines the appropriate element to focus when the radio group
      * gains focus. It considers the last navigation action (whether `Shift+Tab` was used)
      * and focuses the checked option, the first option, or the last option as needed.
-     *
-     * **Behaviour:**
-     * - If the event target is the radio group itself:
-     *   - If an option is already checked, it focuses the checked option.
-     *   - If `Shift+Tab` was pressed, it focuses the last option.
-     *   - Otherwise, it focuses the first option.
-     * - It disables the `tabindex` on the radio group's `fieldset` to allow focus to remain on
-     *   the appropriate option.
-     *
-     * @param {FocusEvent} event - The focus event triggered when the radio group gains focus.
-     *
-     * Example Usage:
-     * - When the user navigates to the radio group using `Shift+Tab`, the last option is focused.
-     * - When the user navigates using `Tab`, the first option is focused (unless one is checked).
-     * - If an option is already checked, it takes precedence and is focused.
      */
     private _handleFocusIn (event: FocusEvent): void {
         if (this !== event.target) return;
@@ -245,26 +214,11 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
      * When focus leaves the radio group, this method enables the `tabindex` attribute
      * on the `fieldset` element. This ensures the radio group remains accessible for
      * keyboard navigation and can be re-focused when tabbing back into the group.
-     *
      */
     private _handleFocusOut (): void {
         this._toggleFieldsetTabindex(true);
     }
 
-    /**
-     * Toggles the `tabindex` attribute on the radio group's `fieldset` element.
-     *
-     * This method enables or disables the `tabindex` on the `fieldset` element based on
-     * the provided `enable` flag. Enabling the `tabindex` allows the radio group to be
-     * focusable via keyboard navigation, while disabling it prevents the `fieldset` from
-     * interfering with the focus management of its child options.
-     *
-     * **Example Usage:**
-     * - When the radio group loses focus, `_toggleFieldsetTabindex(true)` ensures the group is focusable.
-     * - When a specific radio option is focused, `_toggleFieldsetTabindex(false)` prevents accidental focus on the `fieldset`.
-     *
-     * @param {boolean} enable - Whether to enable (`true`) or disable (`false`) the `tabindex` on the `fieldset`.
-     */
     private _toggleFieldsetTabindex (enable: boolean): void {
         if (enable) {
             this._fieldset.setAttribute('tabindex', '0');
@@ -273,21 +227,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
         }
     }
 
-    /**
-     * Moves focus within the radio group to the next or previous option.
-     *
-     * This method calculates the new index of the option to focus based on the
-     * current index and a directional step. It wraps around when the focus reaches
-     * the first or last option.
-     * Once the target option is determined, it focuses and triggers a click event on it.
-     *
-     * **Example Usage:**
-     * - If the current index is `0` and `step` is `1`, the next option (index `1`) will be focused.
-     * - If the current index is the last option and `step` is `1`, focus wraps to the first option.
-     *
-     * @param {number} currentIndex - The index of the currently focused option.
-     * @param {number} step - The directional step to move the focus (e.g., `1` for forward, `-1` for backward).
-     */
     private _moveFocus (currentIndex: number, step: number): void {
         const newIndex = (currentIndex + step + this._slottedChildren.length) % this._slottedChildren.length;
         this._focusAndClickOption(this._slottedChildren[newIndex]);
@@ -304,13 +243,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
      *   - `ArrowRight` and `ArrowDown` indicate forward navigation.
      * - For RTL (Right-to-Left) layouts:
      *   - `ArrowLeft` and `ArrowDown` indicate forward navigation.
-     *
-     * **Example Usage:**
-     * - In an LTR layout, pressing `ArrowRight` or `ArrowDown` returns `true`.
-     * - In an RTL layout, pressing `ArrowLeft` or `ArrowDown` returns `true`.
-     *
-     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
-     * @returns {boolean} `true` if the key press is for forward navigation; otherwise, `false`.
      */
     private _isForwardKey (event: KeyboardEvent): boolean {
         return (event.code === 'ArrowRight' && !this.isRTL) ||
@@ -329,13 +261,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
      *   - `ArrowLeft` and `ArrowUp` indicate backward navigation.
      * - For RTL (Right-to-Left) layouts:
      *   - `ArrowRight` and `ArrowUp` indicate backward navigation.
-     *
-     * **Example Usage:**
-     * - In an LTR layout, pressing `ArrowLeft` or `ArrowUp` returns `true`.
-     * - In an RTL layout, pressing `ArrowRight` or `ArrowUp` returns `true`.
-     *
-     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
-     * @returns {boolean} `true` if the key press is for backward navigation; otherwise, `false`.
      */
     private _isBackwardKey (event: KeyboardEvent): boolean {
         return (event.code === 'ArrowLeft' && !this.isRTL) ||
@@ -349,19 +274,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
      * This method responds to `keydown` events and determines the appropriate navigation
      * action (forward or backward) based on the pressed key and the current focus. It prevents
      * the default browser behaviour (e.g., scrolling) when arrow keys are used for navigation.
-     *
-     * **Behaviour:**
-     * - Checks if the currently focused element is one of the radio group options.
-     * - Determines the index of the currently focused option.
-     * - Prevents default scrolling behavior if an arrow key (`ArrowRight`, `ArrowDown`, `ArrowLeft`, `ArrowUp`) is pressed.
-     * - Uses `_isForwardKey` or `_isBackwardKey` to determine the navigation direction and calls `_moveFocus` to update focus.
-     *
-     * **Example Usage:**
-     * - Pressing `ArrowRight` (in LTR) moves the focus to the next option.
-     * - Pressing `ArrowLeft` (in RTL) moves the focus to the next option.
-     * - Pressing `ArrowUp` or `ArrowDown` navigates backward or forward, respectively, regardless of text direction.
-     *
-     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
      */
     private _handleKeyDown (event: KeyboardEvent): void {
         const currentlyFocusedChild = this._slottedChildren.find((child) => child === document.activeElement);
@@ -387,22 +299,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
         }
     }
 
-    /**
-     * Focuses a radio option and triggers a `click` event to ensure proper behaviour.
-     *
-     * This method sets focus on the provided radio option and programmatically triggers
-     * a `click` event on its underlying `<input>` element. The `click` event ensures
-     * that the radio group emits a `change` event as expected. Additionally,
-     * it disables the `fieldset`'s `tabindex` to maintain proper focus behavior.
-     *
-     * **Behaviour:**
-     * - Sets focus on the provided `option`.
-     * - Finds the corresponding `<input>` element within the `option`'s shadow DOM (if available)
-     *   and triggers a `click` event.
-     * - Disables the `tabindex` on the `fieldset` to ensure focus remains on the option.
-     *
-     * @param {HTMLInputElement} option - The radio option to focus and click.
-     */
     private _focusAndClickOption (option: HTMLInputElement): void {
         option.focus();
         // This is quite hacky, but it ensures the radio elements correct emit a real change event.
@@ -414,7 +310,7 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
     disconnectedCallback (): void {
         super.disconnectedCallback();
-        this._abortController.abort(); // This automatically removes event listeners associated with the signal
+        this._abortController.abort();
     }
 
     render () {

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -6,7 +6,9 @@ import {
     type PropertyValues,
     type TemplateResult,
 } from 'lit';
-import { property, queryAssignedElements, state } from 'lit/decorators.js';
+import {
+    property, query, queryAssignedElements, state,
+} from 'lit/decorators.js';
 import {
     RtlMixin,
     defineCustomElement,
@@ -62,6 +64,9 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
     @queryAssignedElements({ selector: 'pie-radio' })
         _slottedChildren!: Array<HTMLInputElement>;
+
+    @query('fieldset')
+    private _fieldset!: HTMLInputElement;
 
     private _abortController!: AbortController;
 
@@ -261,13 +266,10 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
      * @param {boolean} enable - Whether to enable (`true`) or disable (`false`) the `tabindex` on the `fieldset`.
      */
     private _toggleFieldsetTabindex (enable: boolean): void {
-        const fieldset = this.shadowRoot?.querySelector('fieldset');
-
-        if (!fieldset) return;
         if (enable) {
-            fieldset.setAttribute('tabindex', '0');
+            this._fieldset.setAttribute('tabindex', '0');
         } else {
-            fieldset.removeAttribute('tabindex');
+            this._fieldset.removeAttribute('tabindex');
         }
     }
 

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -66,6 +66,19 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
     private _abortController!: AbortController;
 
     /**
+     * Tracks whether the `Shift` key was held during the last `Tab` key press.
+     *
+     * This static property is updated whenever a `Tab` key press is detected. It is used
+     * to determine navigation direction when the radio group gains focus:
+     * - `true`: Indicates that the user pressed `Shift+Tab` for backward navigation.
+     * - `false`: Indicates that the user pressed `Tab` alone for forward navigation.
+     *
+     * The property is static because it needs to be shared across all instances of the
+     * `PieRadioGroup` component on the same page, ensuring consistent behavior.
+     */
+    private static _wasShiftTabPressed = false;
+
+    /**
      * Dispatches a custom event to notify each slotted child radio element
      * when the radio group is disabled.
      * @private
@@ -147,17 +160,262 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
         }
     }
 
+    protected firstUpdated (): void {
+        // Make all radios impossible to tab to
+        this._slottedChildren.forEach((radio) => radio.setAttribute('tabindex', '-1'));
+    }
+
     connectedCallback (): void {
         super.connectedCallback();
         this._abortController = new AbortController();
         const { signal } = this._abortController;
 
         this.shadowRoot?.addEventListener('change', this._handleRadioChange.bind(this), { signal });
+
+        this.addEventListener('focusin', this._handleFocusIn, { signal });
+        this.addEventListener('focusout', this._handleFocusOut, { signal });
+
+        this.addEventListener('keydown', this._handleKeyDown, { signal });
+        document.addEventListener('keydown', this._updateShiftTabState.bind(this), { signal });
+    }
+
+    /**
+     * Updates the state of `_wasShiftTabPressed` based on the last `Tab` key press.
+     *
+     * When a `Tab` key press is detected, this method updates the static property
+     * `wasShiftTabPressed` to indicate whether the `Shift` key was also held during
+     * the event. This information is used to manage focus direction when the radio
+     * group gains focus.
+     *
+     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
+     *
+     * Example Usage:
+     * - If `Shift+Tab` is pressed, `_wasShiftTabPressed` is set to `true` to signal backward navigation.
+     * - If `Tab` alone is pressed, `_wasShiftTabPressed` is set to `false` for forward navigation.
+     */
+    private _updateShiftTabState (event: KeyboardEvent): void {
+        if (event.key === 'Tab') {
+            PieRadioGroup._wasShiftTabPressed = event.shiftKey;
+        }
+    }
+
+    /**
+     * Handles the `focusin` event to manage focus within the radio group.
+     *
+     * This method determines the appropriate element to focus when the radio group
+     * gains focus. It considers the last navigation action (whether `Shift+Tab` was used)
+     * and focuses the checked option, the first option, or the last option as needed.
+     *
+     * **Behaviour:**
+     * - If the event target is the radio group itself:
+     *   - If an option is already checked, it focuses the checked option.
+     *   - If `Shift+Tab` was pressed, it focuses the last option.
+     *   - Otherwise, it focuses the first option.
+     * - It disables the `tabindex` on the radio group's `fieldset` to allow focus to remain on
+     *   the appropriate option.
+     *
+     * @param {FocusEvent} event - The focus event triggered when the radio group gains focus.
+     *
+     * Example Usage:
+     * - When the user navigates to the radio group using `Shift+Tab`, the last option is focused.
+     * - When the user navigates using `Tab`, the first option is focused (unless one is checked).
+     * - If an option is already checked, it takes precedence and is focused.
+     */
+    private _handleFocusIn (event: FocusEvent): void {
+        if (this !== event.target) return;
+
+        console.log('In _handleFocusIn');
+        const isShiftTab = PieRadioGroup._wasShiftTabPressed;
+        const focusTarget = this._slottedChildren?.find((child) => child.checked) ||
+            (isShiftTab ? this._slottedChildren.at(-1) : this._slottedChildren[0]);
+
+        if (!focusTarget) return;
+
+        console.log('focusing: ', focusTarget);
+        focusTarget.focus();
+        console.log('focused: ', focusTarget);
+        this._toggleFieldsetTabindex(false);
+    }
+
+    /**
+     * Handles the `focusout` event to restore the `tabindex` on the radio group's `fieldset`.
+     *
+     * When focus leaves the radio group, this method enables the `tabindex` attribute
+     * on the `fieldset` element. This ensures the radio group remains accessible for
+     * keyboard navigation and can be re-focused when tabbing back into the group.
+     *
+     */
+    private _handleFocusOut (): void {
+        this._toggleFieldsetTabindex(true);
+    }
+
+    /**
+     * Toggles the `tabindex` attribute on the radio group's `fieldset` element.
+     *
+     * This method enables or disables the `tabindex` on the `fieldset` element based on
+     * the provided `enable` flag. Enabling the `tabindex` allows the radio group to be
+     * focusable via keyboard navigation, while disabling it prevents the `fieldset` from
+     * interfering with the focus management of its child options.
+     *
+     * **Example Usage:**
+     * - When the radio group loses focus, `_toggleFieldsetTabindex(true)` ensures the group is focusable.
+     * - When a specific radio option is focused, `_toggleFieldsetTabindex(false)` prevents accidental focus on the `fieldset`.
+     *
+     * @param {boolean} enable - Whether to enable (`true`) or disable (`false`) the `tabindex` on the `fieldset`.
+     */
+    private _toggleFieldsetTabindex (enable: boolean): void {
+        const fieldset = this.shadowRoot?.querySelector('fieldset');
+
+        if (!fieldset) return;
+        if (enable) {
+            fieldset.setAttribute('tabindex', '0');
+        } else {
+            fieldset.removeAttribute('tabindex');
+        }
+    }
+
+    /**
+     * Moves focus within the radio group to the next or previous option.
+     *
+     * This method calculates the new index of the option to focus based on the
+     * current index and a directional step. It wraps around when the focus reaches
+     * the first or last option.
+     * Once the target option is determined, it focuses and triggers a click event on it.
+     *
+     * **Example Usage:**
+     * - If the current index is `0` and `step` is `1`, the next option (index `1`) will be focused.
+     * - If the current index is the last option and `step` is `1`, focus wraps to the first option.
+     *
+     * @param {number} currentIndex - The index of the currently focused option.
+     * @param {number} step - The directional step to move the focus (e.g., `1` for forward, `-1` for backward).
+     */
+    private _moveFocus (currentIndex: number, step: number): void {
+        const newIndex = (currentIndex + step + this._slottedChildren.length) % this._slottedChildren.length;
+        this._focusAndClickOption(this._slottedChildren[newIndex]);
+    }
+
+    /**
+     * Determines if a key press indicates forward navigation within the radio group.
+     *
+     * This method evaluates a keyboard event to check if the pressed key corresponds
+     * to forward navigation based on the current text direction (LTR or RTL).
+     *
+     * **Behaviour:**
+     * - For LTR (Left-to-Right) layouts:
+     *   - `ArrowRight` and `ArrowDown` indicate forward navigation.
+     * - For RTL (Right-to-Left) layouts:
+     *   - `ArrowLeft` and `ArrowDown` indicate forward navigation.
+     *
+     * **Example Usage:**
+     * - In an LTR layout, pressing `ArrowRight` or `ArrowDown` returns `true`.
+     * - In an RTL layout, pressing `ArrowLeft` or `ArrowDown` returns `true`.
+     *
+     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
+     * @returns {boolean} `true` if the key press is for forward navigation; otherwise, `false`.
+     */
+    private _isForwardKey (event: KeyboardEvent): boolean {
+        return (event.code === 'ArrowRight' && !this.isRTL) ||
+            (event.code === 'ArrowLeft' && this.isRTL) ||
+            event.code === 'ArrowDown';
+    }
+
+    /**
+     * Determines if a key press indicates backward navigation within the radio group.
+     *
+     * This method evaluates a keyboard event to check if the pressed key corresponds
+     * to backward navigation based on the current text direction (LTR or RTL).
+     *
+     * **Behaviour:**
+     * - For LTR (Left-to-Right) layouts:
+     *   - `ArrowLeft` and `ArrowUp` indicate backward navigation.
+     * - For RTL (Right-to-Left) layouts:
+     *   - `ArrowRight` and `ArrowUp` indicate backward navigation.
+     *
+     * **Example Usage:**
+     * - In an LTR layout, pressing `ArrowLeft` or `ArrowUp` returns `true`.
+     * - In an RTL layout, pressing `ArrowRight` or `ArrowUp` returns `true`.
+     *
+     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
+     * @returns {boolean} `true` if the key press is for backward navigation; otherwise, `false`.
+     */
+    private _isBackwardKey (event: KeyboardEvent): boolean {
+        return (event.code === 'ArrowLeft' && !this.isRTL) ||
+            (event.code === 'ArrowRight' && this.isRTL) ||
+            event.code === 'ArrowUp';
+    }
+
+    /**
+     * Handles keyboard navigation within the radio group using arrow keys.
+     *
+     * This method responds to `keydown` events and determines the appropriate navigation
+     * action (forward or backward) based on the pressed key and the current focus. It prevents
+     * the default browser behaviour (e.g., scrolling) when arrow keys are used for navigation.
+     *
+     * **Behaviour:**
+     * - Checks if the currently focused element is one of the radio group options.
+     * - Determines the index of the currently focused option.
+     * - Prevents default scrolling behavior if an arrow key (`ArrowRight`, `ArrowDown`, `ArrowLeft`, `ArrowUp`) is pressed.
+     * - Uses `_isForwardKey` or `_isBackwardKey` to determine the navigation direction and calls `_moveFocus` to update focus.
+     *
+     * **Example Usage:**
+     * - Pressing `ArrowRight` (in LTR) moves the focus to the next option.
+     * - Pressing `ArrowLeft` (in RTL) moves the focus to the next option.
+     * - Pressing `ArrowUp` or `ArrowDown` navigates backward or forward, respectively, regardless of text direction.
+     *
+     * @param {KeyboardEvent} event - The keyboard event containing information about the key press.
+     */
+    private _handleKeyDown (event: KeyboardEvent): void {
+        const currentlyFocusedChild = this._slottedChildren.find((child) => child === document.activeElement);
+
+        if (!currentlyFocusedChild) {
+            return;
+        }
+
+        const currentIndex = this._slottedChildren.indexOf(currentlyFocusedChild);
+        if (currentIndex === -1) {
+            return;
+        }
+
+        // Prevent default scrolling behavior when using Arrow keys for Radio Group navigation
+        if (['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'].includes(event.code)) {
+            event.preventDefault();
+        }
+
+        if (this._isForwardKey(event)) {
+            this._moveFocus(currentIndex, 1);
+        } else if (this._isBackwardKey(event)) {
+            this._moveFocus(currentIndex, -1);
+        }
+    }
+
+    /**
+     * Focuses a radio option and triggers a `click` event to ensure proper behaviour.
+     *
+     * This method sets focus on the provided radio option and programmatically triggers
+     * a `click` event on its underlying `<input>` element. The `click` event ensures
+     * that the radio group emits a `change` event as expected. Additionally,
+     * it disables the `fieldset`'s `tabindex` to maintain proper focus behavior.
+     *
+     * **Behaviour:**
+     * - Sets focus on the provided `option`.
+     * - Finds the corresponding `<input>` element within the `option`'s shadow DOM (if available)
+     *   and triggers a `click` event.
+     * - Disables the `tabindex` on the `fieldset` to ensure focus remains on the option.
+     *
+     * @param {HTMLInputElement} option - The radio option to focus and click.
+     */
+    private _focusAndClickOption (option: HTMLInputElement): void {
+        option.focus();
+        // This is quite hacky, but it ensures the radio elements correct emit a real change event.
+        // Simply setting option.checked as true would require re-architecture of both this component and the radio button
+        // to ensure that property changes are observed and correctly propagated up.
+        option.shadowRoot?.querySelector('input')?.click();
+        this._toggleFieldsetTabindex(false);
     }
 
     disconnectedCallback (): void {
         super.disconnectedCallback();
-        this._abortController.abort();
+        this._abortController.abort(); // This automatically removes event listeners associated with the signal
     }
 
     render () {
@@ -179,6 +437,7 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
         return html`
             <fieldset
+                tabindex="0"
                 name=${ifDefined(name)}
                 ?disabled=${disabled}
                 data-test-id="pie-radio-group"

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -224,16 +224,13 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
     private _handleFocusIn (event: FocusEvent): void {
         if (this !== event.target) return;
 
-        console.log('In _handleFocusIn');
         const isShiftTab = PieRadioGroup._wasShiftTabPressed;
         const focusTarget = this._slottedChildren?.find((child) => child.checked) ||
             (isShiftTab ? this._slottedChildren.at(-1) : this._slottedChildren[0]);
 
         if (!focusTarget) return;
 
-        console.log('focusing: ', focusTarget);
         focusTarget.focus();
-        console.log('focused: ', focusTarget);
         this._toggleFieldsetTabindex(false);
     }
 

--- a/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
+++ b/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
@@ -1,0 +1,349 @@
+import { test, expect } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+
+// The structure of this object reflects the structure of our test Story
+const selectors = {
+    button1: 'btn-1',
+    radioGroup1: {
+        self: 'radio-group-1',
+        radios: {
+            1: 'radio-1',
+            2: 'radio-2',
+            3: 'radio-3',
+            4: 'radio-4',
+            5: 'radio-5',
+        },
+    },
+    button2: 'btn-2',
+    button3: 'btn-3',
+    radioGroup2: {
+        self: 'radio-group-2',
+        radios: {
+            1: 'radio-6',
+            2: 'radio-7',
+            3: 'radio-8',
+            4: 'radio-9',
+            5: 'radio-10',
+        },
+    },
+    button4: 'btn-4',
+};
+
+test.describe('PieRadioGroup - Component tests new', () => {
+    let pageObject;
+
+    test.describe('Keyboard navigation', () => {
+        test.describe('Tab', () => {
+            test.beforeEach(async ({ page }) => {
+                pageObject = new BasePage(page, 'radio-group');
+                await pageObject.load();
+            });
+
+            test('Tab and no option selected focuses the first radio', async ({ page }) => {
+                // Tab 2 times to go button 1 -> Radio group 1
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                const radio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+
+                await expect(radio).toBeFocused();
+            });
+
+            test('Tab and an option selected focuses the selected', async ({ page }) => {
+                // Tab 5 times to go button 1 -> Radio group 1 -> Button 2 -> Button 3 -> Radio group 2 (Where the focused option is)
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                const radio = page.getByTestId(selectors.radioGroup2.radios[4]).locator('input');
+
+                await expect(radio).toBeFocused();
+            });
+
+            test('Second Tab leaves the radio group', async ({ page }) => {
+                // Tab 3 times to go button 1 -> Radio group 1 -> Button 2
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                const button = page.getByTestId(selectors.button2);
+
+                await expect(button).toBeFocused();
+            });
+        });
+
+        test.describe('Shift + Tab', () => {
+            test.beforeEach(async ({ page }) => {
+                pageObject = new BasePage(page, 'radio-group');
+                await pageObject.load();
+            });
+
+            test('Shift + Tab and no option selected focuses the last radio', async ({ page }) => {
+                // First Tab 3 times to go button 1 -> Radio group 1 -> button 2
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                await page.keyboard.press('Shift+Tab');
+
+                const radio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+
+                await expect(radio).toBeFocused();
+            });
+
+            test('Shift + Tab and an option selected focuses the selected', async ({ page }) => {
+                // First Tab 6 times to go button 1 -> Radio group 1 -> button 2 -> Button 3 -> Radio group 2 -> Button 4
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                await page.keyboard.press('Shift+Tab');
+
+                const radio = page.getByTestId(selectors.radioGroup2.radios[4]).locator('input');
+
+                await expect(radio).toBeFocused();
+            });
+
+            test('Second Shift + Tab leaves the radio group', async ({ page }) => {
+                // First Tab 3 times to go button 1 -> Radio group 1 -> button 2
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                await page.keyboard.press('Shift+Tab');
+                await page.keyboard.press('Shift+Tab');
+
+                const button = page.getByTestId(selectors.button1);
+
+                await expect(button).toBeFocused();
+            });
+        });
+
+        test.describe('Arrow Keys', () => {
+            test.beforeEach(async ({ page }) => {
+                pageObject = new BasePage(page, 'radio-group');
+                await pageObject.load();
+            });
+
+            test('Left Arrow goes backwards through radios and loops', async ({ page }) => {
+                // Tab 2 times to go button 1 -> Radio group 1
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                await page.keyboard.press('ArrowLeft');
+
+                // Ensure it's gone backwards and selected the last radio
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                await expect(lastRadio).toBeFocused();
+                await expect(lastRadio).toBeChecked();
+
+                // Ensure it's gone backwards once more and selected the second to last radio
+                await page.keyboard.press('ArrowLeft');
+                const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                await expect(secondToLastRadio).toBeFocused();
+                await expect(secondToLastRadio).toBeChecked();
+            });
+
+            test('Up Arrow goes backwards through radios and loops', async ({ page }) => {
+                // Tab 2 times to go button 1 -> Radio group 1
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                await page.keyboard.press('ArrowUp');
+
+                // Ensure it's gone backwards and selected the last radio
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                await expect(lastRadio).toBeFocused();
+                await expect(lastRadio).toBeChecked();
+
+                // Ensure it's gone backwards once more and selected the second to last radio
+                await page.keyboard.press('ArrowUp');
+                const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                await expect(secondToLastRadio).toBeFocused();
+                await expect(secondToLastRadio).toBeChecked();
+            });
+
+            test('Right Arrow goes forwards through radios and loops', async ({ page }) => {
+                // Tab 2 times to go button 1 -> Radio group 1
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                // Press Arrow Right 4 times to get to the last radio
+                await page.keyboard.press('ArrowRight');
+                await page.keyboard.press('ArrowRight');
+                await page.keyboard.press('ArrowRight');
+                await page.keyboard.press('ArrowRight');
+
+                // Ensure we are on the last radio
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                await expect(lastRadio).toBeFocused();
+                await expect(lastRadio).toBeChecked();
+
+                // Press Arrow Right 1 more time to get back to the first radio
+                await page.keyboard.press('ArrowRight');
+
+                const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                await expect(firstRadio).toBeFocused();
+                await expect(firstRadio).toBeChecked();
+            });
+
+            test('Down Arrow goes forwards through radios and loops', async ({ page }) => {
+                // Tab 2 times to go button 1 -> Radio group 1
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                // Press Arrow Down 4 times to get to the last radio
+                await page.keyboard.press('ArrowDown');
+                await page.keyboard.press('ArrowDown');
+                await page.keyboard.press('ArrowDown');
+                await page.keyboard.press('ArrowDown');
+
+                // Ensure we are on the last radio
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                await expect(lastRadio).toBeFocused();
+                await expect(lastRadio).toBeChecked();
+
+                // Press Arrow Down 1 more time to get back to the first radio
+                await page.keyboard.press('ArrowDown');
+
+                const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                await expect(firstRadio).toBeFocused();
+                await expect(firstRadio).toBeChecked();
+            });
+
+            test('Arrow key selection in one Group does not affect the other', async ({ page }) => {
+                // Tab 2 times to go button 1 -> Radio group 1
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                await page.keyboard.press('ArrowRight');
+
+                // Ensure it's gone forwards and selected the second radio
+                const secondRadioButtonGroup1 = page.getByTestId(selectors.radioGroup1.radios[2]).locator('input');
+                await expect(secondRadioButtonGroup1).toBeFocused();
+                await expect(secondRadioButtonGroup1).toBeChecked();
+
+                // Move to next radio group
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+
+                // Press right to move from the selected radio to the next
+                await page.keyboard.press('ArrowRight');
+                const lastRadioButtonGroup2 = page.getByTestId(selectors.radioGroup2.radios[5]).locator('input');
+                await expect(lastRadioButtonGroup2).toBeFocused();
+                await expect(lastRadioButtonGroup2).toBeChecked();
+
+                // Press Shift + Tab 3 times to get back into the first radio group
+                await page.keyboard.press('Shift+Tab');
+                await page.keyboard.press('Shift+Tab');
+                await page.keyboard.press('Shift+Tab');
+
+                // Ensure the previously selected radio in the first group is focused and still selected
+                await expect(secondRadioButtonGroup1).toBeFocused();
+                await expect(secondRadioButtonGroup1).toBeChecked();
+            });
+        });
+
+        test.describe('RTL (Right-to-left)', () => {
+            test.beforeEach(async ({ page }) => {
+                pageObject = new BasePage(page, 'radio-group');
+                await pageObject.load({}, { writingDirection: 'rtl' });
+            });
+
+            test.describe('Arrow Keys', () => {
+                test('Left Arrow goes forwards through radios and loops', async ({ page }) => {
+                    // Tab 2 times to go button 1 -> Radio group 1
+                    await page.keyboard.press('Tab');
+                    await page.keyboard.press('Tab');
+
+                    // Press Arrow Left 4 times to get to the last radio
+                    await page.keyboard.press('ArrowLeft');
+                    await page.keyboard.press('ArrowLeft');
+                    await page.keyboard.press('ArrowLeft');
+                    await page.keyboard.press('ArrowLeft');
+
+                    // Ensure we are on the last radio
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    await expect(lastRadio).toBeFocused();
+                    await expect(lastRadio).toBeChecked();
+
+                    // Press Arrow Left 1 more time to get back to the first radio
+                    await page.keyboard.press('ArrowLeft');
+
+                    const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                    await expect(firstRadio).toBeFocused();
+                    await expect(firstRadio).toBeChecked();
+                });
+
+                test('Up Arrow goes backwards through radios and loops', async ({ page }) => {
+                    // Tab 2 times to go button 1 -> Radio group 1
+                    await page.keyboard.press('Tab');
+                    await page.keyboard.press('Tab');
+
+                    await page.keyboard.press('ArrowUp');
+
+                    // Ensure it's gone backwards and selected the last radio
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    await expect(lastRadio).toBeFocused();
+                    await expect(lastRadio).toBeChecked();
+
+                    // Ensure it's gone backwards once more and selected the second to last radio
+                    await page.keyboard.press('ArrowUp');
+                    const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                    await expect(secondToLastRadio).toBeFocused();
+                    await expect(secondToLastRadio).toBeChecked();
+                });
+
+                test('Right Arrow goes backwards through radios and loops', async ({ page }) => {
+                    // Tab 2 times to go button 1 -> Radio group 1
+                    await page.keyboard.press('Tab');
+                    await page.keyboard.press('Tab');
+
+                    await page.keyboard.press('ArrowRight');
+
+                    // Ensure it's gone backwards and selected the last radio
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    await expect(lastRadio).toBeFocused();
+                    await expect(lastRadio).toBeChecked();
+
+                    // Ensure it's gone backwards once more and selected the second to last radio
+                    await page.keyboard.press('ArrowRight');
+                    const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                    await expect(secondToLastRadio).toBeFocused();
+                    await expect(secondToLastRadio).toBeChecked();
+                });
+
+                test('Down Arrow goes forwards through radios and loops', async ({ page }) => {
+                    // Tab 2 times to go button 1 -> Radio group 1
+                    await page.keyboard.press('Tab');
+                    await page.keyboard.press('Tab');
+
+                    // Press Arrow Down 4 times to get to the last radio
+                    await page.keyboard.press('ArrowDown');
+                    await page.keyboard.press('ArrowDown');
+                    await page.keyboard.press('ArrowDown');
+                    await page.keyboard.press('ArrowDown');
+
+                    // Ensure we are on the last radio
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    await expect(lastRadio).toBeFocused();
+                    await expect(lastRadio).toBeChecked();
+
+                    // Press Arrow Down 1 more time to get back to the first radio
+                    await page.keyboard.press('ArrowDown');
+
+                    const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                    await expect(firstRadio).toBeFocused();
+                    await expect(firstRadio).toBeChecked();
+                });
+            });
+        });
+    });
+});
+

--- a/packages/components/pie-radio/src/index.ts
+++ b/packages/components/pie-radio/src/index.ts
@@ -27,6 +27,7 @@ const componentSelector = 'pie-radio';
  * @event {CustomEvent} change - Fires when the radio is checked (but not when unchecked).
  */
 export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements RadioProps {
+    static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
     @state()
     private _disabledByParent = false;
 

--- a/packages/components/pie-radio/src/index.ts
+++ b/packages/components/pie-radio/src/index.ts
@@ -27,7 +27,6 @@ const componentSelector = 'pie-radio';
  * @event {CustomEvent} change - Fires when the radio is checked (but not when unchecked).
  */
 export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements RadioProps {
-    static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
     @state()
     private _disabledByParent = false;
 
@@ -94,6 +93,10 @@ export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements 
         this.dispatchEvent(customChangeEvent);
 
         this._handleFormAssociation();
+    }
+
+    public focus () {
+        this._radio.focus();
     }
 
     /**

--- a/packages/components/pie-webc-testing/src/helpers/page-object/storybook-extensions.ts
+++ b/packages/components/pie-webc-testing/src/helpers/page-object/storybook-extensions.ts
@@ -1,4 +1,9 @@
-export const buildUrl = (componentName: string, path: string, args: string) => {
+export const buildUrl = (
+    componentName: string,
+    path: string,
+    args: string,
+    globals = '',
+) => {
     const prNumber = process.env.PR_NUMBER;
     const branch = process.env.GITHUB_REF;
 
@@ -18,5 +23,10 @@ export const buildUrl = (componentName: string, path: string, args: string) => {
         url += `&args=${args}`;
     }
 
+    if (globals) {
+        url += `&globals=${globals}`;
+    }
+
     return url;
 };
+


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Introduces keyboard navigation inside the Radio Group component. This functionality should adhere to the behaviours outlined in [this W3 guide](https://www.w3.org/WAI/ARIA/apg/patterns/radio/). Image attached below showing the relevant section.
- I have opted to mirror the `Shift + Tab` behaviour displayed in Chrome, whereby focusing the radio group when no option is selected will focus the last item.
- RTL support is included. When in RTL, the left arrow key will go forwards and the right array will go backwards.

<img width="993" alt="Screenshot 2024-12-12 at 15 45 56" src="https://github.com/user-attachments/assets/65a71d1a-b39b-4c56-a769-16ab2aac8ef8" />

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have reviewed visual test updates properly before approving.
---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](https://github.com/justeattakeaway/pie-aperture/pull/232) |
| NextJS 14 deployment   | [🔗](https://pr232-aperture-nextjs-app-v14.pie.design/components/radio-group) |
| Nuxt 3 deployment      | [🔗](https://pr232-aperture-nuxt-app.pie.design/components/radio-group) |
| Vanilla deployment     | [🔗](https://pr232-aperture-vanilla-app.pie.design/components/radio-group.html) |
| Storybook Deployment | [🔗](https://pr2108-storybook.pie.design/?path=/story/radio-group--default)

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.
