### PR TITLE
feat(pie-radio-group): DSW-2634 make screenreaders narrate index and selected

### DIFF
--- a/.changeset/two-boxes-lie.md
+++ b/.changeset/two-boxes-lie.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-radio-group": minor
+"@justeattakeaway/pie-radio": minor
+---
+
+[Fixed] - Ensure screenreaders correctly announce radio index in groups

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -303,6 +303,7 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
     private _focusAndClickOption (option: HTMLInputElement): void {
         option.focus();
+        console.log(document.activeElement);
         // This is quite hacky, but it ensures the radio elements correct emit a real change event.
         // Simply setting option.checked as true would require re-architecture of both this component and the radio button
         // to ensure that property changes are observed and correctly propagated up.
@@ -334,6 +335,7 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
         return html`
             <fieldset
+                role="radiogroup"
                 tabindex="0"
                 name=${ifDefined(name)}
                 ?disabled=${disabled}

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -303,7 +303,6 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(LitElement)) implem
 
     private _focusAndClickOption (option: HTMLInputElement): void {
         option.focus();
-        console.log(document.activeElement);
         // This is quite hacky, but it ensures the radio elements correct emit a real change event.
         // Simply setting option.checked as true would require re-architecture of both this component and the radio button
         // to ensure that property changes are observed and correctly propagated up.

--- a/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
+++ b/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
@@ -1,5 +1,8 @@
-import { test, expect } from '@playwright/test';
+import {
+    test, expect, type Page, type Expect,
+} from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { type PieRadio } from '@justeattakeaway/pie-radio';
 
 // The structure of this object reflects the structure of our test Story
 const selectors = {
@@ -29,6 +32,30 @@ const selectors = {
     button4: 'btn-4',
 };
 
+// Returns the checked state of the currently focused pie-radio on the page
+// Will error if the active element on the page is not a pie-radio instance
+const expectFocusedRadioToBeChecked = async (page: Page, expect: Expect): Promise<void> => {
+    const result = await page.evaluate(() => {
+        const queryResult: { checked: boolean, error?: boolean } = {
+            checked: false,
+        };
+
+        if (document.activeElement?.nodeName === 'PIE-RADIO') {
+            queryResult.checked = (document.activeElement as PieRadio)?.checked;
+        } else {
+            queryResult.error = true;
+        }
+
+        return queryResult;
+    });
+
+    if (result.error) {
+        throw new Error('The currently focused element was not an instance of PIE-RADIO.');
+    }
+
+    await expect(result.checked).toBe(true);
+};
+
 test.describe('PieRadioGroup - Component tests new', () => {
     let pageObject;
 
@@ -44,8 +71,7 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('Tab');
                 await page.keyboard.press('Tab');
 
-                const radio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
-
+                const radio = page.getByTestId(selectors.radioGroup1.radios[1]);
                 await expect(radio).toBeFocused();
             });
 
@@ -57,7 +83,7 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('Tab');
                 await page.keyboard.press('Tab');
 
-                const radio = page.getByTestId(selectors.radioGroup2.radios[4]).locator('input');
+                const radio = page.getByTestId(selectors.radioGroup2.radios[4]);
 
                 await expect(radio).toBeFocused();
             });
@@ -88,7 +114,7 @@ test.describe('PieRadioGroup - Component tests new', () => {
 
                 await page.keyboard.press('Shift+Tab');
 
-                const radio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                const radio = page.getByTestId(selectors.radioGroup1.radios[5]);
 
                 await expect(radio).toBeFocused();
             });
@@ -104,7 +130,7 @@ test.describe('PieRadioGroup - Component tests new', () => {
 
                 await page.keyboard.press('Shift+Tab');
 
-                const radio = page.getByTestId(selectors.radioGroup2.radios[4]).locator('input');
+                const radio = page.getByTestId(selectors.radioGroup2.radios[4]);
 
                 await expect(radio).toBeFocused();
             });
@@ -138,15 +164,15 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('ArrowLeft');
 
                 // Ensure it's gone backwards and selected the last radio
-                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                 await expect(lastRadio).toBeFocused();
-                await expect(lastRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
 
                 // Ensure it's gone backwards once more and selected the second to last radio
                 await page.keyboard.press('ArrowLeft');
-                const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]);
                 await expect(secondToLastRadio).toBeFocused();
-                await expect(secondToLastRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
             });
 
             test('Up Arrow goes backwards through radios and loops', async ({ page }) => {
@@ -157,15 +183,15 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('ArrowUp');
 
                 // Ensure it's gone backwards and selected the last radio
-                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                 await expect(lastRadio).toBeFocused();
-                await expect(lastRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
 
                 // Ensure it's gone backwards once more and selected the second to last radio
                 await page.keyboard.press('ArrowUp');
-                const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]);
                 await expect(secondToLastRadio).toBeFocused();
-                await expect(secondToLastRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
             });
 
             test('Right Arrow goes forwards through radios and loops', async ({ page }) => {
@@ -180,16 +206,16 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('ArrowRight');
 
                 // Ensure we are on the last radio
-                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                 await expect(lastRadio).toBeFocused();
-                await expect(lastRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
 
                 // Press Arrow Right 1 more time to get back to the first radio
                 await page.keyboard.press('ArrowRight');
 
-                const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]);
                 await expect(firstRadio).toBeFocused();
-                await expect(firstRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
             });
 
             test('Down Arrow goes forwards through radios and loops', async ({ page }) => {
@@ -204,16 +230,16 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('ArrowDown');
 
                 // Ensure we are on the last radio
-                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                 await expect(lastRadio).toBeFocused();
-                await expect(lastRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
 
                 // Press Arrow Down 1 more time to get back to the first radio
                 await page.keyboard.press('ArrowDown');
 
-                const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]);
                 await expect(firstRadio).toBeFocused();
-                await expect(firstRadio).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
             });
 
             test('Arrow key selection in one Group does not affect the other', async ({ page }) => {
@@ -224,9 +250,9 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 await page.keyboard.press('ArrowRight');
 
                 // Ensure it's gone forwards and selected the second radio
-                const secondRadioButtonGroup1 = page.getByTestId(selectors.radioGroup1.radios[2]).locator('input');
+                const secondRadioButtonGroup1 = page.getByTestId(selectors.radioGroup1.radios[2]);
                 await expect(secondRadioButtonGroup1).toBeFocused();
-                await expect(secondRadioButtonGroup1).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
 
                 // Move to next radio group
                 await page.keyboard.press('Tab');
@@ -235,9 +261,9 @@ test.describe('PieRadioGroup - Component tests new', () => {
 
                 // Press right to move from the selected radio to the next
                 await page.keyboard.press('ArrowRight');
-                const lastRadioButtonGroup2 = page.getByTestId(selectors.radioGroup2.radios[5]).locator('input');
+                const lastRadioButtonGroup2 = page.getByTestId(selectors.radioGroup2.radios[5]);
                 await expect(lastRadioButtonGroup2).toBeFocused();
-                await expect(lastRadioButtonGroup2).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
 
                 // Press Shift + Tab 3 times to get back into the first radio group
                 await page.keyboard.press('Shift+Tab');
@@ -246,7 +272,7 @@ test.describe('PieRadioGroup - Component tests new', () => {
 
                 // Ensure the previously selected radio in the first group is focused and still selected
                 await expect(secondRadioButtonGroup1).toBeFocused();
-                await expect(secondRadioButtonGroup1).toBeChecked();
+                await expectFocusedRadioToBeChecked(page, expect);
             });
         });
 
@@ -269,16 +295,16 @@ test.describe('PieRadioGroup - Component tests new', () => {
                     await page.keyboard.press('ArrowLeft');
 
                     // Ensure we are on the last radio
-                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                     await expect(lastRadio).toBeFocused();
-                    await expect(lastRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
 
                     // Press Arrow Left 1 more time to get back to the first radio
                     await page.keyboard.press('ArrowLeft');
 
-                    const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                    const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]);
                     await expect(firstRadio).toBeFocused();
-                    await expect(firstRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
                 });
 
                 test('Up Arrow goes backwards through radios and loops', async ({ page }) => {
@@ -289,15 +315,15 @@ test.describe('PieRadioGroup - Component tests new', () => {
                     await page.keyboard.press('ArrowUp');
 
                     // Ensure it's gone backwards and selected the last radio
-                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                     await expect(lastRadio).toBeFocused();
-                    await expect(lastRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
 
                     // Ensure it's gone backwards once more and selected the second to last radio
                     await page.keyboard.press('ArrowUp');
-                    const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                    const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]);
                     await expect(secondToLastRadio).toBeFocused();
-                    await expect(secondToLastRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
                 });
 
                 test('Right Arrow goes backwards through radios and loops', async ({ page }) => {
@@ -308,15 +334,15 @@ test.describe('PieRadioGroup - Component tests new', () => {
                     await page.keyboard.press('ArrowRight');
 
                     // Ensure it's gone backwards and selected the last radio
-                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                     await expect(lastRadio).toBeFocused();
-                    await expect(lastRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
 
                     // Ensure it's gone backwards once more and selected the second to last radio
                     await page.keyboard.press('ArrowRight');
-                    const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]).locator('input');
+                    const secondToLastRadio = page.getByTestId(selectors.radioGroup1.radios[4]);
                     await expect(secondToLastRadio).toBeFocused();
-                    await expect(secondToLastRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
                 });
 
                 test('Down Arrow goes forwards through radios and loops', async ({ page }) => {
@@ -331,16 +357,16 @@ test.describe('PieRadioGroup - Component tests new', () => {
                     await page.keyboard.press('ArrowDown');
 
                     // Ensure we are on the last radio
-                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]).locator('input');
+                    const lastRadio = page.getByTestId(selectors.radioGroup1.radios[5]);
                     await expect(lastRadio).toBeFocused();
-                    await expect(lastRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
 
                     // Press Arrow Down 1 more time to get back to the first radio
                     await page.keyboard.press('ArrowDown');
 
-                    const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]).locator('input');
+                    const firstRadio = page.getByTestId(selectors.radioGroup1.radios[1]);
                     await expect(firstRadio).toBeFocused();
-                    await expect(firstRadio).toBeChecked();
+                    await expectFocusedRadioToBeChecked(page, expect);
                 });
             });
         });

--- a/packages/components/pie-radio/src/index.ts
+++ b/packages/components/pie-radio/src/index.ts
@@ -95,10 +95,6 @@ export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements 
         this._handleFormAssociation();
     }
 
-    // public focus () {
-    //     this._radio.focus();
-    // }
-
     /**
      * (Read-only) returns a ValidityState with the validity states that this element is in.
      * https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/validity
@@ -126,6 +122,9 @@ export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements 
     }
 
     updated () {
+        // Ensure aria-checked reflects the checked state
+        this.setAttribute('aria-checked', String(this.checked));
+
         this._handleFormAssociation();
     }
 

--- a/packages/components/pie-radio/src/index.ts
+++ b/packages/components/pie-radio/src/index.ts
@@ -62,7 +62,7 @@ export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements 
         super.connectedCallback();
         this._abortController = new AbortController();
         const { signal } = this._abortController;
-
+        this.setAttribute('role', 'radio');
         this.addEventListener('pie-radio-group-disabled', (e: CustomEventInit) => { this._disabledByParent = e.detail.disabled; }, { signal });
     }
 
@@ -95,9 +95,9 @@ export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements 
         this._handleFormAssociation();
     }
 
-    public focus () {
-        this._radio.focus();
-    }
+    // public focus () {
+    //     this._radio.focus();
+    // }
 
     /**
      * (Read-only) returns a ValidityState with the validity states that this element is in.
@@ -151,6 +151,7 @@ export class PieRadio extends FormControlMixin(RtlMixin(LitElement)) implements 
         return html`
         <label class=${classMap(classes)} for="radioId">
             <input
+                tabindex="-1"
                 class="c-radio-input"
                 type="radio"
                 id="radioId"

--- a/packages/components/pie-radio/src/radio.scss
+++ b/packages/components/pie-radio/src/radio.scss
@@ -1,9 +1,5 @@
 @use '@justeattakeaway/pie-css/scss' as p;
 
-// :host(:focus) {
-//     background: red;
-// }
-
 @mixin radio-interactive-state($bg-color) {
     .c-radio-input {
         &:hover:not(:checked, :disabled) {
@@ -67,10 +63,6 @@
         @include radio-interactive-state('dt-color-support-error');
     }
 
-    // &:focus .c-radio-input {
-    //     @include p.focus;
-    // }
-
     .c-radio-input {
         appearance: none;
         display: block;
@@ -84,10 +76,6 @@
         background-color: var(--radio-bg-color);
         transition: background-color var(--dt-motion-timing-100) var(--radio-motion-easing);
         flex-shrink: 0;
-
-        // &:focus {
-        //     @include p.focus;
-        // }
 
         // The filled circle before checking the radio
         &:before {
@@ -122,6 +110,7 @@
         }
 
         &:checked {
+
             // The dot in the middle after checking the radio
             &:after {
                 transform: translate(-50%, -50%) scale(1);

--- a/packages/components/pie-radio/src/radio.scss
+++ b/packages/components/pie-radio/src/radio.scss
@@ -1,5 +1,9 @@
 @use '@justeattakeaway/pie-css/scss' as p;
 
+// :host(:focus) {
+//     background: red;
+// }
+
 @mixin radio-interactive-state($bg-color) {
     .c-radio-input {
         &:hover:not(:checked, :disabled) {
@@ -50,6 +54,8 @@
 
     @include radio-interactive-state('dt-color-interactive-brand');
 
+
+
     &.c-radio--disabled {
         --radio-cursor: not-allowed;
     }
@@ -60,6 +66,10 @@
 
         @include radio-interactive-state('dt-color-support-error');
     }
+
+    // &:focus .c-radio-input {
+    //     @include p.focus;
+    // }
 
     .c-radio-input {
         appearance: none;
@@ -75,9 +85,9 @@
         transition: background-color var(--dt-motion-timing-100) var(--radio-motion-easing);
         flex-shrink: 0;
 
-        &:focus {
-            @include p.focus;
-        }
+        // &:focus {
+        //     @include p.focus;
+        // }
 
         // The filled circle before checking the radio
         &:before {
@@ -146,5 +156,13 @@
             --radio-dot-bg-color: var(--dt-color-content-disabled);
             --radio-bg-color--checked: var(--dt-color-disabled-01);
         }
+    }
+}
+
+:host(:focus) {
+    outline: none;
+
+    .c-radio .c-radio-input {
+        @include p.focus;
     }
 }

--- a/packages/components/pie-radio/src/radio.scss
+++ b/packages/components/pie-radio/src/radio.scss
@@ -110,7 +110,6 @@
         }
 
         &:checked {
-
             // The dot in the middle after checking the radio
             &:after {
                 transform: translate(-50%, -50%) scale(1);

--- a/packages/components/pie-radio/test/component/pie-radio.spec.ts
+++ b/packages/components/pie-radio/test/component/pie-radio.spec.ts
@@ -119,6 +119,41 @@ test.describe('PieRadio - Component tests', () => {
                 // Assert
                 await expect(radio).not.toBeChecked();
             });
+
+            test('should keep aria-checked in sync with the checked prop', async ({ page, mount }) => {
+                // Arrange
+                await mount(PieRadio, {
+                    props: {
+                        checked: false,
+                        value: 'testValue',
+                    } as RadioProps,
+                    slots,
+                });
+
+                // Act
+                const radio = page.locator('pie-radio');
+
+                // Assert initial state
+                await expect(radio).toHaveAttribute('aria-checked', 'false');
+
+                // Update checked prop to true
+                await page.evaluate(() => {
+                    const radioComponent = document.querySelector('pie-radio');
+                    if (radioComponent) radioComponent.checked = true;
+                });
+
+                // Assert updated state
+                await expect(radio).toHaveAttribute('aria-checked', 'true');
+
+                // Update checked prop back to false
+                await page.evaluate(() => {
+                    const radioComponent = document.querySelector('pie-radio');
+                    if (radioComponent) radioComponent.checked = false;
+                });
+
+                // Assert reverted state
+                await expect(radio).toHaveAttribute('aria-checked', 'false');
+            });
         });
 
         test.describe('disabled', () => {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Updates the Radio and Radio Group components to ensure screenreaders correctly announce the index and selection size of inputs in a group. For example "2 of 6".
- Updates Radio to apply an `aria-checked` attribute to itself that reflects the checked state, so that screenreaders will say "selected" or similar when the radio is selected.
- New tests to check the features above

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [ ] I have reviewed visual test updates properly before approving.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

- Please visit each Aperture Radio Group page below and, with screen readers enabled, navigate through the radio buttons using your keyboard. The screenreader should correctly identify which position your selected radio button is in the group. For example "2 of 4" and it should say it is selected.

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](https://github.com/justeattakeaway/pie-aperture/pull/234) |
| NextJS 14 deployment   | [🔗](https://pr234-aperture-nextjs-app-v14.pie.design/components/radio-group) |
| Nuxt 3 deployment      | [🔗](https://pr234-aperture-nuxt-app.pie.design/components/radio-group) |
| Vanilla deployment     | [🔗](https://pr234-aperture-vanilla-app.pie.design/components/radio-group.html) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
