### PR TITLE
cosmetic(pie-radio-group): DSW-2633 minor styling tweaks

### DIFF
--- a/.changeset/nasty-kings-hang.md
+++ b/.changeset/nasty-kings-hang.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-radio-group": patch
+"@justeattakeaway/pie-radio": patch
+---
+
+[Changed] - Minor styling tweaks to labels to add more spacing and ensure radio inputs are correctly aligned with labels that span multiple lines.

--- a/apps/pie-storybook/stories/pie-radio.stories.ts
+++ b/apps/pie-storybook/stories/pie-radio.stories.ts
@@ -145,6 +145,12 @@ const ExampleFormTemplate: TemplateFunction<RadioProps> = ({
     };
 
     return html`
+        <style>
+            pie-radio {
+                display: block;
+                margin-bottom: var(--dt-spacing-b);
+            }
+        </style>
         <form id="testForm">
             <pie-radio
                 .value="${value}"
@@ -156,8 +162,8 @@ const ExampleFormTemplate: TemplateFunction<RadioProps> = ({
                 @change="${onChange}">
                 ${sanitizeAndRenderHTML(slot)}
             </pie-radio>
-            <button type="reset">Reset</button>
-            <button type="submit">Submit</button>
+            <pie-button variant="secondary" type="reset">Reset</pie-button>
+            <pie-button type="submit">Submit</pie-button>
             <script>
                 // var is used to prevent storybook from erroring when the script is re-run
                 var form = document.querySelector('#testForm');

--- a/packages/components/pie-radio-group/src/radio-group.scss
+++ b/packages/components/pie-radio-group/src/radio-group.scss
@@ -12,7 +12,11 @@
     flex-flow: column wrap;
     gap: var(--radio-group-gap);
 
-    &.c-radioGroup--inline { 
+    > legend {
+        margin-bottom: var(--dt-spacing-b);
+    }
+
+    &.c-radioGroup--inline {
         flex-flow: row wrap;
         gap: var(--radio-group-gap--inline);
     }

--- a/packages/components/pie-radio-group/src/radio-group.scss
+++ b/packages/components/pie-radio-group/src/radio-group.scss
@@ -13,7 +13,7 @@
     gap: var(--radio-group-gap);
 
     > legend {
-        margin-bottom: var(--dt-spacing-b);
+        margin-block-end: var(--dt-spacing-b);
     }
 
     &.c-radioGroup--inline {

--- a/packages/components/pie-radio/src/radio.scss
+++ b/packages/components/pie-radio/src/radio.scss
@@ -64,6 +64,7 @@
     }
 
     .c-radio-input {
+        align-self: flex-start;
         appearance: none;
         display: block;
         position: relative;

--- a/packages/components/pie-radio/test/visual/pie-radio.spec.ts
+++ b/packages/components/pie-radio/test/visual/pie-radio.spec.ts
@@ -89,4 +89,24 @@ for (const dir of readingDirections) {
 
         await percySnapshot(page, `PIE Radio - Labelled - ${dir}`, percyWidths);
     });
+
+    test(`Long label text - ${dir}`, async ({ mount, page }) => {
+        if (dir === 'RTL') {
+            setRTL(page);
+        }
+
+        await mount(
+            PieRadio,
+            {
+                props: {
+                    checked: true,
+                } as RadioProps,
+                slots: {
+                    default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi pretium quam eget dolor imperdiet placerat. Aliquam sollicitudin erat sed est lobortis sollicitudin. Nam vulputate, mi vel finibus convallis, mi dolor molestie arcu, vel pulvinar urna neque et sapien. Aenean euismod faucibus turpis et efficitur. Sed porttitor dui at justo cursus pulvinar. Sed scelerisque aliquet diam sed feugiat. Fusce id lorem finibus, tempor nulla tempor, tincidunt odio. Mauris consequat lectus ex, eget lacinia dui finibus sit amet. Phasellus maximus posuere sapien eget condimentum. Nunc viverra pharetra blandit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Cras vel auctor erat, id ultrices ipsum. Suspendisse erat elit, facilisis et mi eget, interdum imperdiet ligula. Donec faucibus, lectus id sollicitudin accumsan, libero erat iaculis metus, vel finibus quam leo at mauris. Etiam pretium vitae est tempor commodo.',
+                },
+            },
+        );
+
+        await percySnapshot(page, `PIE Radio - Long label text - ${dir}`, percyWidths);
+    });
 }


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Ensures the radio always aligns to the first line of multi-line label text
- Uses `pie-button` for form buttons in Storybook
- Adds 8px spacing between the form label and first radio in `pie-radio-group`
- Adds some label spacing in the Story for `pie-radio-group`

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | N/A |
| NextJS 14 deployment   | N/A |
| Nuxt 3 deployment      | N/A |
| Vanilla deployment     | N/A |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 @raoufswe 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
