### PR TITLE
refactor(pie-notification): DSW-2380 to use `@playwright/test` & storybook for testing

### DIFF
--- a/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
@@ -95,7 +95,6 @@ const notificationStoryMeta: NotificationStoryMeta = {
         heading: {
             description: 'The text to display in the notification\'s heading.',
             control: 'text',
-            ariaLabel: 'FOOBAR',
         },
         headingLevel: {
             description: 'The HTML heading tag to use for the notification\'s heading. Can from h2 to h6. The font size is kept the same for all heading levels.',
@@ -144,12 +143,6 @@ const notificationStoryMeta: NotificationStoryMeta = {
         },
     },
     args: defaultArgs,
-    parameters: {
-        design: {
-            type: 'figma',
-            url: 'https://www.figma.com/file/pPSC73rPin4csb8DiK1CRr/branch/r96WaDE105zDbe5itnleVv/%E2%9C%A8-%5BCore%5D-Web-Components-%5BPIE-3%5D?type=design&node-id=1005-30849&mode=design&t=lYLzXOzJIeo6OvAw-0',
-        },
-    },
 };
 
 export default notificationStoryMeta;

--- a/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { action } from '@storybook/addon-actions';
 import { type Meta } from '@storybook/web-components';
@@ -9,13 +9,14 @@ import {
 } from '@justeattakeaway/pie-notification';
 
 import '@justeattakeaway/pie-icons-webc/dist/IconPlaceholder.js';
+import '@justeattakeaway/pie-icons-webc/dist/IconHeartFilled';
 
-import { createStory, type TemplateFunction } from '../utilities';
+import { createStory, createVariantStory, type TemplateFunction } from '../../utilities';
 
 // Extending the props type definition to include storybook specific properties for controls
 type NotificationProps = NotificationBaseProps & {
     slot: string;
-    iconSlot: keyof typeof slotOptions;
+    iconSlot: keyof typeof slotOptions | TemplateResult;
 };
 
 type NotificationStoryMeta = Meta<NotificationProps>;
@@ -23,7 +24,7 @@ type NotificationStoryMeta = Meta<NotificationProps>;
 const defaultArgs: NotificationProps = {
     ...defaultProps,
     slot: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis. Cras pretium venenatis elementum. Duis tristique neque non varius tempor. In hac habitasse platea dictumst. Aenean accumsan vehicula urna.',
-    heading: 'Heading',
+    heading: '',
     leadingAction: {
         text: 'Confirm',
         ariaLabel: 'Descriptive confirmation text',
@@ -42,6 +43,11 @@ const defaultArgs: NotificationProps = {
 const slotOptions = {
     None: nothing,
     Placeholder: html`<icon-placeholder slot="icon"></icon-placeholder>`,
+};
+
+const slotOptionsVisual = {
+    None: nothing,
+    Placeholder: html`<icon-heart-filled slot="icon"></icon-heart-filled>`,
 };
 
 const notificationStoryMeta: NotificationStoryMeta = {
@@ -89,6 +95,7 @@ const notificationStoryMeta: NotificationStoryMeta = {
         heading: {
             description: 'The text to display in the notification\'s heading.',
             control: 'text',
+            ariaLabel: 'FOOBAR',
         },
         headingLevel: {
             description: 'The HTML heading tag to use for the notification\'s heading. Can from h2 to h6. The font size is kept the same for all heading levels.',
@@ -152,6 +159,9 @@ const pieNotificationSupportingActionClick = action('pie-notification-supporting
 const pieNotificationClose = action('pie-notification-close');
 const pieNotificationOpen = action('pie-notification-open');
 
+const slotContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis. Cras pretium venenatis elementum. Duis tristique neque non varius tempor. In hac habitasse platea dictumst. Aenean accumsan vehicula urna. Cras fringilla sed ipsum nec dignissim. Aliquam sit amet ullamcorper ligula.';
+const mockSlottedIcon = html`<div slot="icon" data-test-id="pie-notification-icon-slotted">Mocked Icon Slot</div>`;
+
 const Template : TemplateFunction<NotificationProps> = ({
     aria,
     isOpen,
@@ -197,3 +207,58 @@ export const Info = createNotificationStory({ variant: 'info' });
 export const Success = createNotificationStory({ variant: 'success' });
 export const Error = createNotificationStory({ variant: 'error' });
 export const Warning = createNotificationStory({ variant: 'warning' });
+
+export const NotificationWithSlot = createNotificationStory({
+    slot: slotContent,
+    iconSlot: mockSlottedIcon,
+});
+
+const VariantsTemplate = (propVals: NotificationProps) => html`<pie-notification
+        variant="${propVals.variant}"
+        ?isCompact="${propVals.isCompact}"
+        ?isDismissible="${propVals.isDismissible}"
+        ?hideIcon="${propVals.hideIcon}"
+        heading="${propVals.heading}">
+            ${propVals.iconSlot}
+            ${slotContent}
+        </pie-notification>`;
+
+const sharedPropOptions = {
+    isCompact: [true, false],
+    isDismissible: [true, false],
+    hideIcon: [true, false],
+    heading: ['Title', null],
+    iconSlot: [slotOptionsVisual.None, slotOptionsVisual.Placeholder],
+};
+
+const neutralPropOptions = {
+    variant: ['neutral'],
+    ...sharedPropOptions,
+};
+
+const neutralAlternativePropOptions = {
+    ...sharedPropOptions,
+    variant: ['neutral-alternative'],
+};
+
+const infoPropOptions = {
+    ...sharedPropOptions,
+    variant: ['info'],
+};
+
+const successPropOptions = {
+    ...sharedPropOptions,
+    variant: ['success'],
+};
+
+const warningPropOptions = {
+    ...sharedPropOptions,
+    variant: ['warning'],
+};
+
+const errorPropOptions = {
+    ...sharedPropOptions,
+    variant: ['error'],
+};
+
+export const NeutralPropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, neutralPropOptions);

--- a/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
@@ -227,7 +227,7 @@ const sharedPropOptions = {
     isCompact: [true, false],
     isDismissible: [true, false],
     hideIcon: [true, false],
-    heading: ['Title', null],
+    heading: ['Title', nothing],
     iconSlot: [slotOptionsVisual.None, slotOptionsVisual.Placeholder],
 };
 

--- a/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
@@ -162,6 +162,18 @@ const pieNotificationOpen = action('pie-notification-open');
 const slotContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis. Cras pretium venenatis elementum. Duis tristique neque non varius tempor. In hac habitasse platea dictumst. Aenean accumsan vehicula urna. Cras fringilla sed ipsum nec dignissim. Aliquam sit amet ullamcorper ligula.';
 const mockSlottedIcon = html`<div slot="icon" data-test-id="pie-notification-icon-slotted">Mocked Icon Slot</div>`;
 
+const slotContentRTL = 'هذه الفقرة باللغة العربية ، لذا يجب الانتقال من اليمين إلى اليسار.';
+const titleRTL = 'عنوان';
+const confirmRTL = 'يتأكد';
+const denyRTL = 'ينكر';
+
+const mainAction = {
+    text: confirmRTL,
+};
+const secondaryAction = {
+    text: denyRTL,
+};
+
 const Template : TemplateFunction<NotificationProps> = ({
     aria,
     isOpen,
@@ -213,6 +225,13 @@ export const NotificationWithSlot = createNotificationStory({
     iconSlot: mockSlottedIcon,
 });
 
+export const NotificationRTL = createNotificationStory({
+    slot: slotContentRTL,
+    heading: titleRTL,
+    leadingAction: mainAction,
+    supportingAction: secondaryAction,
+});
+
 const VariantsTemplate = (propVals: NotificationProps) => html`<pie-notification
         variant="${propVals.variant}"
         ?isCompact="${propVals.isCompact}"
@@ -237,28 +256,33 @@ const neutralPropOptions = {
 };
 
 const neutralAlternativePropOptions = {
-    ...sharedPropOptions,
     variant: ['neutral-alternative'],
+    ...sharedPropOptions,
 };
 
 const infoPropOptions = {
-    ...sharedPropOptions,
     variant: ['info'],
+    ...sharedPropOptions,
 };
 
 const successPropOptions = {
-    ...sharedPropOptions,
     variant: ['success'],
+    ...sharedPropOptions,
 };
 
 const warningPropOptions = {
-    ...sharedPropOptions,
     variant: ['warning'],
+    ...sharedPropOptions,
 };
 
 const errorPropOptions = {
-    ...sharedPropOptions,
     variant: ['error'],
+    ...sharedPropOptions,
 };
 
 export const NeutralPropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, neutralPropOptions);
+export const NeutralAlternativePropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, neutralAlternativePropOptions);
+export const InfoPropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, infoPropOptions);
+export const SuccessPropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, successPropOptions);
+export const WarningPropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, warningPropOptions);
+export const ErrorPropVariations = createVariantStory<Partial<NotificationProps>>(VariantsTemplate, errorPropOptions);

--- a/apps/pie-storybook/utilities/index.ts
+++ b/apps/pie-storybook/utilities/index.ts
@@ -73,38 +73,37 @@ export const sanitizeAndRenderHTML = (slot: string) => unsafeHTML(DOMPurify.sani
  */
 export const createVariantStory = <T>(
     template: TemplateFunction<T>,
-    propOptions: Record<keyof T, unknown[]>,
+    propOptions: Partial<Record<keyof T, unknown[]>>,
     storyOpts?: StoryOptions,
 ) => ({
-        render: () => {
-            const generateCombinations = (options: Record<keyof T, unknown[]>): T[] => {
-                const keys = Object.keys(options) as (keyof T)[];
-                const combinations: T[] = [];
+    render: () => {
+        const generateCombinations = (options: Partial<Record<keyof T, unknown[]>>): T[] => {
+            const keys = Object.keys(options) as (keyof T)[];
+            const combinations: T[] = [];
 
-                const buildCombination = (index: number, currentCombination: Partial<T>) => {
-                    if (index === keys.length) {
-                        combinations.push(currentCombination as T);
-                        return;
-                    }
+            const buildCombination = (index: number, currentCombination: Partial<T>) => {
+                if (index === keys.length) {
+                    combinations.push(currentCombination as T);
+                    return;
+                }
 
-                    const key = keys[index];
-                    const values = options[key];
+                const key = keys[index];
+                const values = options[key] || [];
 
-                    values.forEach((value) => {
-                        buildCombination(index + 1, { ...currentCombination, [key]: value });
-                    });
-                };
-
-                buildCombination(0, {});
-                return combinations;
+                values.forEach((value) => {
+                    buildCombination(index + 1, { ...currentCombination, [key]: value });
+                });
             };
 
-            const propCombinations = generateCombinations(propOptions);
+            buildCombination(0, {});
+            return combinations;
+        };
 
-            return html`
-            <div style="display: block; width: 100%;">
-                ${propCombinations.map((props) => {
-                // Type assertion to ensure darkBackground is recognized
+        const propCombinations = generateCombinations(propOptions);
+
+        return html`
+        <div style="display: block; width: 100%;">
+            ${propCombinations.map((props) => {
                 const typedProps = props as T & { darkBackground?: boolean };
 
                 return html`
@@ -129,25 +128,25 @@ export const createVariantStory = <T>(
                     </div>
                   `;
             })}
-          </div>
-        `;
+        </div>
+      `;
+    },
+    parameters: {
+        backgrounds: {
+            ...(storyOpts?.bgColor ? { default: storyOpts.bgColor } : {}),
         },
-        parameters: {
-            backgrounds: {
-                ...(storyOpts?.bgColor ? { default: storyOpts.bgColor } : {}),
-            },
-            controls: {
-                disable: true,
-            },
-            design: {
-                disable: true,
-            },
-            actions: {
-                disable: true,
-            },
-            a11y: {
-                disable: true,
-            },
+        controls: {
+            disable: true,
         },
-        ...(storyOpts?.argTypes ? { argTypes: storyOpts.argTypes } : {}),
-    });
+        design: {
+            disable: true,
+        },
+        actions: {
+            disable: true,
+        },
+        a11y: {
+            disable: true,
+        },
+    },
+    ...(storyOpts?.argTypes ? { argTypes: storyOpts.argTypes } : {}),
+});

--- a/apps/pie-storybook/utilities/index.ts
+++ b/apps/pie-storybook/utilities/index.ts
@@ -76,32 +76,32 @@ export const createVariantStory = <T>(
     propOptions: Partial<Record<keyof T, unknown[]>>,
     storyOpts?: StoryOptions,
 ) => ({
-    render: () => {
-        const generateCombinations = (options: Partial<Record<keyof T, unknown[]>>): T[] => {
-            const keys = Object.keys(options) as (keyof T)[];
-            const combinations: T[] = [];
+        render: () => {
+            const generateCombinations = (options: Partial<Record<keyof T, unknown[]>>): T[] => {
+                const keys = Object.keys(options) as (keyof T)[];
+                const combinations: T[] = [];
 
-            const buildCombination = (index: number, currentCombination: Partial<T>) => {
-                if (index === keys.length) {
-                    combinations.push(currentCombination as T);
-                    return;
-                }
+                const buildCombination = (index: number, currentCombination: Partial<T>) => {
+                    if (index === keys.length) {
+                        combinations.push(currentCombination as T);
+                        return;
+                    }
 
-                const key = keys[index];
-                const values = options[key] || [];
+                    const key = keys[index];
+                    const values = options[key] || [];
 
-                values.forEach((value) => {
-                    buildCombination(index + 1, { ...currentCombination, [key]: value });
-                });
+                    values.forEach((value) => {
+                        buildCombination(index + 1, { ...currentCombination, [key]: value });
+                    });
+                };
+
+                buildCombination(0, {});
+                return combinations;
             };
 
-            buildCombination(0, {});
-            return combinations;
-        };
+            const propCombinations = generateCombinations(propOptions);
 
-        const propCombinations = generateCombinations(propOptions);
-
-        return html`
+            return html`
         <div style="display: block; width: 100%;">
             ${propCombinations.map((props) => {
                 const typedProps = props as T & { darkBackground?: boolean };
@@ -130,23 +130,23 @@ export const createVariantStory = <T>(
             })}
         </div>
       `;
-    },
-    parameters: {
-        backgrounds: {
-            ...(storyOpts?.bgColor ? { default: storyOpts.bgColor } : {}),
         },
-        controls: {
-            disable: true,
+        parameters: {
+            backgrounds: {
+                ...(storyOpts?.bgColor ? { default: storyOpts.bgColor } : {}),
+            },
+            controls: {
+                disable: true,
+            },
+            design: {
+                disable: true,
+            },
+            actions: {
+                disable: true,
+            },
+            a11y: {
+                disable: true,
+            },
         },
-        design: {
-            disable: true,
-        },
-        actions: {
-            disable: true,
-        },
-        a11y: {
-            disable: true,
-        },
-    },
-    ...(storyOpts?.argTypes ? { argTypes: storyOpts.argTypes } : {}),
-});
+        ...(storyOpts?.argTypes ? { argTypes: storyOpts.argTypes } : {}),
+    });

--- a/packages/components/pie-notification/playwright-lit-visual.config.ts
+++ b/packages/components/pie-notification/playwright-lit-visual.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightVisualConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeVisualConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightVisualConfig());
+export default defineConfig(getPlaywrightNativeVisualConfig());

--- a/packages/components/pie-notification/playwright-lit.config.ts
+++ b/packages/components/pie-notification/playwright-lit.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightConfig());
+export default defineConfig(getPlaywrightNativeConfig());

--- a/packages/components/pie-notification/test/accessibility/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/accessibility/pie-notification.spec.ts
@@ -1,14 +1,11 @@
-import { test, expect } from '@justeattakeaway/pie-webc-testing/src/playwright/webc-fixtures.ts';
-import { PieNotification, type NotificationProps } from '../../src/index.ts';
+import { test, expect } from '@justeattakeaway/pie-webc-testing/src/playwright/playwright-fixtures.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 
 test.describe('PieNotification - Accessibility tests', () => {
-    test('a11y - should test the PieNotification component WCAG compliance', async ({ makeAxeBuilder, mount }) => {
-        await mount(
-            PieNotification,
-            {
-                props: {} as NotificationProps,
-            },
-        );
+    test('a11y - should test the PieNotification component WCAG compliance', async ({ makeAxeBuilder, page }) => {
+        const notificationPage = new BasePage(page, 'notification');
+
+        await notificationPage.load();
 
         const results = await makeAxeBuilder().analyze();
 

--- a/packages/components/pie-notification/test/component/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/component/pie-notification.spec.ts
@@ -4,13 +4,11 @@ import { type NotificationProps, headingLevels, variants } from '../../src/defs.
 
 import { notification } from '../helpers/page-object/selectors.ts';
 
-const slotContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis. Cras pretium venenatis elementum. Duis tristique neque non varius tempor. In hac habitasse platea dictumst. Aenean accumsan vehicula urna. Cras fringilla sed ipsum nec dignissim. Aliquam sit amet ullamcorper ligula.';
-
 test.describe('PieNotification - Component tests', () => {
     test('should render successfully', async ({ page }) => {
         // Arrange
         const notificationPage = new BasePage(page, 'notification');
-        await notificationPage.load({ default: slotContent });
+        await notificationPage.load();
 
         // Act
         const notificationComponent = page.locator(notification.selectors.container.dataTestId);
@@ -25,7 +23,11 @@ test.describe('PieNotification - Component tests', () => {
                 test(`should render when the variant is ${variant}`, async ({ page }) => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
-                    await notificationPage.load({ variant });
+                    const props: NotificationProps = {
+                        variant,
+                    };
+
+                    await notificationPage.load({ ...props });
 
                     // Act
                     const notificationComponent = page.locator(notification.selectors.container.dataTestId);
@@ -38,7 +40,11 @@ test.describe('PieNotification - Component tests', () => {
             test('should render icon-info when variant is info', async ({ page }) => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
-                await notificationPage.load({ variant: 'info' });
+                const props: NotificationProps = {
+                    variant: 'info',
+                };
+
+                await notificationPage.load({ ...props });
 
                 // Act
                 const notificationComponent = page.locator(notification.selectors.container.dataTestId);
@@ -52,7 +58,12 @@ test.describe('PieNotification - Component tests', () => {
             test('should render icon-success when variant is success', async ({ page }) => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
-                await notificationPage.load({ variant: 'success' });
+
+                const props: NotificationProps = {
+                    variant: 'success',
+                };
+
+                await notificationPage.load({ ...props });
 
                 // Act
                 const notificationComponent = page.locator(notification.selectors.container.dataTestId);
@@ -66,7 +77,11 @@ test.describe('PieNotification - Component tests', () => {
             test('should render icon-warning when variant is warning', async ({ page }) => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
-                await notificationPage.load({ variant: 'warning' });
+                const props: NotificationProps = {
+                    variant: 'warning',
+                };
+
+                await notificationPage.load({ ...props });
 
                 // Act
                 const notificationComponent = page.locator(notification.selectors.container.dataTestId);
@@ -80,7 +95,7 @@ test.describe('PieNotification - Component tests', () => {
             test('should render icon-error when variant is error', async ({ page }) => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     variant: 'error',
                 };
 
@@ -100,10 +115,10 @@ test.describe('PieNotification - Component tests', () => {
             test('should not render the close icon if isCompact is true ', async ({ page }) => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
-
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     isCompact: true,
                 };
+
                 await notificationPage.load({ ...props });
 
                 // Act
@@ -120,10 +135,10 @@ test.describe('PieNotification - Component tests', () => {
             test('should render the header when heading is provided', async ({ page }) => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
-
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     heading: 'Title',
                 };
+
                 await notificationPage.load({ ...props });
 
                 // Act
@@ -144,7 +159,7 @@ test.describe('PieNotification - Component tests', () => {
                         // Arrange
                         const notificationPage = new BasePage(page, 'notification');
 
-                        const props: Partial<NotificationProps> = {
+                        const props: NotificationProps = {
                             headingLevel,
                             heading: `Title using ${headingLevel}`,
                         };
@@ -168,8 +183,9 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps & { iconSlot: string } = {
                         variant,
+                        iconSlot: 'Placeholder',
                         hideIcon: true,
                     };
                     await notificationPage.load({ ...props });
@@ -191,7 +207,7 @@ test.describe('PieNotification - Component tests', () => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
 
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     isDismissible: false,
                 };
                 await notificationPage.load({ ...props });
@@ -209,7 +225,7 @@ test.describe('PieNotification - Component tests', () => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
 
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     isDismissible: false,
                     isCompact: false,
                 };
@@ -228,7 +244,7 @@ test.describe('PieNotification - Component tests', () => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
 
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     isDismissible: true,
                     isCompact: true,
                 };
@@ -247,7 +263,7 @@ test.describe('PieNotification - Component tests', () => {
                 // Arrange
                 const notificationPage = new BasePage(page, 'notification');
 
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     isDismissible: true,
                 };
                 await notificationPage.load({ ...props });
@@ -277,7 +293,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         leadingAction: undefined,
                     };
                     await notificationPage.load({ ...props });
@@ -295,7 +311,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         isDismissible: true,
                         leadingAction: mainAction,
                     };
@@ -318,7 +334,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         isDismissible: true,
                         leadingAction: undefined,
                         supportingAction: secondaryAction,
@@ -342,7 +358,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         isDismissible: true,
                         leadingAction: mainAction,
                         supportingAction: secondaryAction,
@@ -368,7 +384,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         isDismissible: true,
                         leadingAction: mainAction,
                         supportingAction: secondaryAction,
@@ -397,7 +413,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         isDismissible: true,
                         leadingAction: mainAction,
                         supportingAction: secondaryAction,
@@ -442,7 +458,7 @@ test.describe('PieNotification - Component tests', () => {
                     const notificationPage = new BasePage(page, 'notification');
 
                     const ariaLabel = 'Notification heading';
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         aria: {
                             label: ariaLabel,
                         },
@@ -462,7 +478,7 @@ test.describe('PieNotification - Component tests', () => {
                     const notificationPage = new BasePage(page, 'notification');
 
                     const ariaLabel = 'Notification heading';
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         aria: {
                             label: ariaLabel,
                         },
@@ -485,7 +501,7 @@ test.describe('PieNotification - Component tests', () => {
                     const notificationPage = new BasePage(page, 'notification');
 
                     const ariaLabel = 'Notification heading';
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         aria: {
                             label: ariaLabel,
                         },
@@ -504,7 +520,7 @@ test.describe('PieNotification - Component tests', () => {
                     const notificationPage = new BasePage(page, 'notification');
 
                     const ariaLabel = 'Notification heading';
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         aria: {
                             label: ariaLabel,
                         },
@@ -535,7 +551,7 @@ test.describe('PieNotification - Component tests', () => {
                     // Arrange
                     const notificationPage = new BasePage(page, 'notification');
 
-                    const props: Partial<NotificationProps> = {
+                    const props: NotificationProps = {
                         variant: 'error',
                     };
 

--- a/packages/components/pie-notification/test/component/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/component/pie-notification.spec.ts
@@ -1,193 +1,161 @@
-import { test, expect } from '@sand4rt/experimental-ct-web';
-import { PieNotification } from '../../src/index.ts';
+import { test, expect } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 import { type NotificationProps, headingLevels, variants } from '../../src/defs.ts';
 
-const rootSelector = 'pie-notification';
-const componentSelector = `[data-test-id="${rootSelector}"]`;
-const iconCloseSelector = `[data-test-id="${rootSelector}-icon-close"]`;
-const slottedIconSelector = `[data-test-id="${rootSelector}-icon-slotted"]`;
-const headingIconInfoSelector = `[data-test-id="${rootSelector}-heading-icon-info"]`;
-const headingIconSuccessSelector = `[data-test-id="${rootSelector}-heading-icon-success"]`;
-const headingIconWarningSelector = `[data-test-id="${rootSelector}-heading-icon-warning"]`;
-const headingIconErrorSelector = `[data-test-id="${rootSelector}-heading-icon-error"]`;
-const headingSelector = `[data-test-id="${rootSelector}-heading"]`;
-const footerSelector = `[data-test-id="${rootSelector}-footer"]`;
-const leadingActionSelector = `[data-test-id="${rootSelector}-leading-action"]`;
-const supportingActionSelector = `[data-test-id="${rootSelector}-supporting-action"]`;
+import { notification } from '../helpers/page-object/selectors.ts';
 
 const slotContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis. Cras pretium venenatis elementum. Duis tristique neque non varius tempor. In hac habitasse platea dictumst. Aenean accumsan vehicula urna. Cras fringilla sed ipsum nec dignissim. Aliquam sit amet ullamcorper ligula.';
-const mockSlottedIcon = `<div slot="icon" data-test-id="${rootSelector}-icon-slotted">Mocked Icon Slot</div>`;
 
 test.describe('PieNotification - Component tests', () => {
-    // IMPORTANT: Mounting and Unmounting the component before each test ensures that any tests that do not explicitly
-    // mount the component will still have it available in Playwright's cache (loaded and registered in the test browser)
-    test.beforeEach(async ({ mount }) => {
-        const component = await mount(PieNotification);
-        await component.unmount();
-    });
-
-    // IMPORTANT: Mounting and Unmounting the component before each test ensures that any tests that do not explicitly
-    // mount the component will still have it available in Playwright's cache (loaded and registered in the test browser)
-    test.beforeEach(async ({ mount }) => {
-        const component = await mount(PieNotification);
-        await component.unmount();
-    });
-
-    test('should render successfully', async ({ mount, page }) => {
+    test('should render successfully', async ({ page }) => {
         // Arrange
-        await mount(PieNotification, {
-            props: {} as NotificationProps,
-            slots: { default: slotContent },
-        });
+        const notificationPage = new BasePage(page, 'notification');
+        await notificationPage.load({ default: slotContent });
 
         // Act
-        const notification = page.locator(componentSelector);
+        const notificationComponent = page.locator(notification.selectors.container.dataTestId);
 
         // Assert
-        expect(notification).toBeVisible();
+        await expect(notificationComponent).toBeVisible();
     });
 
     test.describe('Props', () => {
         test.describe('variants', () => {
             variants.forEach((variant) => {
-                test(`should render when the variant is ${variant}`, async ({ mount, page }) => {
+                test(`should render when the variant is ${variant}`, async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {
-                        props: {
-                            variant,
-                        },
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
+                    await notificationPage.load({ variant });
 
                     // Act
-                    const notification = page.locator(componentSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
                 });
             });
 
-            test('should render icon-info when variant is info', async ({ mount, page }) => {
+            test('should render icon-info when variant is info', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        variant: 'info',
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+                await notificationPage.load({ variant: 'info' });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const icon = page.locator(headingIconInfoSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const icon = notificationComponent.getByTestId(notification.selectors.headingIconInfo.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(icon).toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(icon).toBeVisible();
             });
 
-            test('should render icon-success when variant is success', async ({ mount, page }) => {
+            test('should render icon-success when variant is success', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        variant: 'success',
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+                await notificationPage.load({ variant: 'success' });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const icon = page.locator(headingIconSuccessSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const icon = notificationComponent.getByTestId(notification.selectors.headingIconSuccess.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(icon).toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(icon).toBeVisible();
             });
 
-            test('should render icon-warning when variant is warning', async ({ mount, page }) => {
+            test('should render icon-warning when variant is warning', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        variant: 'warning',
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+                await notificationPage.load({ variant: 'warning' });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const icon = page.locator(headingIconWarningSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const icon = notificationComponent.getByTestId(notification.selectors.headingIconWarning.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(icon).toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(icon).toBeVisible();
             });
 
-            test('should render icon-error when variant is error', async ({ mount, page }) => {
+            test('should render icon-error when variant is error', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        variant: 'error',
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    variant: 'error',
+                };
+
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const icon = page.locator(headingIconErrorSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const icon = notificationComponent.getByTestId(notification.selectors.headingIconError.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(icon).toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(icon).toBeVisible();
             });
         });
 
         test.describe('isCompact', () => {
-            test('should not render the close icon if isCompact is true ', async ({ mount, page }) => {
+            test('should not render the close icon if isCompact is true ', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: { isCompact: true },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+
+                const props: Partial<NotificationProps> = {
+                    isCompact: true,
+                };
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const iconClose = page.locator(iconCloseSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const iconClose = notificationComponent.getByTestId(notification.selectors.iconClose.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(iconClose).not.toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(iconClose).not.toBeVisible();
             });
         });
 
         test.describe('heading', () => {
-            test('should render the header when heading is provided', async ({ mount, page }) => {
+            test('should render the header when heading is provided', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: { heading: 'Title' } as NotificationProps,
-                });
+                const notificationPage = new BasePage(page, 'notification');
+
+                const props: Partial<NotificationProps> = {
+                    heading: 'Title',
+                };
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const heading = page.locator(`h2${headingSelector}`);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const heading = notificationComponent.locator('h2');
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(heading).toBeVisible();
-                expect(heading).toHaveText('Title');
+                await expect(notificationComponent).toBeVisible();
+                await expect(heading).toBeVisible();
+                await expect(heading).toHaveText('Title');
             });
         });
 
         test.describe('headingLevel', () => {
             test.describe('heading levels', () => {
                 headingLevels.forEach((headingLevel) => {
-                    test(`should render successfully when heading level is ${headingLevel}`, async ({ mount, page }) => {
+                    test(`should render successfully when heading level is ${headingLevel}`, async ({ page }) => {
                         // Arrange
-                        await mount(PieNotification, {
-                            props: {
-                                headingLevel,
-                                heading: `Title using ${headingLevel}`,
-                            } as NotificationProps,
-                        });
+                        const notificationPage = new BasePage(page, 'notification');
+
+                        const props: Partial<NotificationProps> = {
+                            headingLevel,
+                            heading: `Title using ${headingLevel}`,
+                        };
+                        await notificationPage.load({ ...props });
 
                         // Act
-                        const heading = page.locator(`${headingLevel}${headingSelector}`);
+                        const heading = page.locator(`${headingLevel}`);
 
                         // Assert
-                        expect(heading).toBeVisible();
-                        expect(heading).toHaveText(`Title using ${headingLevel}`);
+                        await expect(heading).toBeVisible();
+                        await expect(heading).toHaveText(`Title using ${headingLevel}`);
                     });
                 });
             });
@@ -196,96 +164,101 @@ test.describe('PieNotification - Component tests', () => {
         test.describe('hideIcon', () => {
             const variantsWithDefaultIcon = ['info', 'success', 'warning', 'error'];
             variants.filter((variant) => variantsWithDefaultIcon.includes(variant)).forEach((variant) => {
-                test(`should not render the default icon when the variant is ${variant} and hideIcon is true`, async ({ mount, page }) => {
+                test(`should not render the default icon when the variant is ${variant} and hideIcon is true`, async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {
-                        props: {
-                            variant,
-                            hideIcon: true,
-                        },
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        variant,
+                        hideIcon: true,
+                    };
+                    await notificationPage.load({ ...props });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const iconSelector = page.locator(`[data-test-id="${rootSelector}-heading-icon-${variant}"]`);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const iconSelector = page.locator(`[data-test-id="${notification.selectors.container.dataTestId}-heading-icon-${variant}"]`);
 
                     // Assert
-                    expect(notification).toBeVisible();
-                    expect(notification).toHaveAttribute('variant', variant);
-                    expect(iconSelector).not.toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
+                    await expect(notificationComponent).toHaveAttribute('variant', variant);
+                    await expect(iconSelector).not.toBeVisible();
                 });
             });
         });
 
         test.describe('isDismissible', () => {
-            test('should not show the close icon if isDismissible is false', async ({ mount, page }) => {
+            test('should not show the close icon if isDismissible is false', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        isDismissible: false,
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+
+                const props: Partial<NotificationProps> = {
+                    isDismissible: false,
+                };
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const iconClose = page.locator(iconCloseSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const iconClose = notificationComponent.getByTestId(notification.selectors.iconClose.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(iconClose).not.toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(iconClose).not.toBeVisible();
             });
 
-            test('should not show the close icon if isDismissible is false and isCompact is false', async ({ mount, page }) => {
+            test('should not show the close icon if isDismissible is false and isCompact is false', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        isDismissible: false,
-                        isCompact: false,
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+
+                const props: Partial<NotificationProps> = {
+                    isDismissible: false,
+                    isCompact: false,
+                };
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const iconClose = page.locator(iconCloseSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const iconClose = notificationComponent.getByTestId(notification.selectors.iconClose.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(iconClose).not.toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(iconClose).not.toBeVisible();
             });
 
-            test('should not show the close icon if isDismissible is true and isCompact is true', async ({ mount, page }) => {
+            test('should not show the close icon if isDismissible is true and isCompact is true', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        isDismissible: true,
-                        isCompact: true,
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+
+                const props: Partial<NotificationProps> = {
+                    isDismissible: true,
+                    isCompact: true,
+                };
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const iconClose = page.locator(iconCloseSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const iconClose = notificationComponent.getByTestId(notification.selectors.iconClose.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(iconClose).not.toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(iconClose).not.toBeVisible();
             });
 
-            test('should show the close icon if isDismissible is true', async ({ mount, page }) => {
+            test('should show the close icon if isDismissible is true', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        isDismissible: true,
-                    },
-                });
+                const notificationPage = new BasePage(page, 'notification');
+
+                const props: Partial<NotificationProps> = {
+                    isDismissible: true,
+                };
+                await notificationPage.load({ ...props });
 
                 // Act
-                const notification = page.locator(componentSelector);
-                const iconClose = page.locator(iconCloseSelector);
+                const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                const iconClose = notificationComponent.getByTestId(notification.selectors.iconClose.dataTestId);
 
                 // Assert
-                expect(notification).toBeVisible();
-                expect(iconClose).toBeVisible();
+                await expect(notificationComponent).toBeVisible();
+                await expect(iconClose).toBeVisible();
             });
         });
 
@@ -300,138 +273,148 @@ test.describe('PieNotification - Component tests', () => {
             };
 
             test.describe('leadingAction', () => {
-                test('should not show the footer if leadingAction is not provided', async ({ mount, page }) => {
+                test('should not show the footer if leadingAction is not provided', async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification);
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        leadingAction: undefined,
+                    };
+                    await notificationPage.load({ ...props });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const footer = page.locator(footerSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const footer = notificationComponent.getByTestId(notification.selectors.footer.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
-                    expect(footer).not.toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
+                    await expect(footer).not.toBeVisible();
                 });
 
-                test('should show the footer if leadingAction is provided', async ({ mount, page }) => {
+                test('should show the footer if leadingAction is provided', async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {
-                        props: {
-                            isDismissible: true,
-                            leadingAction: mainAction,
-                        } as NotificationProps,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        isDismissible: true,
+                        leadingAction: mainAction,
+                    };
+                    await notificationPage.load({ ...props });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const footer = page.locator(footerSelector);
-                    const actionLeading = page.locator(leadingActionSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const footer = notificationComponent.getByTestId(notification.selectors.footer.dataTestId);
+                    const actionLeading = notificationComponent.getByTestId(notification.selectors.leadingAction.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
-                    expect(footer).toBeVisible();
-                    expect(actionLeading).toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
+                    await expect(footer).toBeVisible();
+                    await expect(actionLeading).toBeVisible();
                 });
             });
 
             test.describe('supportingAction', () => {
-                test('should not show the footer nor leadingAction if only supportingAction is provided', async ({ mount, page }) => {
+                test('should not show the footer nor leadingAction if only supportingAction is provided', async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {
-                        props: {
-                            isDismissible: true,
-                            supportingAction: secondaryAction,
-                        } as NotificationProps,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        isDismissible: true,
+                        leadingAction: undefined,
+                        supportingAction: secondaryAction,
+                    };
+                    await notificationPage.load({ ...props });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const footer = page.locator(footerSelector);
-                    const actionLeading = page.locator(leadingActionSelector);
-                    const actionSupporting = page.locator(supportingActionSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const footer = notificationComponent.getByTestId(notification.selectors.footer.dataTestId);
+                    const actionLeading = notificationComponent.getByTestId(notification.selectors.leadingAction.dataTestId);
+                    const actionSupporting = notificationComponent.getByTestId(notification.selectors.supportingAction.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
-                    expect(footer).not.toBeVisible();
-                    expect(actionLeading).not.toBeVisible();
-                    expect(actionSupporting).not.toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
+                    await expect(footer).not.toBeVisible();
+                    await expect(actionLeading).not.toBeVisible();
+                    await expect(actionSupporting).not.toBeVisible();
                 });
 
-                test('should the leadingAction and supportingAction when both are provided', async ({ mount, page }) => {
+                test('should the leadingAction and supportingAction when both are provided', async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {
-                        props: {
-                            isDismissible: true,
-                            leadingAction: mainAction,
-                            supportingAction: secondaryAction,
-                        } as NotificationProps,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        isDismissible: true,
+                        leadingAction: mainAction,
+                        supportingAction: secondaryAction,
+                    };
+                    await notificationPage.load({ ...props });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const footer = page.locator(footerSelector);
-                    const actionLeading = page.locator(leadingActionSelector);
-                    const actionSupporting = page.locator(supportingActionSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const footer = notificationComponent.getByTestId(notification.selectors.footer.dataTestId);
+                    const actionLeading = notificationComponent.getByTestId(notification.selectors.leadingAction.dataTestId);
+                    const actionSupporting = notificationComponent.getByTestId(notification.selectors.supportingAction.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
-                    expect(footer).toBeVisible();
-                    expect(actionLeading).toBeVisible();
-                    expect(actionSupporting).toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
+                    await expect(footer).toBeVisible();
+                    await expect(actionLeading).toBeVisible();
+                    await expect(actionSupporting).toBeVisible();
                 });
             });
 
             test.describe('hasStackedActions', () => {
-                test('should stack buttons on small screens', async ({ mount, page }) => {
+                test('should stack buttons on small screens', async ({ page }) => {
                     // Arrange
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        isDismissible: true,
+                        leadingAction: mainAction,
+                        supportingAction: secondaryAction,
+                        hasStackedActions: true,
+                    };
+                    await notificationPage.load({ ...props });
+
                     await page.setViewportSize({ width: 375, height: 667 });
-                    await mount(PieNotification, {
-                        props: {
-                            isDismissible: true,
-                            leadingAction: mainAction,
-                            supportingAction: secondaryAction,
-                            hasStackedActions: true,
-                        } as NotificationProps,
-                    });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const footer = page.locator(footerSelector);
-                    const actionLeading = page.locator(leadingActionSelector);
-                    const actionSupporting = page.locator(supportingActionSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const footer = notificationComponent.getByTestId(notification.selectors.footer.dataTestId);
+                    const actionLeading = notificationComponent.getByTestId(notification.selectors.leadingAction.dataTestId);
+                    const actionSupporting = notificationComponent.getByTestId(notification.selectors.supportingAction.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
-                    expect(footer).toBeVisible();
-                    expect(actionLeading).toBeVisible();
-                    expect(actionSupporting).toBeVisible();
+                    await expect(notificationComponent).toBeVisible();
+                    await expect(footer).toBeVisible();
+                    await expect(actionLeading).toBeVisible();
+                    await expect(actionSupporting).toBeVisible();
 
-                    expect(footer).toHaveCSS('flex-direction', 'column-reverse');
-                    // 295px is the size of the button when the viewport size is 375px
-                    expect(actionLeading).toHaveCSS('width', '295px');
-                    expect(actionSupporting).toHaveCSS('width', '295px');
+                    await expect(footer).toHaveCSS('flex-direction', 'column-reverse');
                 });
 
-                test('should not stack buttons on large screens', async ({ mount, page }) => {
+                test('should not stack buttons on large screens', async ({ page }) => {
                     // Arrange
+                    const notificationPage = new BasePage(page, 'notification');
+
+                    const props: Partial<NotificationProps> = {
+                        isDismissible: true,
+                        leadingAction: mainAction,
+                        supportingAction: secondaryAction,
+                        hasStackedActions: true,
+                    };
+                    await notificationPage.load({ ...props });
+
                     await page.setViewportSize({ width: 1275, height: 900 });
-                    await mount(PieNotification, {
-                        props: {
-                            isDismissible: true,
-                            leadingAction: mainAction,
-                            supportingAction: secondaryAction,
-                            hasStackedActions: true,
-                        } as NotificationProps,
-                    });
 
                     // Act
-                    const notification = page.locator(componentSelector);
-                    const footer = page.locator(footerSelector);
-                    const actionLeading = page.locator(leadingActionSelector);
-                    const actionSupporting = page.locator(supportingActionSelector);
+                    const notificationComponent = page.locator(notification.selectors.container.dataTestId);
+                    const footer = notificationComponent.getByTestId(notification.selectors.footer.dataTestId);
+                    const actionLeading = notificationComponent.getByTestId(notification.selectors.leadingAction.dataTestId);
+                    const actionSupporting = notificationComponent.getByTestId(notification.selectors.supportingAction.dataTestId);
 
                     // Assert
-                    expect(notification).toBeVisible();
+                    expect(notificationComponent).toBeVisible();
                     expect(footer).toBeVisible();
                     expect(actionLeading).toBeVisible();
                     expect(actionSupporting).toBeVisible();
@@ -442,140 +425,146 @@ test.describe('PieNotification - Component tests', () => {
         });
 
         test.describe('Aria attributes', () => {
-            test('should assign role="region"', async ({ mount, page }) => {
+            test('should assign role="region"', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {});
+                const notificationPage = new BasePage(page, 'notification');
+                await notificationPage.load();
 
-                const notification = await page.locator(componentSelector);
+                const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
 
                 // Act & Assert
-                await expect(notification).toHaveAttribute('role', 'region');
+                await expect(notificationComponent).toHaveAttribute('role', 'region');
             });
 
             test.describe('aria-label', () => {
-                test('should only be set if there is no heading to ensure the region is announced with a title', async ({ mount, page }) => {
+                test('should only be set if there is no heading to ensure the region is announced with a title', async ({ page }) => {
                     // Arrange
-                    const ariaLabel = 'Notification heading';
-                    await mount(PieNotification, {
-                        props: {
-                            aria: {
-                                label: ariaLabel,
-                            },
-                        } as PieNotification,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
 
-                    const notification = await page.locator(componentSelector);
-                    const heading = await page.locator(`h2${headingSelector}`);
+                    const ariaLabel = 'Notification heading';
+                    const props: Partial<NotificationProps> = {
+                        aria: {
+                            label: ariaLabel,
+                        },
+                    };
+                    await notificationPage.load({ ...props });
+
+                    const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
+                    const heading = page.locator('h2');
 
                     // Act & Assert
-                    expect(notification).toHaveAttribute('aria-label', ariaLabel);
-                    expect(heading).not.toBeVisible();
+                    await expect(notificationComponent).toHaveAttribute('aria-label', ariaLabel);
+                    await expect(heading).not.toBeVisible();
                 });
 
-                test('should be ignored if heading is provided as the title will be used as the region title', async ({ mount, page }) => {
+                test('should be ignored if heading is provided as the title will be used as the region title', async ({ page }) => {
                     // Arrange
-                    const ariaLabel = 'Notification heading';
-                    await mount(PieNotification, {
-                        props: {
-                            aria: {
-                                label: ariaLabel,
-                            },
-                            heading: 'Heading',
-                        } as PieNotification,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
 
-                    const notification = await page.locator(componentSelector);
-                    const heading = await page.locator(`h2${headingSelector}`);
+                    const ariaLabel = 'Notification heading';
+                    const props: Partial<NotificationProps> = {
+                        aria: {
+                            label: ariaLabel,
+                        },
+                        heading: 'Heading',
+                    };
+                    await notificationPage.load({ ...props });
+
+                    const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
+                    const heading = page.locator('h2');
 
                     // Act & Assert
-                    expect(notification).not.toHaveAttribute('aria-label', ariaLabel);
-                    expect(heading).toBeVisible();
+                    await expect(notificationComponent).not.toHaveAttribute('aria-label', ariaLabel);
+                    await expect(heading).toBeVisible();
                 });
             });
 
             test.describe('aria-labelledby', () => {
-                test('should only be set if heading is provided to ensure the region is announced with a title', async ({ mount, page }) => {
+                test('should only be set if heading is provided to ensure the region is announced with a title', async ({ page }) => {
                     // Arrange
-                    const ariaLabel = 'Notification heading';
-                    await mount(PieNotification, {
-                        props: {
-                            aria: {
-                                label: ariaLabel,
-                            },
-                            heading: 'Heading',
-                        } as PieNotification,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
 
-                    const notification = await page.locator(componentSelector);
+                    const ariaLabel = 'Notification heading';
+                    const props: Partial<NotificationProps> = {
+                        aria: {
+                            label: ariaLabel,
+                        },
+                        heading: 'Heading',
+                    };
+                    await notificationPage.load({ ...props });
+
+                    const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
 
                     // Act & Assert
-                    expect(notification).toHaveAttribute('aria-labelledby', `${rootSelector}-heading`);
+                    await expect(notificationComponent).toHaveAttribute('aria-labelledby', `${notification.selectors.heading.dataTestId}`);
                 });
 
-                test('should be ignored if heading is not provided', async ({ mount, page }) => {
+                test('should be ignored if heading is not provided', async ({ page }) => {
                     // Arrange
-                    const ariaLabel = 'Notification heading';
-                    await mount(PieNotification, {
-                        props: {
-                            aria: {
-                                label: ariaLabel,
-                            },
-                        } as PieNotification,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
 
-                    const notification = await page.locator(componentSelector);
+                    const ariaLabel = 'Notification heading';
+                    const props: Partial<NotificationProps> = {
+                        aria: {
+                            label: ariaLabel,
+                        },
+                    };
+                    await notificationPage.load({ ...props });
+
+                    const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
 
                     // Act & Assert
-                    expect(notification).not.toHaveAttribute('aria-labelledby', `${rootSelector}-heading`);
+                    await expect(notificationComponent).not.toHaveAttribute('aria-labelledby', `${notification.selectors.heading.dataTestId}`);
                 });
             });
 
             test.describe('aria-live', () => {
-                test('should be set to `polite` by default', async ({ mount, page }) => {
+                test('should be set to `polite` by default', async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {});
+                    const notificationPage = new BasePage(page, 'notification');
 
-                    const notification = await page.locator(componentSelector);
+                    await notificationPage.load();
+
+                    const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
 
                     // Act & Assert
-                    expect(notification).toHaveAttribute('aria-live', 'polite');
+                    await expect(notificationComponent).toHaveAttribute('aria-live', 'polite');
                 });
 
-                test('should be set to `assertive` for the error variant', async ({ mount, page }) => {
+                test('should be set to `assertive` for the error variant', async ({ page }) => {
                     // Arrange
-                    await mount(PieNotification, {
-                        props: {
-                            variant: 'error',
-                        } as PieNotification,
-                    });
+                    const notificationPage = new BasePage(page, 'notification');
 
-                    const notification = await page.locator(componentSelector);
+                    const props: Partial<NotificationProps> = {
+                        variant: 'error',
+                    };
+
+                    await notificationPage.load({ ...props });
+
+                    const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
 
                     // Act & Assert
-                    expect(notification).toHaveAttribute('aria-live', 'assertive');
+                    await expect(notificationComponent).toHaveAttribute('aria-live', 'assertive');
                 });
             });
         });
     });
 
     test.describe('Slots', () => {
-        test('should correctly render the slot content and an icon as named slot', async ({ mount, page }) => {
+        test('should correctly render the slot content and an icon as named slot', async ({ page }) => {
             // Arrange
-            await mount(PieNotification, {
-                slots: {
-                    default: slotContent,
-                    icon: mockSlottedIcon,
-                },
-            });
+            const notificationPage = new BasePage(page, 'notification--notification-with-slot');
+
+            await notificationPage.load();
 
             // Act
-            const notification = page.locator(componentSelector);
-            const slottedIcon = page.locator(slottedIconSelector);
+            const notificationComponent = page.getByTestId(notification.selectors.container.dataTestId);
+            const slottedIcon = page.getByTestId(notification.selectors.slottedIcon.dataTestId);
 
             // Assert
-            expect(notification).toBeVisible();
-            expect(slottedIcon).toBeVisible();
-            expect(slottedIcon).toHaveText('Mocked Icon Slot');
+            await expect(notificationComponent).toBeVisible();
+            await expect(slottedIcon).toBeVisible();
+            await expect(slottedIcon).toHaveText('Mocked Icon Slot');
         });
     });
 });

--- a/packages/components/pie-notification/test/helpers/page-object/selectors.ts
+++ b/packages/components/pie-notification/test/helpers/page-object/selectors.ts
@@ -1,0 +1,51 @@
+const notification = {
+    selectors: {
+        container: {
+            description: 'The selector for the notification container',
+            dataTestId: 'pie-notification',
+        },
+        iconClose: {
+            description: 'The selector for the close icon',
+            dataTestId: 'pie-notification-icon-close',
+        },
+        slottedIcon: {
+            description: 'The selector for the slotted icon',
+            dataTestId: 'pie-notification-icon-slotted',
+        },
+        headingIconInfo: {
+            description: 'The selector for the info icon',
+            dataTestId: 'pie-notification-heading-icon-info',
+        },
+        headingIconSuccess: {
+            description: 'The selector for the success icon',
+            dataTestId: 'pie-notification-heading-icon-success',
+        },
+        headingIconWarning: {
+            description: 'The selector for the warning icon',
+            dataTestId: 'pie-notification-heading-icon-warning',
+        },
+        headingIconError: {
+            description: 'The selector for the error icon',
+            dataTestId: 'pie-notification-heading-icon-error',
+        },
+        heading: {
+            description: 'The selector for the notification heading',
+            dataTestId: 'pie-notification-heading',
+        },
+        footer: {
+            description: 'The selector for the notification footer',
+            dataTestId: 'pie-notification-footer',
+        },
+        leadingAction: {
+            description: 'The selector for the notification leading action',
+            dataTestId: 'pie-notification-leading-action',
+        },
+        supportingAction: {
+            description: 'The selector for the notification supporting action',
+            dataTestId: 'pie-notification-supporting-action',
+        },
+    },
+};
+export {
+    notification,
+};

--- a/packages/components/pie-notification/test/visual/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/visual/pie-notification.spec.ts
@@ -1,99 +1,21 @@
-import { test } from '@sand4rt/experimental-ct-web';
+import { test } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
-import type {
-    PropObject, WebComponentPropValues, WebComponentTestInput,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 import {
-    getAllPropCombinations, splitCombinationsByPropertyValue,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/get-all-prop-combos.ts';
-import {
-    createTestWebComponent,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
-import {
-    WebComponentTestWrapper,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
-import { setRTL } from '@justeattakeaway/pie-webc-testing/src/helpers/set-rtl-direction.ts';
-import { IconHeartFilled } from '@justeattakeaway/pie-icons-webc';
-import {
+    type NotificationProps,
     variants,
     headingLevels,
     positions,
 } from '../../src/defs.ts';
-import { PieNotification, type NotificationProps } from '../../src/index.ts';
 
 export const screenWidths = {
     widths: [1450, 375],
 };
 
-const slotContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis. Cras pretium venenatis elementum. Duis tristique neque non varius tempor. In hac habitasse platea dictumst. Aenean accumsan vehicula urna. Cras fringilla sed ipsum nec dignissim. Aliquam sit amet ullamcorper ligula.';
-const slotContentRTL = 'هذه الفقرة باللغة العربية ، لذا يجب الانتقال من اليمين إلى اليسار.';
-const titleRTL = 'عنوان';
-const confirmRTL = 'يتأكد';
-const denyRTL = 'ينكر';
+variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
+    const basePage = new BasePage(page, `notification--${variant}-prop-variations`);
 
-const props: PropObject = {
-    variant: variants,
-    heading: ['Title', ''],
-    isDismissible: [false, true],
-    isCompact: [false, true],
-    hideIcon: [false, true],
-    iconSlot: ['', '<icon-heart-filled slot="icon"></icon-heart-filled>'],
-};
-
-// Renders a <pie-notification> HTML string with the given prop values
-const renderTestPieNotification = (propVals: WebComponentPropValues) => `<pie-notification
-        variant="${propVals.variant}"
-        ${propVals.isCompact ? 'isCompact' : ''}
-        ${propVals.isDismissible ? 'isDismissible' : ''}
-        ${propVals.hideIcon ? 'hideIcon' : ''}
-        heading="${propVals.heading}">
-            ${propVals.iconSlot}
-            ${slotContent}
-        </pie-notification>`;
-
-const componentPropsMatrix: WebComponentPropValues[] = getAllPropCombinations(props);
-const componentPropsMatrixByVariant: Record<string, WebComponentPropValues[]> = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
-const componentVariants: string[] = Object.keys(componentPropsMatrixByVariant);
-
-test.beforeEach(async ({ mount }, testInfo) => {
-    testInfo.setTimeout(testInfo.timeout + 40000);
-
-    // This ensures the tag and icon components are registered in the DOM for each test.
-    // It appears to add them to a Playwright cache which we understand is required for the tests to work correctly.
-    const tagComponent = await mount(PieNotification);
-    await tagComponent.unmount();
-    const iconComponent = await mount(IconHeartFilled);
-    await iconComponent.unmount();
-});
-
-componentVariants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page, mount }) => {
-    for (const combo of componentPropsMatrixByVariant[variant]) {
-        const testComponent: WebComponentTestInput = createTestWebComponent(combo, renderTestPieNotification);
-
-        const propKeyValues = `
-            variant: ${testComponent.propValues.variant},
-            isCompact: ${testComponent.propValues.isCompact},
-            isDismissible: ${testComponent.propValues.isDismissible},
-            hideIcon: ${testComponent.propValues.hideIcon},
-            heading: ${testComponent.propValues.heading},
-            iconSlot: ${testComponent.propValues.iconSlot ? 'with an external icon' : 'no external icon'}
-        `;
-
-        const darkMode = ['neutral-alternative'].includes(variant);
-
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues, darkMode },
-                slots: {
-                    component: testComponent.renderedString.trim(),
-                },
-            },
-        );
-    }
-
-    // Follow up to remove in Jan
-    await page.waitForTimeout(5000);
+    await basePage.load();
 
     await percySnapshot(page, `PIE Notification - Variant: ${variant}`, screenWidths);
 }));
@@ -120,15 +42,17 @@ test.describe('Props', () => {
 
     test.describe('PieNotification headingLevels', () => {
         headingLevels.forEach((headingLevel) => {
-            test(`should render correctly the ${headingLevel} headingLevel`, async ({ page, mount }) => {
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        headingLevel,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+            test(`should render correctly the ${headingLevel} headingLevel`, async ({ page }) => {
+                // Arrange
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    headingLevel,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, `PieNotification - headingLevel = ${headingLevel} but font size remains the same`);
             });
         });
@@ -136,142 +60,150 @@ test.describe('Props', () => {
 
     test.describe('Action buttons', () => {
         test.describe('leadingAction', () => {
-            test('should render leadingAction when leadingAction is provided', async ({ mount, page }) => {
+            test('should render leadingAction when leadingAction is provided', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 375, height: 667 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - leadingAction');
             });
 
-            test('should not render leadingAction when leadingAction not is provided', async ({ mount, page }) => {
+            test('should not render leadingAction when leadingAction not is provided', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 375, height: 667 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: undefined,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: undefined,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - leadingAction not provided');
             });
         });
 
         test.describe('supportingAction', () => {
-            test('should not render supportingAction when leadingAction not is provided', async ({ mount, page }) => {
+            test('should not render supportingAction when leadingAction not is provided', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 375, height: 667 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: undefined,
-                        supportingAction: secondaryAction,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: undefined,
+                    supportingAction: secondaryAction,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - leadingAction not provided and supportingAction is provided');
             });
 
-            test('should render supportingAction when leadingAction and supportingAction is provided', async ({ mount, page }) => {
+            test('should render supportingAction when leadingAction and supportingAction is provided', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 375, height: 667 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                        supportingAction: secondaryAction,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                    supportingAction: secondaryAction,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - leadingAction is provided and supportingAction is provided');
             });
         });
 
         test.describe('hasStackedActions', () => {
-            test('should stack buttons on small screens', async ({ mount, page }) => {
+            test('should stack buttons on small screens', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 375, height: 667 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                        supportingAction: secondaryAction,
-                        hasStackedActions: true,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                    supportingAction: secondaryAction,
+                    hasStackedActions: true,
+                };
 
+                await basePage.load({ ...props });
+                await page.setViewportSize({ width: 375, height: 667 });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - hasStackedActions = true - should stack buttons on small screens');
             });
 
-            test('should not stack buttons on small screens', async ({ mount, page }) => {
+            test('should not stack buttons on small screens', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 375, height: 667 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                        supportingAction: secondaryAction,
-                        hasStackedActions: false,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                    supportingAction: secondaryAction,
+                    hasStackedActions: false,
+                };
 
+                await basePage.load({ ...props });
+                await page.setViewportSize({ width: 375, height: 667 });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - hasStackedActions = false - should not stack buttons on small screens');
             });
 
-            test('should not stack buttons on large screens when hasStackedActions is true', async ({ mount, page }) => {
+            test('should not stack buttons on large screens when hasStackedActions is true', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 1275, height: 900 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                        supportingAction: secondaryAction,
-                        hasStackedActions: true,
-                    } as NotificationProps,
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                    supportingAction: secondaryAction,
+                    hasStackedActions: true,
+                };
 
+                await basePage.load({ ...props });
+                await page.setViewportSize({ width: 1275, height: 900 });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - hasStackedActions = true - should not stack buttons on large screens');
             });
 
-            test('should not stack buttons on large screens when hasStackedActions is false', async ({ mount, page }) => {
+            test('should not stack buttons on large screens when hasStackedActions is false', async ({ page }) => {
                 // Arrange
-                await page.setViewportSize({ width: 1275, height: 900 });
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                        supportingAction: secondaryAction,
-                        hasStackedActions: false,
-                    } as NotificationProps,
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                    supportingAction: secondaryAction,
+                    hasStackedActions: false,
+                };
 
+                await basePage.load({ ...props });
+                await page.setViewportSize({ width: 1275, height: 900 });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - hasStackedActions = false - should not stack buttons on large screens');
             });
 
-            test('should not stack buttons when hasStackedActions is true and isCompact is true regardless the screen size', async ({ mount, page }) => {
+            test('should not stack buttons when hasStackedActions is true and isCompact is true regardless the screen size', async ({ page }) => {
                 // Arrange
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        leadingAction: mainAction,
-                        supportingAction: secondaryAction,
-                        hasStackedActions: true,
-                        isCompact: true,
-                    } as NotificationProps,
-                });
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    leadingAction: mainAction,
+                    supportingAction: secondaryAction,
+                    hasStackedActions: true,
+                    isCompact: true,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, 'PieNotification - hasStackedActions = false, isCompact = true - should not stack buttons');
             });
         });
@@ -279,15 +211,17 @@ test.describe('Props', () => {
 
     test.describe('PieNotification positions', () => {
         positions.forEach((positionValue) => {
-            test(`should render correctly the ${positionValue} position`, async ({ page, mount }) => {
-                await mount(PieNotification, {
-                    props: {
-                        ...initialValues,
-                        position: positionValue,
-                    } as NotificationProps,
-                    slots: { default: slotContent },
-                });
+            test(`should render correctly the ${positionValue} position`, async ({ page }) => {
+                // Arrange
+                const basePage = new BasePage(page, 'notification');
+                const props: Partial<NotificationProps> = {
+                    ...initialValues,
+                    position: positionValue,
+                };
 
+                await basePage.load({ ...props });
+
+                // Assert
                 await percySnapshot(page, `PieNotification - position = ${positionValue} border-radius`);
             });
         });
@@ -295,26 +229,17 @@ test.describe('Props', () => {
 });
 
 test.describe('Reading direction - RTL - Right to Left', () => {
-    test('should slots icons and buttons when the reading direction is RTL', async ({ mount, page }) => {
-        setRTL(page);
-
-        const mainAction = {
-            text: confirmRTL,
-        };
-        const secondaryAction = {
-            text: denyRTL,
+    test('should slots icons and buttons when the reading direction is RTL', async ({ page }) => {
+        // Arrange
+        const basePage = new BasePage(page, 'notification--rtl-visual');
+        const props: Partial<NotificationProps> = {
+            isOpen: true,
+            isDismissible: true,
         };
 
-        await mount(PieNotification, {
-            props: {
-                ...initialValues,
-                heading: titleRTL,
-                leadingAction: mainAction,
-                supportingAction: secondaryAction,
-            } as NotificationProps,
-            slots: { default: slotContentRTL },
-        });
+        await basePage.load({ ...props }, { writingDirection: 'rtl' });
 
+        // Assert
         await percySnapshot(page, 'PieNotification - Reading direction - RTL - Right to Left');
     });
 });

--- a/packages/components/pie-notification/test/visual/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/visual/pie-notification.spec.ts
@@ -31,10 +31,6 @@ const initialValues: NotificationProps = {
 };
 
 test.describe('Props', () => {
-    const mainAction = {
-        text: 'Confirm',
-        ariaLabel: 'Button that confirm the action',
-    };
     const secondaryAction = {
         text: 'Cancel',
         ariaLabel: 'Button that cancel the action',
@@ -45,9 +41,8 @@ test.describe('Props', () => {
             test(`should render correctly the ${headingLevel} headingLevel`, async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    headingLevel,
                 };
 
                 await basePage.load({ ...props });
@@ -63,9 +58,8 @@ test.describe('Props', () => {
             test('should render leadingAction when leadingAction is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                 };
 
                 await basePage.load({ ...props });
@@ -77,7 +71,7 @@ test.describe('Props', () => {
             test('should not render leadingAction when leadingAction not is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
                     leadingAction: undefined,
                 };
@@ -93,7 +87,7 @@ test.describe('Props', () => {
             test('should not render supportingAction when leadingAction not is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
                     leadingAction: undefined,
                     supportingAction: secondaryAction,
@@ -108,9 +102,8 @@ test.describe('Props', () => {
             test('should render supportingAction when leadingAction and supportingAction is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                     supportingAction: secondaryAction,
                 };
 
@@ -125,9 +118,8 @@ test.describe('Props', () => {
             test('should stack buttons on small screens', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                     supportingAction: secondaryAction,
                     hasStackedActions: true,
                 };
@@ -142,9 +134,8 @@ test.describe('Props', () => {
             test('should not stack buttons on small screens', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                     supportingAction: secondaryAction,
                     hasStackedActions: false,
                 };
@@ -159,9 +150,8 @@ test.describe('Props', () => {
             test('should not stack buttons on large screens when hasStackedActions is true', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                     supportingAction: secondaryAction,
                     hasStackedActions: true,
                 };
@@ -176,9 +166,8 @@ test.describe('Props', () => {
             test('should not stack buttons on large screens when hasStackedActions is false', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                     supportingAction: secondaryAction,
                     hasStackedActions: false,
                 };
@@ -193,9 +182,8 @@ test.describe('Props', () => {
             test('should not stack buttons when hasStackedActions is true and isCompact is true regardless the screen size', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
-                    leadingAction: mainAction,
                     supportingAction: secondaryAction,
                     hasStackedActions: true,
                     isCompact: true,
@@ -214,7 +202,7 @@ test.describe('Props', () => {
             test(`should render correctly the ${positionValue} position`, async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                const props: Partial<NotificationProps> = {
+                const props: NotificationProps = {
                     ...initialValues,
                     position: positionValue,
                 };
@@ -231,8 +219,8 @@ test.describe('Props', () => {
 test.describe('Reading direction - RTL - Right to Left', () => {
     test('should slots icons and buttons when the reading direction is RTL', async ({ page }) => {
         // Arrange
-        const basePage = new BasePage(page, 'notification--rtl-visual');
-        const props: Partial<NotificationProps> = {
+        const basePage = new BasePage(page, 'notification--notification-rtl');
+        const props: NotificationProps = {
             isOpen: true,
             isDismissible: true,
         };

--- a/packages/components/pie-notification/turbo.json
+++ b/packages/components/pie-notification/turbo.json
@@ -6,19 +6,35 @@
   "pipeline": {
     "test:browsers": {
       "cache": true,
-      "dependsOn": []
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"
+      ]
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": []
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"
+      ]
     },
     "test:visual": {
       "cache": false,
-      "dependsOn": []
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"
+      ]
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": []
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"
+      ]
     }
   }
 }

--- a/packages/components/pie-notification/turbo.json
+++ b/packages/components/pie-notification/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": [
+    "//"
+  ],
+  "pipeline": {
+    "test:browsers": {
+      "cache": true,
+      "dependsOn": []
+    },
+    "test:browsers:ci": {
+      "cache": true,
+      "dependsOn": []
+    },
+    "test:visual": {
+      "cache": false,
+      "dependsOn": []
+    },
+    "test:visual:ci": {
+      "cache": false,
+      "dependsOn": []
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,20 +5174,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-toast-provider@0.1.0, @justeattakeaway/pie-toast-provider@workspace:packages/components/pie-toast-provider":
+"@justeattakeaway/pie-toast-provider@0.2.0, @justeattakeaway/pie-toast-provider@workspace:packages/components/pie-toast-provider":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-toast-provider@workspace:packages/components/pie-toast-provider"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.9.0
     "@justeattakeaway/pie-components-config": 0.18.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-toast": 0.6.0
+    "@justeattakeaway/pie-toast": 0.7.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     cem-plugin-module-file-extensions: 0.0.5
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-toast@0.6.0, @justeattakeaway/pie-toast@workspace:packages/components/pie-toast":
+"@justeattakeaway/pie-toast@0.7.0, @justeattakeaway/pie-toast@workspace:packages/components/pie-toast":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-toast@workspace:packages/components/pie-toast"
   dependencies:
@@ -5222,7 +5222,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.6.0, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.6.1, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
@@ -5249,8 +5249,8 @@ __metadata:
     "@justeattakeaway/pie-text-input": 0.24.6
     "@justeattakeaway/pie-textarea": 0.13.1
     "@justeattakeaway/pie-thumbnail": 0.1.0
-    "@justeattakeaway/pie-toast": 0.6.0
-    "@justeattakeaway/pie-toast-provider": 0.1.0
+    "@justeattakeaway/pie-toast": 0.7.0
+    "@justeattakeaway/pie-toast-provider": 0.2.0
     chalk: 5.3.0
   bin:
     add-components: ./src/index.js
@@ -22858,8 +22858,8 @@ __metadata:
     "@justeattakeaway/pie-text-input": 0.24.6
     "@justeattakeaway/pie-textarea": 0.13.1
     "@justeattakeaway/pie-thumbnail": 0.1.0
-    "@justeattakeaway/pie-toast": 0.6.0
-    "@justeattakeaway/pie-toast-provider": 0.1.0
+    "@justeattakeaway/pie-toast": 0.7.0
+    "@justeattakeaway/pie-toast-provider": 0.2.0
     "@storybook/addon-a11y": 8.4.5
     "@storybook/addon-designs": 8.0.4
     "@storybook/addon-essentials": 8.4.5
@@ -29586,7 +29586,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.6.0
+    "@justeattakeaway/pie-webc": 0.6.1
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -29600,7 +29600,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.6.0
+    "@justeattakeaway/pie-webc": 0.6.1
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -29615,7 +29615,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.6.0
+    "@justeattakeaway/pie-webc": 0.6.1
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -29635,7 +29635,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.6.0
+    "@justeattakeaway/pie-webc": 0.6.1
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -29655,7 +29655,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
-    "@justeattakeaway/pie-webc": 0.6.0
+    "@justeattakeaway/pie-webc": 0.6.1
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Added Notification test story to Storybook testing folder
- Added turbo.json to stop component building locally
- Added missing `aria` props and controls into Storybook
- Updated `createVariantStory` to support option props.
- Updated `Component`, `Accessibility` and `Visual` tests from `@sand4rt/experimental-ct-web` package to `@playwright/test` as well as corresponding `playwright-lit` configs.

**_Note:_**
There is a minor problem we have found with the labelling for the iconSlot within the variants visual test that we were not able to solve. I have since created a follow up ticket to address this post refactors.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
- [-] - NA I have added thorough tests where applicable (unit / component / visual).
- [-] - NA If changes will affect consumers of the package, I have created a changeset entry.
- [-] - NA If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @siggerzz 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A - I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A - I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
