### PR TITLE
fix(pie-monorepo): WCP-000 downgrade GHA runner  to fix playwright dep issue with ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
   browser-tests-components:
     needs: [ build-ubuntu-node-20, deploy-storybook ]
     if: needs.check-change-type.outputs.web-components-change == 'true' || github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the Repo
       - name: Checkout
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/actions/setup-repo
         with:
           node-version: 20
-          os: ubuntu-latest
+          os: ubuntu-20.04
       # Setup Playwright
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
@@ -283,7 +283,7 @@ jobs:
 
   browser-tests-docs:
     needs: deploy-docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the Repo
       - name: Checkout
@@ -295,7 +295,7 @@ jobs:
         uses: ./.github/actions/setup-repo
         with:
           node-version: 20
-          os: ubuntu-latest
+          os: ubuntu-20.04
       # Setup Playwright
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright

--- a/yarn.lock
+++ b/yarn.lock
@@ -5063,7 +5063,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio-group@0.3.1, @justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group":
+"@justeattakeaway/pie-radio-group@0.4.0, @justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio-group@workspace:packages/components/pie-radio-group"
   dependencies:
@@ -5071,13 +5071,13 @@ __metadata:
     "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-radio": 0.5.0
+    "@justeattakeaway/pie-radio": 0.6.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-radio@0.5.0, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
+"@justeattakeaway/pie-radio@0.6.0, @justeattakeaway/pie-radio@workspace:packages/components/pie-radio":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-radio@workspace:packages/components/pie-radio"
   dependencies:
@@ -5162,7 +5162,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-thumbnail@0.0.0, @justeattakeaway/pie-thumbnail@workspace:packages/components/pie-thumbnail":
+"@justeattakeaway/pie-thumbnail@0.1.0, @justeattakeaway/pie-thumbnail@workspace:packages/components/pie-thumbnail":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-thumbnail@workspace:packages/components/pie-thumbnail"
   dependencies:
@@ -5221,7 +5221,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.5.57, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.5.59, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
@@ -5240,14 +5240,14 @@ __metadata:
     "@justeattakeaway/pie-lottie-player": 0.0.5
     "@justeattakeaway/pie-modal": 1.0.2
     "@justeattakeaway/pie-notification": 0.12.7
-    "@justeattakeaway/pie-radio": 0.5.0
-    "@justeattakeaway/pie-radio-group": 0.3.1
+    "@justeattakeaway/pie-radio": 0.6.0
+    "@justeattakeaway/pie-radio-group": 0.4.0
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-switch": 1.0.1
     "@justeattakeaway/pie-tag": 0.12.0
     "@justeattakeaway/pie-text-input": 0.24.6
     "@justeattakeaway/pie-textarea": 0.13.1
-    "@justeattakeaway/pie-thumbnail": 0.0.0
+    "@justeattakeaway/pie-thumbnail": 0.1.0
     "@justeattakeaway/pie-toast": 0.5.2
     "@justeattakeaway/pie-toast-provider": 0.0.0
     chalk: 5.3.0
@@ -22849,14 +22849,14 @@ __metadata:
     "@justeattakeaway/pie-modal": 1.0.2
     "@justeattakeaway/pie-monorepo-utils": 0.2.0
     "@justeattakeaway/pie-notification": 0.12.7
-    "@justeattakeaway/pie-radio": 0.5.0
-    "@justeattakeaway/pie-radio-group": 0.3.1
+    "@justeattakeaway/pie-radio": 0.6.0
+    "@justeattakeaway/pie-radio-group": 0.4.0
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-switch": 1.0.1
     "@justeattakeaway/pie-tag": 0.12.0
     "@justeattakeaway/pie-text-input": 0.24.6
     "@justeattakeaway/pie-textarea": 0.13.1
-    "@justeattakeaway/pie-thumbnail": 0.0.0
+    "@justeattakeaway/pie-thumbnail": 0.1.0
     "@justeattakeaway/pie-toast": 0.5.2
     "@justeattakeaway/pie-toast-provider": 0.0.0
     "@storybook/addon-a11y": 8.4.5
@@ -29585,7 +29585,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.57
+    "@justeattakeaway/pie-webc": 0.5.59
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -29599,7 +29599,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.57
+    "@justeattakeaway/pie-webc": 0.5.59
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -29614,7 +29614,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.57
+    "@justeattakeaway/pie-webc": 0.5.59
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -29634,7 +29634,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.57
+    "@justeattakeaway/pie-webc": 0.5.59
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -29654,7 +29654,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.5.57
+    "@justeattakeaway/pie-webc": 0.5.59
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
As we're currently unable to upgrade `@playwright/test`, this PR changes the test jobs to run on the old Github Action runner that doesn't exhibit a playwright dep install error.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [-] - N/A I have added thorough tests where applicable (unit / component / visual).
- [-] - N/A If changes will affect consumers of the package, I have created a changeset entry.
- [-] - N/A If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 @raoufswe 
- [-] - N/A I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] - N/A I have reviewed the Aperture changes (if added)
- [-] - N/A If there are visual test updates, I have reviewed them.

### Reviewer 2 @JoshuaNg2332 
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
