### PR TITLE
refactor(pie-button): DSW-2369 to use @playwright/test & storybook for testing

### DIFF
--- a/apps/pie-storybook/stories/testing/pie-button.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-button.test.stories.ts
@@ -1,0 +1,455 @@
+import { html, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { type Meta } from '@storybook/web-components';
+
+import '@justeattakeaway/pie-button';
+import {
+    type ButtonProps as ButtonPropsBase, defaultProps, iconPlacements, responsiveSizes, sizes, types, variants,
+} from '@justeattakeaway/pie-button';
+import '@justeattakeaway/pie-icons-webc/dist/IconPlusCircle.js';
+
+import {
+    createStory, createVariantStory, type TemplateFunction, sanitizeAndRenderHTML,
+} from '../../utilities';
+import { type SlottedComponentProps } from '../../types';
+
+type ButtonProps = SlottedComponentProps<ButtonPropsBase> & {
+    showSubmitButton?: boolean;
+    showNativeResetButton?: boolean;
+    renderIncorrectForm?: boolean;
+};
+type ButtonStoryMeta = Meta<ButtonProps>;
+
+function handleClick () {
+    console.info('Button clicked!');
+}
+
+const defaultArgs: ButtonProps = {
+    ...defaultProps,
+    iconPlacement: undefined,
+    slot: 'Label',
+    showNativeResetButton: false,
+    showSubmitButton: true,
+    renderIncorrectForm: false,
+};
+
+const buttonStoryMeta: ButtonStoryMeta = {
+    title: 'Button',
+    component: 'pie-button',
+    argTypes: {
+        tag: {
+            control: {
+                disable: true,
+            },
+            defaultValue: {
+                summary: 'button',
+            },
+        },
+        size: {
+            control: 'select',
+            options: sizes,
+            defaultValue: {
+                summary: defaultProps.size,
+            },
+        },
+        type: {
+            control: 'select',
+            options: types,
+            defaultValue: {
+                summary: defaultProps.type,
+            },
+        },
+        variant: {
+            control: 'select',
+            options: variants,
+            defaultValue: {
+                summary: defaultProps.variant,
+            },
+        },
+        iconPlacement: {
+            control: 'select',
+            options: [undefined, ...iconPlacements],
+        },
+        disabled: {
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.disabled,
+            },
+        },
+        isFullWidth: {
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.isFullWidth,
+            },
+        },
+        isLoading: {
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.isLoading,
+            },
+        },
+        isResponsive: {
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.isResponsive,
+            },
+        },
+        slot: {
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        name: {
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+            if: { arg: 'type', eq: 'submit' },
+        },
+        value: {
+            control: 'text',
+            defaultValue: {
+                summary: '',
+            },
+            if: { arg: 'type', eq: 'submit' },
+        },
+        responsiveSize: {
+            control: 'select',
+            options: ['', ...responsiveSizes],
+            defaultValue: {
+                summary: 'productive',
+            },
+            if: { arg: 'isResponsive', eq: true },
+        },
+        href: {
+            control: 'text',
+        },
+        target: {
+            control: 'text',
+        },
+        rel: {
+            control: 'text',
+        },
+        showSubmitButton: {
+            control: 'boolean',
+            defaultValue: {
+                summary: true,
+            },
+        },
+        showNativeResetButton: {
+            control: 'boolean',
+            defaultValue: {
+                summary: false,
+            },
+        },
+    },
+    args: {
+        ...defaultArgs,
+    },
+};
+
+export default buttonStoryMeta;
+
+const Template: TemplateFunction<ButtonProps> = ({
+    size,
+    variant,
+    type,
+    disabled,
+    isFullWidth,
+    isLoading,
+    isResponsive,
+    slot,
+    iconPlacement,
+    name,
+    value,
+    responsiveSize,
+}) => html`
+<pie-button
+    tag="button"
+    data-test-id="pie-button-${type}"  
+    size="${ifDefined(size)}"
+    variant="${ifDefined(variant)}"
+    type="${ifDefined(type)}"
+    iconPlacement="${ifDefined(iconPlacement)}"
+    ?disabled="${disabled}"
+    ?isLoading="${isLoading}"
+    ?isFullWidth="${isFullWidth}"
+    ?isResponsive="${isResponsive}"
+    name=${ifDefined(name)}
+    value=${ifDefined(value)}
+    @click=${handleClick}
+    responsiveSize="${ifDefined(responsiveSize)}">
+    ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}
+    ${sanitizeAndRenderHTML(slot)}
+</pie-button>`;
+
+const AnchorTemplate: TemplateFunction<ButtonProps> = (props: ButtonProps) => html`
+    <pie-button
+        tag="a"
+        size="${ifDefined(props.size)}"
+        variant="${ifDefined(props.variant)}"
+        iconPlacement="${ifDefined(props.iconPlacement)}"
+        ?isFullWidth="${props.isFullWidth}"
+        ?isResponsive="${props.isResponsive}"
+        responsiveSize="${ifDefined(props.responsiveSize)}"
+        href="${ifDefined(props.href)}"
+        rel="${ifDefined(props.rel)}"
+        target="${ifDefined(props.target)}">
+        ${props.iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}
+        ${sanitizeAndRenderHTML(props.slot)}
+    </pie-button>`;
+
+const FormTemplate: TemplateFunction<ButtonProps> = ({
+    showSubmitButton,
+    showNativeResetButton,
+    renderIncorrectForm,
+    ...props
+}) => {
+    function onSubmit (event: Event) {
+        event.preventDefault();
+
+        const formLog = document.querySelector('#formLog') as HTMLElement;
+        if (!formLog) return;
+
+        formLog.textContent = 'Form submitted!';
+        formLog.style.display = 'block';
+
+        const span = document.createElement('span');
+        span.id = 'formSubmittedFlag';
+        span.setAttribute('data-test-id', 'formSubmittedFlag');
+        span.style.display = 'none';
+        document.body.appendChild(span);
+
+        setTimeout(() => {
+            formLog.textContent = '';
+            formLog.style.display = 'none';
+        }, 8000);
+    }
+
+    return html`
+        ${renderIncorrectForm ? html`<form id="wrongForm"></form>` : nothing}
+        <p id="formLog" style="display: none; font-size: 2rem; color: var(--dt-color-support-positive);"></p>
+        <h2>Fake form</h2>
+        <form data-test-id="testForm" id="testForm" @submit=${onSubmit}>
+            <p>Required fields are followed by <strong><span aria-label="required">*</span></strong>.</p>
+            <section>
+                <h2>Contact information</h2>
+                <p>
+                    <label for="name">
+                        <span>Name: </span>
+                        <strong><span aria-label="required">*</span></strong>
+                    </label>
+                    <input type="text" id="name" data-test-id="name" name="username" required />
+                </p>
+                <p>
+                    <label for="mail">
+                        <span>E-mail: </span>
+                        <strong><span aria-label="required">*</span></strong>
+                    </label>
+                    <input type="email" data-test-id="usermail" id="mail" name="usermail" required />
+                </p>
+                <p>
+                    <label for="pwd">
+                        <span>Password: </span>
+                        <strong><span aria-label="required">*</span></strong>
+                    </label>
+                    <input type="password" data-test-id="password" id="pwd" name="password" required />
+                </p>
+            </section>
+            <section>
+                <h2>Payment information</h2>
+                <p>
+                    <label for="card">
+                        <span>Card type:</span>
+                    </label>
+                    <select data-test-id="usercard" id="card" name="usercard">
+                        <option value="visa">Visa</option>
+                        <option value="mastercard">Mastercard</option>
+                        <option value="amex">American Express</option>
+                    </select>
+                </p>
+                <p>
+                    <label for="number">
+                        <span>Card number:</span>
+                        <strong><span aria-label="required">*</span></strong>
+                    </label>
+                    <input type="tel" data-test-id="card-number" id="number" name="cardnumber" required />
+                </p>
+                <p>
+                    <label for="expiration">
+                        <span>Expiration date:</span>
+                        <strong><span aria-label="required">*</span></strong>
+                    </label>
+                    <input type="text" data-test-id="card-expiration" id="expiration" required placeholder="MM/YY"
+                        pattern="^(0[1-9]|1[0-2])\/([0-9]{2})$" />
+                </p>
+            </section>
+            <section style="display: flex; gap: var(--dt-spacing-a); justify-content: flex-end; flex-wrap: wrap; margin-top: var(--dt-spacing-b);">
+                ${showNativeResetButton ? html`<button data-test-id="button-reset" id="resetNativeButton" type="reset">Reset</button>` : Template({
+        ...props,
+        variant: 'secondary',
+        slot: 'Reset',
+        type: 'reset',
+    })}
+                ${showSubmitButton ? Template({
+        ...props,
+        variant: 'primary',
+        slot: 'Submit payment',
+        type: 'submit',
+    }) : nothing}
+            </section>
+        </form>
+    `;
+};
+
+const createButtonStory = createStory<ButtonProps>(Template, defaultArgs);
+
+const createButtonStoryWithForm = createStory<ButtonProps>(FormTemplate, defaultArgs);
+
+export const Primary = createButtonStory();
+
+export const Anchor = createStory(AnchorTemplate, defaultArgs)({
+    href: '/?path=/story/button--anchor',
+}, {
+    argTypes: {
+        tag: {
+            description: 'Choose the HTML element that will be used to render the button.<br>For this story, the prop has the value of `a`. See the other stories to interact with the component when this prop has a value of `button`.',
+        },
+    },
+});
+
+export const FormIntegration = createButtonStoryWithForm({ type: 'submit' });
+
+const FormSubmissionTemplate: TemplateFunction<ButtonProps> = () => html`
+    <form id="formSubmissionTestForm" action="/submit-endpoint" method="POST">
+        <input type="text" name="username" placeholder="Enter your username" required>
+        <pie-button
+            id="TestButton"
+            type="submit"
+            name="submitButton"
+            value="submitValue"
+        >
+          Submit
+        </pie-button>
+    </form>
+`;
+
+export const FormSubmission = createStory<ButtonProps>(FormSubmissionTemplate, {
+    ...defaultArgs,
+    type: 'submit',
+})();
+
+const FormWithAllAttributesTemplate: TemplateFunction<ButtonProps> = () => html`
+    <form id="testForm" action="/default-endpoint" method="GET">
+        <input type="text" name="username" required>
+        <pie-button id="testButton"
+                    type="submit"
+                    name="submitButton"
+                    value="submitValue"
+                    formaction="/custom-endpoint"
+                    formenctype="multipart/form-data"
+                    formmethod="POST"
+                    formnovalidate
+                    formtarget="_self">
+            Submit
+        </pie-button>
+    </form>
+`;
+
+export const FormWithAllAttributes = createStory<ButtonProps>(FormWithAllAttributesTemplate, {
+    ...defaultArgs,
+    type: 'submit',
+})();
+
+const sharedPropMatrix : Partial<Record<keyof ButtonProps, unknown[]>> = {
+    iconPlacement: [...iconPlacements],
+    isFullWidth: [true, false],
+    isLoading: [true, false],
+    disabled: [true, false],
+    slot: ['Label'],
+    size: [...sizes],
+};
+
+export const DoubleLineTextButtonVariations = createVariantStory<ButtonProps>(Template, {
+    slot: ['This is a really long string to test the overflow'],
+    size: [...sizes],
+    isResponsive: [true, false],
+    responsiveSize: [...responsiveSizes],
+});
+
+export const ResponsiveButtonVariations = createVariantStory<ButtonProps>(Template, {
+    slot: ['Hello World'],
+    size: [...sizes],
+    responsiveSize: [...responsiveSizes],
+    isResponsive: [true, false],
+}, { multiColumn: true });
+
+/*----------------------------------------
+  Anchor Variations
+----------------------------------------*/
+const sharedAnchorPropMatrix : Partial<Record<keyof ButtonProps, unknown[]>> = {
+    tag: ['a'],
+    slot: ['Hello World'],
+    isResponsive: [true, false],
+    responsiveSize: [...responsiveSizes],
+    size: [...sizes],
+};
+
+export const PrimaryAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['primary'] });
+export const SecondaryAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['secondary'] });
+export const OutlineAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['outline'] });
+export const GhostAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['ghost'] });
+export const OutlineInverseAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['outline-inverse'] }, { bgColor: 'background-dark' });
+export const InverseAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['inverse'] }, { bgColor: 'background-dark' });
+export const GhostInverseAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['ghost-inverse'] }, { bgColor: 'background-dark' });
+export const DestructiveAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['destructive'] });
+export const DestructiveGhostAnchorVariations = createVariantStory<ButtonProps>(AnchorTemplate, { ...sharedAnchorPropMatrix, variant: ['destructive-ghost'] });
+
+/*----------------------------------------
+  Button Variations
+----------------------------------------*/
+export const PrimaryVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['primary'],
+}, { multiColumn: true });
+
+export const SecondaryVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['secondary'],
+}, { multiColumn: true });
+
+export const OutlineVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['outline'],
+}, { multiColumn: true });
+
+export const OutlineInverseVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['outline-inverse'],
+}, { bgColor: 'background-dark', multiColumn: true });
+
+export const GhostVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['ghost'],
+}, { multiColumn: true });
+
+export const InverseVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['inverse'],
+}, { bgColor: 'background-dark', multiColumn: true });
+
+export const GhostInverseVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['ghost-inverse'],
+}, { bgColor: 'background-dark', multiColumn: true });
+
+export const DestructiveVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['destructive'],
+}, { multiColumn: true });
+
+export const DestructiveGhostVariations = createVariantStory<ButtonProps>(Template, {
+    ...sharedPropMatrix,
+    variant: ['destructive-ghost'],
+}, { multiColumn: true });

--- a/configs/pie-components-config/playwright-native-config.js
+++ b/configs/pie-components-config/playwright-native-config.js
@@ -8,7 +8,7 @@ export function getPlaywrightNativeConfig () {
         /* The base directory, relative to the config file, for snapshot files created with toMatchSnapshot and toHaveScreenshot. */
         snapshotDir: './__snapshots__',
         /* Maximum time one test can run for. */
-        timeout: 10 * 1000,
+        timeout: 20 * 1000,
         testIgnore: '*-react.spec.js',
         /* Run tests in files in parallel */
         fullyParallel: true,

--- a/packages/components/pie-assistive-text/test/component/pie-assistive-text.spec.ts
+++ b/packages/components/pie-assistive-text/test/component/pie-assistive-text.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 import { assistiveText } from '../helpers/page-object/selectors.ts';
-import type { AssistiveTextProps } from '../../src/index.ts';
 
 test.describe('PieAssistiveText - Component tests', () => {
     test('should render successfully', async ({ page }) => {

--- a/packages/components/pie-button/playwright-lit-visual.config.ts
+++ b/packages/components/pie-button/playwright-lit-visual.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightVisualConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeVisualConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightVisualConfig());
+export default defineConfig(getPlaywrightNativeVisualConfig());

--- a/packages/components/pie-button/playwright-lit.config.ts
+++ b/packages/components/pie-button/playwright-lit.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightConfig());
+export default defineConfig(getPlaywrightNativeConfig());

--- a/packages/components/pie-button/test/component/pie-button.spec.ts
+++ b/packages/components/pie-button/test/component/pie-button.spec.ts
@@ -1,228 +1,110 @@
-import { getShadowElementStylePropValues } from '@justeattakeaway/pie-webc-testing/src/helpers/get-shadow-element-style-prop-values.ts';
-import { test, expect } from '@sand4rt/experimental-ct-web';
-import { PieButton, type ButtonProps } from '../../src/index.ts';
+import { test, expect } from '@playwright/test';
+import { ButtonDefaultPage } from '../helpers/page-object/pie-button-default.page.ts';
+import { ButtonAnchorPage } from '../helpers/page-object/pie-button-anchor.page.ts';
+import { FormIntegrationPage, type FormInput } from '../helpers/page-object/pie-button-form-integration.page.ts';
+import { FormAttributesPage } from '../helpers/page-object/pie-button-form-attributes.page.ts';
+import { FormSubmissionPage } from '../helpers/page-object/pie-button-form-submission.page.ts';
+import type { ButtonProps } from '../../src/index.ts';
 
-type SizeResponsiveSize = {
-    sizeName: ButtonProps['size'];
-    responsiveSize: string;
+const formInputData: FormInput = {
+    userName: 'John Doe',
+    userEmail: 'john.doe@example.com',
+    userPassword: 'password',
+    userPaymentCardType: 'mastercard',
+    userPaymentCardNumber: '4921111111111111',
+    userPaymentCardExpiration: '12/24',
 };
 
-const sizes: Array<SizeResponsiveSize> = [
-    { sizeName: 'xsmall', responsiveSize: '--btn-height--small' },
-    { sizeName: 'small-expressive', responsiveSize: '--btn-height--medium' },
-    { sizeName: 'small-productive', responsiveSize: '--btn-height--medium' },
-    { sizeName: 'medium', responsiveSize: '--btn-height--large' },
-    { sizeName: 'large', responsiveSize: '--btn-height--large' },
-];
+test('should correctly work with native click events', async ({ page }) => {
+    // Arrange
+    const buttonDefaultPage = new ButtonDefaultPage(page);
+    await buttonDefaultPage.load();
 
-test('should correctly work with native click events', async ({ mount }) => {
-    const messages: string[] = [];
-    const expectedEventMessage = 'Native event dispatched';
-    const component = await mount(
-        PieButton,
-        {
-            slots: {
-                default: 'Click me!',
-            },
-            on: {
-                click: () => {
-                    messages.push(expectedEventMessage);
-                },
-            },
-        },
-    );
+    // Set up a listener for console messages
+    const consoleMessages: string[] = [];
+    page.on('console', (message) => {
+        if (message.type() === 'info') {
+            consoleMessages.push(message.text());
+        }
+    });
 
-    await component.click();
+    // Act
+    await buttonDefaultPage.clickButtonWithText('Label');
 
-    expect(messages).toEqual([expectedEventMessage]);
+    // Assert
+    expect(consoleMessages).toContain('Button clicked!');
 });
 
 test.describe('Form Actions', () => {
-    test.beforeEach(async ({ mount }) => {
-        const component = await mount(PieButton);
-        await component.unmount();
-    });
-
     test.describe('Submit', () => {
         test('should correctly submit an HTML form when type is `submit`', async ({ page }) => {
             // Arrange
-            // Inject the test form into the page
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/foo" method="POST">
-                    <input type="text" id="username" name="username" required>
-                    <input type="password" id="password" name="password" required>
-                    <pie-button id="submitButton" type="submit">Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
-
-            // Set up the form submission listener
-            await page.evaluate(() => {
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault(); // Prevent the actual submission - we only care about detecting the submit
-
-                    // Append a hidden span element to the body
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    span.style.display = 'none';
-                    document.body.appendChild(span);
-                });
-            });
-
-            // Fill out the form
-            await page.fill('#username', 'testUser');
-            await page.fill('#password', 'testPassword');
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load();
 
             // Act
-            await page.click('#submitButton');
+            await formIntegrationPage.fillForm(formInputData);
+            await formIntegrationPage.clickButtonWithText('Submit');
 
             // Assert
-            // Check if the hidden span was appended, indicating the form was submitted
-            const wasFormSubmitted = Boolean(await page.$('#formSubmittedFlag'));
-
-            expect(wasFormSubmitted).toBe(true);
+            await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(1);
+            await expect(formIntegrationPage.formSubmittedFlag).toBeHidden();
         });
 
         test('should trigger native HTML form validation for required fields and submit after correcting when type is `submit`', async ({ page }) => {
             // Arrange
-            // Inject the test form into the page
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/foo" method="POST">
-                    <input type="text" id="username" name="username" required>
-                    <input type="password" id="password" name="password" required>
-                    <pie-button id="submitButton" type="submit">Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load();
 
-            // Set up the form submission listener
-            await page.evaluate(() => {
-                const form = document.querySelector('#testForm') as HTMLFormElement;
+            // Act
+            await formIntegrationPage.clickButtonWithText('Submit');
 
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault(); // Prevent the actual submission - we only care about detecting the submit
+            // Assert
+            await expect.soft(formIntegrationPage.formSubmittedFlag).toHaveCount(0);
 
-                    // Add a span to indicate the form was submitted
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
+            await formIntegrationPage.fillForm(formInputData);
+            await formIntegrationPage.clickButtonWithText('Submit');
 
-            // Act & Assert
-            // Attempt to click the submit button without filling out required fields
-            await page.click('#submitButton');
-
-            // Check if the form was not submitted (indicated by the absence of the span)
-            let formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(false);
-
-            // Fill out the form
-            await page.fill('#username', 'testUser');
-            await page.fill('#password', 'testPassword');
-
-            // Attempt to submit the form again
-            await page.click('pie-button[type="submit"]');
-
-            // Check if the form was submitted this time (indicated by the presence of the span)
-            formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(true);
+            // Assert
+            await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(1);
         });
 
         test('should not submit the form when button is disabled and type is `submit`', async ({ page }) => {
             // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/foo" method="POST">
-                    <input type="text" id="username" name="username">
-                    <input type="password" id="password" name="password">
-                    <pie-button id="submitButton" type="submit" disabled>Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
-
-            // Set up the form submission listener
-            await page.evaluate(() => {
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault();
-
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load({ disabled: true });
 
             // Act
-            await page.click('#submitButton');
+            await formIntegrationPage.clickButtonWithText('Submit');
 
             // Assert
-            const formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(false); // Form should not submit
+            await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(0);
         });
 
         test('should not submit the form when button has isLoading set and type is `submit`', async ({ page }) => {
             // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/foo" method="POST">
-                    <input type="text" id="username" name="username">
-                    <input type="password" id="password" name="password">
-                    <pie-button id="submitButton" type="submit" isLoading>Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
-
-            // Set up the form submission listener
-            await page.evaluate(() => {
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault();
-
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load({ isLoading: true });
 
             // Act
-            await page.click('#submitButton');
+            await formIntegrationPage.clickButtonWithText('Submit');
 
             // Assert
-            const formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(false); // Form should not submit
+            await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(0);
         });
 
         test('should include pie-button\'s name and value in the form submission data when it triggers submission', async ({ page }) => {
             // Arrange
-            // Inject the test form into the page with pie-button having name and value attributes
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/submit-endpoint" method="POST">
-                    <input type="text" name="username">
-                    <pie-button id="testButton" type="submit" name="submitButton" value="submitValue">Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
+            const formSubmissionPage = new FormSubmissionPage(page);
+            await formSubmissionPage.load();
 
-            // Intercept form submissions
-            const [request] = await Promise.all([
-                page.waitForRequest('/submit-endpoint'),
-                page.fill('input[name="username"]', 'testUser'),
-                page.click('#testButton'),
-            ]);
+            // Act
+            const requestPromise = page.waitForRequest(/submit-endpoint/);
+            await page.fill('input[name="username"]', 'testUser');
 
+            await formSubmissionPage.clickButtonWithText('Submit');
+
+            const request = await requestPromise;
             const formData = request.postData();
 
             // Assert
@@ -231,39 +113,22 @@ test.describe('Form Actions', () => {
 
         test('should respect all form-related attributes on the pie-button', async ({ page }) => {
             // Arrange
-            // Inject the test form into the page with pie-button having multiple form attributes
-            await page.evaluate(() => {
-                const formHTML = `
-                    <form id="testForm" action="/default-endpoint" method="GET">
-                        <input type="text" name="username" required>
-                        <pie-button id="testButton"
-                                    type="submit"
-                                    name="submitButton"
-                                    value="submitValue"
-                                    formaction="/custom-endpoint"
-                                    formenctype="multipart/form-data"
-                                    formmethod="POST"
-                                    formnovalidate
-                                    formtarget="_self">Submit</pie-button>
-                    </form>
-                `;
-                document.body.innerHTML = formHTML;
-            });
+            const formAttributesPage = new FormAttributesPage(page);
+            await formAttributesPage.load();
 
             // Act
-            // Intercept form submissions
-            const [request] = await Promise.all([
-                page.waitForRequest('/custom-endpoint'),
-                page.fill('input[name="username"]', 'testUser'),
-                page.click('#testButton'),
-            ]);
+            const requestPromise = page.waitForRequest(/custom-endpoint/);
+            await page.fill('input[name="username"]', 'testUser');
+            await formAttributesPage.clickButtonWithText('Submit');
+
+            const request = await requestPromise;
 
             const postData = request.postData();
             const method = request.method();
             const headers = request.headers();
 
             // Assert
-            expect(postData).toBeTruthy();
+            expect(postData).not.toBeNull();
             const submitButtonDisposition = 'Content-Disposition: form-data; name="submitButton"';
             const submitButtonValuePosition = (postData as string).indexOf(submitButtonDisposition) + submitButtonDisposition.length;
             expect((postData as string).includes(submitButtonDisposition)).toBeTruthy();
@@ -272,422 +137,148 @@ test.describe('Form Actions', () => {
             expect(method).toBe('POST');
         });
 
-        test('should submit the form when pressing Enter with pie-button type `submit`', async ({ page }) => {
-            // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/foo" method="POST">
-                    <input type="text" id="username" name="username" required>
-                    <input type="password" id="password" name="password" required>
-                    <pie-button id="submitButton" type="submit">Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
+        const submitTestCases = [
+            { titlePrefix: 'should submit', showSubmitButton: true, expectedFormSubmittedFlagCount: 1 },
+            { titlePrefix: 'should not submit', showSubmitButton: false, expectedFormSubmittedFlagCount: 0 },
+        ];
+
+        submitTestCases.forEach((testCase) => {
+            test(` ${testCase.titlePrefix} the form when pressing Enter with pie-button type 'submit': ${testCase.showSubmitButton}`, async ({ page }) => {
+                // Arrange
+                const formIntegrationPage = new FormIntegrationPage(page);
+                await formIntegrationPage.load({ showSubmitButton: testCase.showSubmitButton });
+
+                // Act
+                await formIntegrationPage.fillForm(formInputData);
+                await formIntegrationPage.userPasswordInput.focus();
+                await formIntegrationPage.userPasswordInput.press('Enter');
+
+                // Assert
+                await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(testCase.expectedFormSubmittedFlagCount);
             });
-
-            // Set up the form submission listener
-            await page.evaluate(() => {
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault();
-
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
-
-            // Fill out the form
-            await page.fill('#username', 'testUser');
-            await page.fill('#password', 'testPassword');
-
-            // Act
-            // Press Enter in the password field
-            await page.focus('#password');
-            await page.press('#password', 'Enter');
-
-            // Assert
-            const formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(true);
-        });
-
-        test('should NOT submit the form when pressing Enter with pie-button type other than `submit`', async ({ page }) => {
-            // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm" action="/foo" method="POST">
-                    <input type="text" id="username" name="username" required>
-                    <input type="password" id="password" name="password" required>
-                    <pie-button id="resetButton" type="reset">Reset</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
-
-            // Set up the form submission listener
-            await page.evaluate(() => {
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault();
-
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
-
-            // Fill out the form
-            await page.fill('#username', 'testUser');
-            await page.fill('#password', 'testPassword');
-
-            // Act
-            // Press Enter in the password field
-            await page.focus('#password');
-            await page.press('#password', 'Enter');
-
-            // Assert
-            const formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(false);
         });
 
         test('should NOT submit the form when pressing Enter on a pie-button that is not type of submit', async ({ page }) => {
             // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                    <form id="testForm" action="/foo" method="POST">
-                        <input type="text" id="username" name="username" required>
-                        <input type="password" id="password" name="password" required>
-                        <pie-button type="submit">Submit</pie-button>
-                        <pie-button id="resetPieButton" type="reset">Reset</pie-button>
-                    </form>
-                `;
-                document.body.innerHTML = formHTML;
-
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault();
-
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load();
 
             // Fill out the form
-            await page.fill('#username', 'testUser');
-            await page.fill('#password', 'testPassword');
+            await formIntegrationPage.fillForm(formInputData);
 
             // Act
-            // Press Tab until we focus the reset button
             await page.keyboard.press('Tab');
-            await page.keyboard.press('Tab');
-
-            // Press Enter on the pie-button with type reset
-            await page.press('#resetPieButton', 'Enter');
+            await page.keyboard.press('Enter');
 
             // Assert
-            const formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(false);
+            await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(0);
         });
 
         test('should NOT submit the form when pressing Enter on a native non-submit button', async ({ page }) => {
             // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                    <form id="testForm" action="/foo" method="POST">
-                        <input type="text" id="username" name="username" required>
-                        <input type="password" id="password" name="password" required>
-                        <pie-button type="submit">Submit</pie-button>
-                        <button id="resetNativeButton" type="reset">Reset</button>
-                    </form>
-                `;
-                document.body.innerHTML = formHTML;
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load({ showNativeResetButton: true });
 
-                const form = document.querySelector('#testForm') as HTMLFormElement;
-
-                form.addEventListener('submit', (e) => {
-                    e.preventDefault();
-
-                    const span = document.createElement('span');
-                    span.id = 'formSubmittedFlag';
-                    document.body.appendChild(span);
-                });
-            });
-
-            // Fill out the form
-            await page.fill('#username', 'testUser');
-            await page.fill('#password', 'testPassword');
+            await formIntegrationPage.fillForm(formInputData);
 
             // Act
-            // Press Enter on the native button with type reset
-            await page.focus('#resetNativeButton');
-            await page.press('#resetNativeButton', 'Enter');
+            await formIntegrationPage.resetNativeButton.focus();
+            await formIntegrationPage.resetNativeButton.press('Enter');
 
             // Assert
-            const formSubmittedFlagExists = Boolean(await page.$('#formSubmittedFlag'));
-            expect(formSubmittedFlagExists).toBe(false);
+            await expect(formIntegrationPage.formSubmittedFlag).toHaveCount(0);
         });
     });
 
     test.describe('Reset', () => {
         test('should reset the form by clicking the reset button when type is `reset`', async ({ page }) => {
             // Arrange
-            // Inject the test form into the page with a reset button
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm">
-                    <input type="text" data-test-id="username" id="username" name="username" required>
-                    <input type="password" data-test-id="password" id="password" name="password" required>
-                    <pie-button type="reset" id="resetButton">Reset</pie-button>
-                    <pie-button type="submit">Submit</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load();
 
-            // Fill out the form
-            const testUsername = 'testUser';
-            const testPassword = 'testPassword';
-            await page.fill('#username', testUsername);
-            await page.fill('#password', testPassword);
+            await formIntegrationPage.fillForm(formInputData);
 
             // Act
-            await page.click('#resetButton');
+            await formIntegrationPage.clickButtonWithText('Reset');
 
             // Assert
-            // Check if the form fields have been reset
-            const usernameValue = await page.getByTestId('username').inputValue();
-            const passwordValue = await page.getByTestId('password').inputValue();
+            const formFieldValues = await formIntegrationPage.getFormFieldValues();
 
-            expect(usernameValue).toBe('');
-            expect(passwordValue).toBe('');
+            const expectedFormFieldValues: FormInput = {
+                userName: '',
+                userEmail: '',
+                userPassword: '',
+                userPaymentCardType: 'visa',
+                userPaymentCardNumber: '',
+                userPaymentCardExpiration: '',
+            };
+
+            expect(formFieldValues).toEqual(expectedFormFieldValues);
         });
 
         test('should not reset the form when button is disabled and type is `reset`', async ({ page }) => {
             // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm">
-                    <input type="text" id="username" name="username" value="initialValue">
-                    <pie-button id="resetButton" type="reset" disabled>Reset</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load({ disabled: true });
 
-            // Change the form input value
-            await page.fill('#username', 'changedValue');
+            await formIntegrationPage.fillForm(formInputData);
 
             // Act
-            await page.click('#resetButton');
+            await formIntegrationPage.clickButtonWithText('Reset');
 
             // Assert
-            const inputValue = await page.inputValue('#username');
-            expect(inputValue).toBe('changedValue'); // Input value should remain as 'changedValue' and not be reset to 'initialValue'
+            const formFieldValues = await formIntegrationPage.getFormFieldValues();
+            expect(formFieldValues).toEqual(formInputData);
         });
 
         test('should not reset the form when button has `isLoading` set and type is `reset`', async ({ page }) => {
             // Arrange
-            await page.evaluate(() => {
-                const formHTML = `
-                <form id="testForm">
-                    <input type="text" id="username" name="username" value="initialValue">
-                    <pie-button id="resetButton" type="reset" isLoading>Reset</pie-button>
-                </form>
-            `;
-                document.body.innerHTML = formHTML;
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load({ isLoading: true });
 
-            // Change the form input value
-            await page.fill('#username', 'changedValue');
+            await formIntegrationPage.fillForm(formInputData);
 
             // Act
-            await page.click('#resetButton');
+            await formIntegrationPage.clickButtonWithText('Reset');
 
             // Assert
-            const inputValue = await page.inputValue('#username');
-            expect(inputValue).toBe('changedValue'); // Input value should remain as 'changedValue' and not be reset to 'initialValue'
+            const formFieldValues = await formIntegrationPage.getFormFieldValues();
+            expect(formFieldValues).toEqual(formInputData);
         });
     });
 
     test.describe('Association', () => {
         test('should correctly associate with its containing form and not with other forms', async ({ page }) => {
             // Arrange
-            // Inject two forms into the page
-            await page.evaluate(() => {
-                const formsHTML = `
-                <form id="correctForm">
-                    <pie-button id="testButton" type="submit">Submit</pie-button>
-                </form>
-                <form id="wrongForm"></form>
-            `;
-                document.body.innerHTML = formsHTML;
-            });
+            const formIntegrationPage = new FormIntegrationPage(page);
+            await formIntegrationPage.load({ renderIncorrectForm: true });
 
             // Act
-            const associatedFormId = await page.evaluate(() => {
-                const button = document.querySelector('#testButton') as HTMLButtonElement;
-                return button.form ? button.form.id : null;
-            });
+            const associatedFormId = await formIntegrationPage.getAssociatedFormIdForButton('pie-button-submit');
 
             // Assert
-            expect(associatedFormId).toBe('correctForm');
+            expect(associatedFormId).toBe('testForm');
         });
     });
 });
 
 test.describe('props', () => {
-    test.describe('isResponsive', () => {
-        test.describe('when not set', () => {
-            test('the button should not have the attribute', async ({ mount }) => {
-                const component = await mount(
-                    PieButton,
-                    {
-                        slots: {
-                            default: 'Click me!',
-                        },
-                    },
-                );
-
-                await expect(component.locator('button'))
-                    .not.toHaveClass(/o-btn--responsive/);
-            });
-        });
-        test.describe('when set to true', () => {
-            test('the button should have the attribute', async ({ mount }) => {
-                const props: ButtonProps = {
-                    size: 'xsmall',
-                    isResponsive: true,
-                };
-
-                const component = await mount(
-                    PieButton,
-                    {
-                        props,
-                        slots: {
-                            default: 'Click me!',
-                        },
-                    },
-                );
-
-                await expect(component.locator('button'))
-                    .toHaveClass(/o-btn--responsive/);
-            });
-
-            sizes.forEach(({ sizeName, responsiveSize }) => {
-                test(`a "${sizeName}" size button height should be equivalent to "${responsiveSize}"`, async ({ mount }) => {
-                    const props: ButtonProps = {
-                        size: sizeName,
-                        isResponsive: true,
-                    };
-
-                    const component = await mount(PieButton, {
-                        props,
-                        slots: {
-                            default: 'Click me!',
-                        },
-                    });
-
-                    const [currentHeight, expectedHeight] = await getShadowElementStylePropValues(component, 'button', ['--btn-height', responsiveSize]);
-
-                    await expect(currentHeight).toBe(expectedHeight);
-                });
-            });
-        });
-    });
-
-    test.describe('responsiveSize', () => {
-        test.describe('when not set', () => {
-            test('the button should not have the attribute', async ({ mount }) => {
-                const component = await mount(
-                    PieButton,
-                    {
-                        slots: {
-                            default: 'Click me!',
-                        },
-                    },
-                );
-
-                await expect(component.locator('button'))
-                    .not.toHaveClass([/o-btn--productive/, /o-btn--expressive/]);
-            });
-        });
-
-        test.describe('when "isResponsive" is true', () => {
-            test.describe('when "responsiveSize" is "expressive"', () => {
-                test('the button should have the expected attribute', async ({ mount }) => {
-                    const props: ButtonProps = {
-                        size: 'xsmall',
-                        isResponsive: true,
-                        responsiveSize: 'expressive',
-                    };
-
-                    const component = await mount(
-                        PieButton,
-                        {
-                            props,
-                            slots: {
-                                default: 'Click me!',
-                            },
-                        },
-                    );
-
-                    await expect(component.locator('button'))
-                        .toHaveClass([/o-btn--expressive/]);
-                });
-            });
-        });
-
-        test.describe('when "responsiveSize" is "productive"', () => {
-            test('the button should have the expected attribute', async ({ mount }) => {
-                const props: ButtonProps = {
-                    size: 'xsmall',
-                    isResponsive: true,
-                    responsiveSize: 'productive',
-                };
-
-                const component = await mount(
-                    PieButton,
-                    {
-                        props,
-                        slots: {
-                            default: 'Click me!',
-                        },
-                    },
-                );
-
-                await expect(component.locator('button'))
-                    .toHaveClass(/o-btn--productive/);
-            });
-        });
-    });
-
     test.describe('tag', () => {
         test.describe('when set to "button"', () => {
-            test('should render a button element', async ({ mount }) => {
+            test('should render a button element', async ({ page }) => {
                 // Arrange
                 const props: ButtonProps = {
                     tag: 'button',
                 };
 
-                // Act
-                const component = await mount(PieButton, {
-                    props,
-                    slots: {
-                        default: 'Click me!',
-                    },
-                });
-
-                const button = component.locator('button');
+                const buttonDefaultPage = new ButtonDefaultPage(page);
+                await buttonDefaultPage.load({ ...props });
 
                 // Assert
-                expect(button).toBeVisible();
+                await expect(buttonDefaultPage.buttonComponent.componentLocator.locator('button')).toBeVisible();
             });
 
-            test('should not render anchor-specific attributes', async ({ mount }) => {
+            test('should not render anchor-specific attributes', async ({ page }) => {
                 // Arrange
                 const props: ButtonProps = {
                     tag: 'button',
@@ -696,50 +287,31 @@ test.describe('props', () => {
                     rel: 'noopener noreferrer',
                     target: '_blank',
                 };
+                const buttonDefaultPage = new ButtonDefaultPage(page);
+                await buttonDefaultPage.load({ ...props });
 
-                // Act
-                const component = await mount(PieButton, {
-                    props,
-                    slots: {
-                        default: 'Click me!',
-                    },
-                });
-
-                const button = component.locator('button');
-
-                const href = await button.getAttribute('href');
-                const rel = await button.getAttribute('rel');
-                const target = await button.getAttribute('target');
+                const buttonShadowElement = buttonDefaultPage.buttonComponent.componentLocator.locator('button');
 
                 // Assert
-                expect.soft(rel).toBeNull();
-                expect.soft(target).toBeNull();
-                expect(href).toBeNull();
+                await expect(buttonShadowElement).not.toHaveAttribute('rel', props.rel as string);
+                await expect(buttonShadowElement).not.toHaveAttribute('target', props.target as string);
+                await expect(buttonShadowElement).not.toHaveAttribute('href', props.href as string);
             });
         });
 
         test.describe('when set to "a"', () => {
-            test('should render an anchor element', async ({ mount }) => {
+            test('should render an anchor element', async ({ page }) => {
                 // Arrange
-                const props: ButtonProps = {
-                    tag: 'a',
-                };
+                const buttonAnchorPage = new ButtonAnchorPage(page);
+                await buttonAnchorPage.load();
 
-                // Act
-                const component = await mount(PieButton, {
-                    props,
-                    slots: {
-                        default: 'Click me!',
-                    },
-                });
-
-                const anchor = component.locator('a');
+                const anchor = buttonAnchorPage.buttonComponent.componentLocator.locator('a');
 
                 // Assert
-                expect(anchor).toBeVisible();
+                await expect(anchor).toBeVisible();
             });
 
-            test('should not render button-specific attributes', async ({ mount }) => {
+            test('should not render button-specific attributes', async ({ page }) => {
                 // Arrange
                 const props: ButtonProps = {
                     tag: 'a',
@@ -749,25 +321,17 @@ test.describe('props', () => {
                     type: 'submit',
                 };
 
-                // Act
-                const component = await mount(PieButton, {
-                    props,
-                    slots: {
-                        default: 'Click me!',
-                    },
-                });
-
-                const anchor = component.locator('a');
+                const buttonAnchorPage = new ButtonAnchorPage(page);
+                await buttonAnchorPage.load({ ...props });
 
                 // Assert
-                const disabled = await anchor.getAttribute('disabled');
-                const type = await anchor.getAttribute('type');
-                const spinner = component.locator('pie-spinner');
+                const anchor = buttonAnchorPage.buttonComponent.componentLocator.locator('a');
+                const spinner = anchor.locator('pie-spinner');
 
-                expect.soft(anchor).not.toHaveClass(/is-loading/);
-                expect.soft(disabled).toBeNull();
-                expect.soft(type).toBeNull();
-                expect(spinner).not.toBeVisible();
+                await expect.soft(anchor).not.toHaveClass(/is-loading/);
+                await expect.soft(anchor).not.toHaveAttribute('disabled');
+                await expect.soft(anchor).not.toHaveAttribute('type');
+                await expect(spinner).not.toBeVisible();
             });
         });
     });

--- a/packages/components/pie-button/test/helpers/page-object/pie-button-anchor.page.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button-anchor.page.ts
@@ -1,0 +1,12 @@
+import { type Page } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from './pie-button.component.ts';
+
+export class ButtonAnchorPage extends BasePage {
+    readonly buttonComponent: ButtonComponent;
+
+    constructor (page: Page) {
+        super(page, 'button--anchor');
+        this.buttonComponent = new ButtonComponent(page);
+    }
+}

--- a/packages/components/pie-button/test/helpers/page-object/pie-button-default.page.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button-default.page.ts
@@ -1,0 +1,12 @@
+import { type Page } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from './pie-button.component.ts';
+
+export class ButtonDefaultPage extends BasePage {
+    readonly buttonComponent: ButtonComponent;
+
+    constructor (page: Page) {
+        super(page, 'button--primary');
+        this.buttonComponent = new ButtonComponent(page);
+    }
+}

--- a/packages/components/pie-button/test/helpers/page-object/pie-button-form-attributes.page.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button-form-attributes.page.ts
@@ -1,0 +1,11 @@
+import type { Page } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from './pie-button.component.ts';
+
+export class FormAttributesPage extends BasePage {
+    readonly buttonComponent: ButtonComponent;
+    constructor (page: Page) {
+        super(page, 'button--form-with-all-attributes');
+        this.buttonComponent = new ButtonComponent(page);
+    }
+}

--- a/packages/components/pie-button/test/helpers/page-object/pie-button-form-integration-selectors.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button-form-integration-selectors.ts
@@ -1,0 +1,51 @@
+const form = {
+    selectors: {
+        container: {
+            description: 'The selector for the form element',
+            dataTestId: 'testForm',
+        },
+        name: {
+            description: 'The selector for the name input element',
+            dataTestId: 'name',
+        },
+        email: {
+            description: 'The selector for the email input element',
+            dataTestId: 'usermail',
+        },
+        password: {
+            description: 'The selector for the password input element',
+            dataTestId: 'password',
+        },
+        userPaymentCardType: {
+            description: 'The selector for the user payment card type select element',
+            dataTestId: 'usercard',
+        },
+        userPaymentCardNumber: {
+            description: 'The selector for the user payment card number input element',
+            dataTestId: 'card-number',
+        },
+        userPaymentCardExpiration: {
+            description: 'The selector for the user payment card expiration input element',
+            dataTestId: 'card-expiration',
+        },
+        formSubmittedFlag: {
+            description: 'The selector for the form submitted flag element',
+            dataTestId: 'formSubmittedFlag',
+        },
+        pieButtonSubmit: {
+            description: 'The selector for the pie-button submit element',
+            dataTestId: 'pie-button-submit',
+        },
+        pieButtonReset: {
+            description: 'The selector for the pie-button reset element',
+            dataTestId: 'pie-button-reset',
+        },
+        nativeButtonReset: {
+            description: 'The selector for the native reset button element',
+            dataTestId: 'button-reset',
+        },
+    },
+};
+export {
+    form,
+};

--- a/packages/components/pie-button/test/helpers/page-object/pie-button-form-integration.page.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button-form-integration.page.ts
@@ -1,0 +1,112 @@
+import type { Locator, Page } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import type { PieButton } from '../../../src/index.ts';
+import { form } from './pie-button-form-integration-selectors.ts';
+
+// Define the FormInput type with specific options for userPaymentCardType
+export type FormInput = {
+    userName: string;
+    userEmail: string;
+    userPassword: string;
+    userPaymentCardType: 'visa' | 'mastercard' | 'amex';
+    userPaymentCardNumber: string;
+    userPaymentCardExpiration: string;
+};
+
+export type FormButtonType = 'pie-button-submit' | 'pie-button-reset' | 'native-reset';
+
+export class FormIntegrationPage extends BasePage {
+    readonly formLocator: Locator;
+    readonly userNameInput: Locator;
+    readonly userEmailInput: Locator;
+    readonly userPasswordInput: Locator;
+    readonly userPaymentCardTypeSelect: Locator;
+    readonly userPaymentCardNumberInput: Locator;
+    readonly userPaymentCardExpirationInput: Locator;
+    readonly resetPieButton: Locator;
+    readonly resetNativeButton: Locator;
+    readonly submitPieButton: Locator;
+    readonly formSubmittedFlag: Locator;
+
+    constructor (page: Page) {
+        super(page, 'button--form-integration');
+
+        this.formLocator = page.getByTestId(form.selectors.container.dataTestId);
+        this.userNameInput = this.formLocator.getByTestId(form.selectors.name.dataTestId);
+        this.userEmailInput = this.formLocator.getByTestId(form.selectors.email.dataTestId);
+        this.userPasswordInput = this.formLocator.getByTestId(form.selectors.password.dataTestId);
+        this.userPaymentCardTypeSelect = this.formLocator.getByTestId(form.selectors.userPaymentCardType.dataTestId);
+        this.userPaymentCardNumberInput = this.formLocator.getByTestId(form.selectors.userPaymentCardNumber.dataTestId);
+        this.userPaymentCardExpirationInput = this.formLocator.getByTestId(form.selectors.userPaymentCardExpiration.dataTestId);
+
+        this.resetPieButton = this.formLocator.locator(`[data-test-id="${form.selectors.pieButtonReset.dataTestId}"]`);
+        this.resetNativeButton = this.formLocator.locator(`[data-test-id="${form.selectors.nativeButtonReset.dataTestId}"]`);
+        this.submitPieButton = this.formLocator.locator(`[data-test-id="${form.selectors.pieButtonSubmit.dataTestId}"]`);
+
+        this.formSubmittedFlag = this.page.getByTestId(form.selectors.formSubmittedFlag.dataTestId);
+    }
+
+    /**
+     * Fills out the form with the provided input data.
+     *
+     * @param {FormInput} inputData - The data to fill the form with.
+     * @returns {Promise<void>} A Promise that resolves once the form has been filled.
+     */
+    async fillForm (inputData: FormInput): Promise<void> {
+        await this.userNameInput.fill(inputData.userName);
+        await this.userEmailInput.fill(inputData.userEmail);
+        await this.userPasswordInput.fill(inputData.userPassword);
+        await this.userPaymentCardTypeSelect.selectOption(inputData.userPaymentCardType);
+        await this.userPaymentCardNumberInput.fill(inputData.userPaymentCardNumber);
+        await this.userPaymentCardExpirationInput.fill(inputData.userPaymentCardExpiration);
+    }
+
+    /**
+     * Gets the values of the form fields.
+     *
+     * @returns {Promise<FormInput>} A Promise that resolves with the form field values.
+     */
+    async getFormFieldValues (): Promise<FormInput> {
+        const formFieldValues: FormInput = {
+            userName: await this.userNameInput.inputValue(),
+            userEmail: await this.userEmailInput.inputValue(),
+            userPassword: await this.userPasswordInput.inputValue(),
+            userPaymentCardType: await this.userPaymentCardTypeSelect.inputValue() as 'visa' | 'mastercard' | 'amex',
+            userPaymentCardNumber: await this.userPaymentCardNumberInput.inputValue(),
+            userPaymentCardExpiration: await this.userPaymentCardExpirationInput.inputValue(),
+        };
+
+        return formFieldValues;
+    }
+
+    /**
+     * Gets the associated form ID for the specified button.
+     *
+     * @param {FormButtonType} buttonType - The type of the button.
+     * @returns {Promise<string | null>} A Promise that resolves with the associated form ID or null if no form is found.
+     */
+    async getAssociatedFormIdForButton (buttonType: FormButtonType): Promise<string | null> {
+        let selector: string;
+
+        switch (buttonType) {
+            case 'pie-button-submit':
+                selector = form.selectors.pieButtonSubmit.dataTestId;
+                break;
+            case 'pie-button-reset':
+                selector = form.selectors.pieButtonReset.dataTestId;
+                break;
+            case 'native-reset':
+                selector = form.selectors.nativeButtonReset.dataTestId;
+                break;
+            default:
+                throw new Error(`Invalid button type: ${buttonType}`);
+        }
+
+        const associatedFormId = await this.page.evaluate((selector) => {
+            const button = document.querySelector(`[data-test-id="${selector}"]`) as PieButton;
+            return button.form ? button.form.id : null;
+        }, selector);
+
+        return associatedFormId;
+    }
+}

--- a/packages/components/pie-button/test/helpers/page-object/pie-button-form-submission.page.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button-form-submission.page.ts
@@ -1,0 +1,11 @@
+import type { Page } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from './pie-button.component.ts';
+
+export class FormSubmissionPage extends BasePage {
+    readonly buttonComponent: ButtonComponent;
+    constructor (page: Page) {
+        super(page, 'button--form-submission');
+        this.buttonComponent = new ButtonComponent(page);
+    }
+}

--- a/packages/components/pie-button/test/helpers/page-object/pie-button.component.ts
+++ b/packages/components/pie-button/test/helpers/page-object/pie-button.component.ts
@@ -1,0 +1,9 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class ButtonComponent {
+    readonly componentLocator: Locator;
+
+    constructor (page: Page) {
+        this.componentLocator = page.locator('pie-button');
+    }
+}

--- a/packages/components/pie-button/test/visual/pie-button-anchor.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button-anchor.spec.ts
@@ -1,48 +1,20 @@
-import { test } from '@sand4rt/experimental-ct-web';
+import { test, expect } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
-
-import { type PropObject, type WebComponentPropValues } from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
-import { getAllPropCombinations } from '@justeattakeaway/pie-webc-testing/src/helpers/get-all-prop-combos.ts';
-import { createTestWebComponent } from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
-import { WebComponentTestWrapper } from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
+import { variants } from '../../src/defs.ts';
 
-import { PieButton } from '../../src/index.ts';
-import { type ButtonProps, sizes, variants } from '../../src/defs.ts';
+variants.forEach((variant) => {
+    test(`should render all size and variant variations for anchor tag for variant: ${variant}`, async ({ page }) => {
+        // Arrange
+        const buttonPage = new BasePage(page, `button--${variant}-anchor-variations`);
+        const buttonComponent = new ButtonComponent(page);
+        await buttonPage.load();
 
-const props: PropObject<ButtonProps> = {
-    variant: variants,
-    size: sizes,
-    tag: 'a',
-};
-
-// Renders a <pie-button> HTML string with the given prop values
-const renderTestPieButton = (propVals: WebComponentPropValues) => `<pie-button tag="${propVals.tag}" size="${propVals.size}" variant="${propVals.variant}">Hello world</pie-button>`;
-
-const componentPropsMatrix = getAllPropCombinations(props);
-
-test.beforeEach(async ({ mount }, testInfo) => {
-    testInfo.setTimeout(testInfo.timeout + 40000);
-    const component = await mount(PieButton);
-    await component.unmount();
+        // Assert
+        await expect.soft(buttonComponent.componentLocator.first()).toBeVisible();
+        await percySnapshot(page, `PIE Button Anchor Variants - ${variant}`, percyWidths);
+    });
 });
 
-test('should render all size and variant variations for anchor tag', async ({ page, mount }) => {
-    for (const combo of componentPropsMatrix) {
-        const { renderedString, propValues } = createTestWebComponent(combo, renderTestPieButton);
-        const propKeyValues = `tag: ${propValues.tag}, size: ${propValues.size}, variant: ${propValues.variant}`;
-        const darkMode = ['inverse', 'ghost-inverse', 'outline-inverse'].includes(propValues.variant);
-
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues, darkMode },
-                slots: {
-                    component: renderedString.trim(),
-                },
-            },
-        );
-    }
-
-    await percySnapshot(page, 'PIE Button Anchor - sizes/variants', percyWidths);
-});

--- a/packages/components/pie-button/test/visual/pie-button-size.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button-size.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
-import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
+
 test('should render all size variations', async ({ page }) => {
     // Arrange
     const buttonPage = new BasePage(page, 'button--responsive-button-variations');

--- a/packages/components/pie-button/test/visual/pie-button-size.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button-size.spec.ts
@@ -1,80 +1,26 @@
-import { test } from '@sand4rt/experimental-ct-web';
+import { test, expect } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
-import {
-    type PropObject, type WebComponentPropValues,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
-import {
-    getAllPropCombinations,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/get-all-prop-combos.ts';
-import {
-    createTestWebComponent,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
-import {
-    WebComponentTestWrapper,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
-import { PieButton } from '../../src/index.ts';
-import { type ButtonProps, sizes } from '../../src/defs.ts';
+import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+test('should render all size variations', async ({ page }) => {
+    // Arrange
+    const buttonPage = new BasePage(page, 'button--responsive-button-variations');
+    const buttonComponent = new ButtonComponent(page);
+    await buttonPage.load();
 
-const props: PropObject<ButtonProps> = {
-    variant: ['primary'],
-    size: sizes,
-    isResponsive: [true, false],
-    responsiveSize: ['productive', 'expressive'],
-};
-
-// Renders a <pie-button> HTML string with the given prop values
-const renderTestPieButton = (propVals: WebComponentPropValues) => `<pie-button size="${propVals.size}" ${propVals.isResponsive ? 'isResponsive' : ''} responsiveSize="${propVals.responsiveSize ? propVals.responsiveSize : ''}">Hello world</pie-button>`;
-const renderTestPieButtonLargeText = (propVals: WebComponentPropValues) => `<pie-button size="${propVals.size}" ${propVals.isResponsive ? 'isResponsive' : ''} responsiveSize="${propVals.responsiveSize ? propVals.responsiveSize : ''}">This is a really long button string to test the overflow</pie-button>`;
-
-const componentPropsMatrix = getAllPropCombinations(props);
-
-test.beforeEach(async ({ mount }, testInfo) => {
-    testInfo.setTimeout(testInfo.timeout + 40000);
-    const component = await mount(PieButton);
-    await component.unmount();
+    // Assert
+    await expect.soft(buttonComponent.componentLocator.first()).toBeVisible();
+    await percySnapshot(page, 'PIE Button - sizes/isResponsive/responsiveSize', { widths: [1280] });
 });
 
-test('should render all size variations', async ({ page, mount }) => {
-    for (const combo of componentPropsMatrix) {
-        const testComponent = createTestWebComponent(combo, renderTestPieButton);
-        const propKeyValues = `size: ${testComponent.propValues.size}, isResponsive: ${testComponent.propValues.isResponsive}, responsiveSize: ${testComponent.propValues.responsiveSize}`;
+test('should render all size variations, with larger button text string', async ({ page }) => {
+    // Arrange
+    const buttonPage = new BasePage(page, 'button--double-line-text-button-variations');
+    const buttonComponent = new ButtonComponent(page);
+    await buttonPage.load();
 
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues },
-                slots: {
-                    component: testComponent.renderedString.trim(),
-                },
-            },
-        );
-    }
-
-    // Follow up to remove in Jan
-    await page.waitForTimeout(2500);
-
-    await percySnapshot(page, 'PIE Button - sizes/isResponsive/responsiveSize', percyWidths);
-});
-
-test('should render all size variations, with larger button text string', async ({ page, mount }) => {
-    for (const combo of componentPropsMatrix) {
-        const testComponent = createTestWebComponent(combo, renderTestPieButtonLargeText);
-        const propKeyValues = `size: ${testComponent.propValues.size}, isResponsive: ${testComponent.propValues.isResponsive}, responsiveSize: ${testComponent.propValues.responsiveSize}`;
-
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues },
-                slots: {
-                    component: testComponent.renderedString.trim(),
-                },
-            },
-        );
-    }
-
-    // Follow up to remove in Jan
-    await page.waitForTimeout(2500);
-
+    // Assert
+    await expect.soft(buttonComponent.componentLocator.first()).toBeVisible();
     await percySnapshot(page, 'PIE Button - sizes/isResponsive/responsiveSize - double line text', percyWidths);
 });

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
-import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
 import { variants } from '../../src/defs.ts';
 
 variants.forEach((variant) => {

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -1,80 +1,18 @@
-import { test } from '@sand4rt/experimental-ct-web';
+import { test, expect } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
-import {
-    type PropObject, type WebComponentPropValues, type WebComponentTestInput,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
-import {
-    getAllPropCombinations, splitCombinationsByPropertyValue,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/get-all-prop-combos.ts';
-import {
-    createTestWebComponent,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
-import {
-    WebComponentTestWrapper,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
-import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
-import { IconHeartFilled } from '@justeattakeaway/pie-icons-webc/dist/IconHeartFilled';
-import { PieButton } from '../../src/index.ts';
-import {
-    type ButtonProps, sizes, variants, iconPlacements,
-} from '../../src/defs.ts';
+import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { variants } from '../../src/defs.ts';
 
-const props: PropObject<ButtonProps> = {
-    variant: variants,
-    size: sizes,
-    type: 'button', // Changing the type does not affect the appearance of the button
-    isFullWidth: [true, false],
-    disabled: [true, false],
-    isLoading: [true, false],
-    iconPlacement: iconPlacements,
-};
+variants.forEach((variant) => {
+    test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
+        // Arrange
+        const buttonPage = new BasePage(page, `button--${variant}-variations`);
+        const buttonComponent = new ButtonComponent(page);
+        await buttonPage.load();
 
-// Renders a <pie-button> HTML string with the given prop values
-const renderTestPieButton = (propVals: WebComponentPropValues) => `<pie-button variant="${propVals.variant}" size="${propVals.size}" type="${propVals.type}" iconPlacement="${propVals.iconPlacement}" ${propVals.isFullWidth ? 'isFullWidth' : ''} ${propVals.disabled ? 'disabled' : ''} ${propVals.isLoading ? 'isLoading' : ''}>${propVals.iconPlacement ? '<icon-heart-filled slot="icon"></icon-heart-filled>' : ''} Hello world</pie-button>`;
-
-const componentPropsMatrix : WebComponentPropValues[] = getAllPropCombinations(props);
-const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
-const componentVariants: string[] = Object.keys(componentPropsMatrixByVariant);
-
-test.beforeEach(async ({ mount }, testInfo) => {
-    testInfo.setTimeout(testInfo.timeout + 40000);
-
-    // This ensures the button and icon components are registered in the DOM for each test.
-    // It appears to add them to a Playwright cache which we understand is required for the tests to work correctly.
-    const buttonComponent = await mount(PieButton);
-    await buttonComponent.unmount();
-    const iconComponent = await mount(IconHeartFilled);
-    await iconComponent.unmount();
-});
-
-componentVariants.forEach((variant) => {
-    const componentPropsMatrixBySize = splitCombinationsByPropertyValue(componentPropsMatrixByVariant[variant], 'size');
-    const componentSizes: string[] = Object.keys(componentPropsMatrixBySize);
-
-    componentSizes.forEach((size) => {
-        test(`should render all prop variations for Variant: ${variant} and Size: ${size}`, async ({ page, mount }) => {
-            const combos = componentPropsMatrixBySize[size];
-
-            for (const combo of combos) {
-                const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieButton);
-                const propKeyValues = `size: ${testComponent.propValues.size}, iconPlacement: ${testComponent.propValues.iconPlacement}, isFullWidth: ${testComponent.propValues.isFullWidth}, disabled: ${testComponent.propValues.disabled}, isLoading: ${testComponent.propValues.isLoading}`;
-                const darkMode = ['inverse', 'ghost-inverse', 'outline-inverse'].includes(variant);
-
-                await mount(
-                    WebComponentTestWrapper,
-                    {
-                        props: { propKeyValues, darkMode },
-                        slots: {
-                            component: testComponent.renderedString.trim(),
-                        },
-                    },
-                );
-            }
-
-            await page.waitForLoadState('domcontentloaded');
-
-            const snapshotName = `PIE Button - Variant: ${variant} - Size: ${size}`;
-            await percySnapshot(page, snapshotName, percyWidths);
-        });
+        // Assert
+        await expect.soft(buttonComponent.componentLocator.first()).toBeVisible();
+        await percySnapshot(page, `PIE Button - Variant: ${variant}`, { widths: [1280] });
     });
 });

--- a/packages/components/pie-button/turbo.json
+++ b/packages/components/pie-button/turbo.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": [
+    "//"
+  ],
+  "pipeline": {
+    "test:browsers": {
+      "cache": true,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"
+      ]
+    },
+    "test:browsers:ci": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"
+      ]
+    },
+    "test:visual": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"
+      ]
+    },
+    "test:visual:ci": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Refactors pie-button to use page object / `@playwright/test`.
- Adds functionality to `createVariantStory` to allow `multiColumn: bool` to be passed as part of the `StoryOptions` object to make better use of screen width for visual tests where many variations are rendered.


## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [-] I have added thorough tests where applicable (unit / component / visual).
- [-] If changes will affect consumers of the package, I have created a changeset entry.
- [-] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
