### PR TITLE
refactor(pie-tag): DSW-2383 Refactored pie-tag to use @playwright/test

### DIFF
--- a/apps/pie-storybook/stories/testing/pie-tag.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-tag.test.stories.ts
@@ -1,0 +1,220 @@
+import { html, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { type Meta } from '@storybook/web-components';
+
+import '@justeattakeaway/pie-tag';
+import {
+    type TagProps as TagBaseProps,
+    variants,
+    sizes,
+    defaultProps,
+    iconPlacements,
+} from '@justeattakeaway/pie-tag';
+import '@justeattakeaway/pie-icons-webc/dist/IconHeartFilled.js';
+
+import { type SlottedComponentProps } from '../../types';
+import {
+    createStory, createVariantStory, type TemplateFunction, sanitizeAndRenderHTML
+} from '../../utilities';
+
+type TagProps = SlottedComponentProps<TagBaseProps> & { showIcon: boolean };
+type TagStoryMeta = Meta<TagProps>;
+
+const defaultArgs: TagProps = {
+    ...defaultProps,
+    showIcon: false,
+    slot: 'Label',
+};
+
+const tagStoryMeta: TagStoryMeta = {
+    title: 'Tag',
+    component: 'pie-tag',
+    argTypes: {
+        variant: {
+            description: 'Set the variant of the tag.',
+            control: 'select',
+            options: variants,
+            defaultValue: {
+                summary: defaultProps.variant,
+            },
+        },
+        size: {
+            description: 'Set the size of the tag.',
+            control: 'select',
+            options: sizes,
+            defaultValue: {
+                summary: defaultProps.size,
+            },
+        },
+        isStrong: {
+            description: 'If `true`, displays strong tag styles for some of the variant',
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.isStrong,
+            },
+        },
+        disabled: {
+            description: 'For an interactive tag, this applies the disabled attribute to the button and styles it appropriately.<br>For a non-interactive tag, this only applies the disabled styling.',
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultProps.disabled,
+            },
+        },
+        showIcon: {
+            description: '<b>**Not a component prop</b><br><br>Use the `icon` slot to pass a PIE icon component. Available only for large tag size.',
+            control: 'boolean',
+            defaultValue: {
+                summary: defaultArgs.showIcon,
+            },
+            if: { arg: 'size', eq: 'large' },
+        },
+        slot: {
+            description: 'Content to place within the tag',
+            control: 'text',
+        },
+        iconPlacement: {
+            description: 'The placement of the icon slot such as leading or trailing. <br /><br /> Can be only used if `isInteractive` is set to true',
+            control: 'select',
+            options: iconPlacements,
+            defaultValue: {
+                summary: defaultArgs.iconPlacement,
+            },
+            if: { arg: 'isInteractive', eq: true },
+        },
+    },
+    args: defaultArgs,
+};
+
+export default tagStoryMeta;
+
+const Template: TemplateFunction<TagProps> = ({
+    variant,
+    size,
+    isInteractive,
+    isStrong,
+    disabled,
+    showIcon,
+    slot,
+    iconPlacement,
+}) => html`
+    <pie-tag
+        variant="${ifDefined(variant)}"
+        size="${ifDefined(size)}"
+        iconPlacement="${ifDefined(iconPlacement)}"
+        ?isInteractive="${isInteractive}"
+        ?isStrong="${isStrong}"
+        ?disabled="${disabled}">
+        ${showIcon ? html`<icon-heart-filled slot="icon"></icon-heart-filled>` : nothing}
+        ${sanitizeAndRenderHTML(slot)}
+    </pie-tag>
+`;
+
+const createTagStory = createStory<TagProps>(Template, defaultArgs);
+
+const icon = '<svg slot="icon" data-test-id="tag-icon" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--plusCircle"><path d="M8.656 4.596H7.344v2.748H4.596v1.312h2.748v2.748h1.312V8.656h2.748V7.344H8.656V4.596Z"></path><path d="M12.795 3.205a6.781 6.781 0 1 0 0 9.625 6.79 6.79 0 0 0 0-9.625Zm-.927 8.662a5.469 5.469 0 1 1-7.734-7.735 5.469 5.469 0 0 1 7.734 7.736Z"></path></svg>';
+
+// Individual variant stories
+export const Default = createTagStory();
+export const Neutral = createTagStory({ variant: 'neutral' });
+export const NeutralAlternative = createTagStory({ variant: 'neutral-alternative' }, { bgColor: 'dark (container-dark)' });
+export const Information = createTagStory({ variant: 'information' });
+export const Success = createTagStory({ variant: 'success' });
+export const Error = createTagStory({ variant: 'error' });
+export const Outline = createTagStory({ variant: 'outline' });
+export const Ghost = createTagStory({ variant: 'ghost' });
+export const DefaultWithIcon = createTagStory({ slot: `Label ${icon}` });
+
+// Base shared props matrix
+const baseSharedPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    size: [...sizes],
+    isInteractive: [true, false],
+    isStrong: [true, false],
+    disabled: [true, false],
+    showIcon: [true, false],
+    slot: ['Tag'],
+};
+
+// Neutral variant stories
+const neutralPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['neutral'],
+};
+
+// Information variant stories
+const informationPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['information'],
+};
+
+// Success variant stories
+const successPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['success'],
+};
+
+// Error variant stories
+const errorPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['error'],
+};
+
+// Neutral Alternative variant stories (with dark background)
+const neutralAlternativePropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['neutral-alternative'],
+};
+
+// Outline variant stories
+const outlinePropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['outline'],
+};
+
+// Ghost variant stories
+const ghostPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['ghost'],
+};
+
+// Brand-02 variant stories
+const brand02PropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['brand-02'],
+};
+
+// Brand-03 variant stories
+const brand03PropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['brand-03'],
+};
+
+// Brand-04 variant stories
+const brand04PropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['brand-04'],
+};
+
+// Brand-05 variant stories
+const brand05PropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['brand-05'],
+};
+
+// Brand-06 variant stories
+const brand06PropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
+    ...baseSharedPropsMatrix,
+    variant: ['brand-06'],
+};
+
+export const NeutralVariations = createVariantStory<TagProps>(Template, neutralPropsMatrix);
+export const InformationVariations = createVariantStory<TagProps>(Template, informationPropsMatrix);
+export const SuccessVariations = createVariantStory<TagProps>(Template, successPropsMatrix);
+export const ErrorVariations = createVariantStory<TagProps>(Template, errorPropsMatrix);
+export const NeutralAlternativeVariations = createVariantStory<TagProps>(Template, neutralAlternativePropsMatrix, { bgColor: 'dark (container-dark)' });
+export const OutlineVariations = createVariantStory<TagProps>(Template, outlinePropsMatrix);
+export const GhostVariations = createVariantStory<TagProps>(Template, ghostPropsMatrix);
+export const Brand02Variations = createVariantStory<TagProps>(Template, brand02PropsMatrix);
+export const Brand03Variations = createVariantStory<TagProps>(Template, brand03PropsMatrix);
+export const Brand04Variations = createVariantStory<TagProps>(Template, brand04PropsMatrix);
+export const Brand05Variations = createVariantStory<TagProps>(Template, brand05PropsMatrix);
+export const Brand06Variations = createVariantStory<TagProps>(Template, brand06PropsMatrix);

--- a/apps/pie-storybook/stories/testing/pie-tag.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-tag.test.stories.ts
@@ -127,8 +127,9 @@ export const DefaultWithIcon = createTagStory({ slot: `Label ${icon}` });
 // Base shared props matrix
 const baseSharedPropsMatrix: Partial<Record<keyof TagProps, unknown[]>> = {
     size: [...sizes],
-    isInteractive: [true, false],
+    iconPlacement: ['leading', 'trailing'],
     isStrong: [true, false],
+    isInteractive: [true, false],
     disabled: [true, false],
     showIcon: [true, false],
     slot: ['Tag'],

--- a/packages/components/pie-tag/playwright-lit-visual.config.ts
+++ b/packages/components/pie-tag/playwright-lit-visual.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightVisualConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeVisualConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightVisualConfig());
+export default defineConfig(getPlaywrightNativeVisualConfig());

--- a/packages/components/pie-tag/playwright-lit.config.ts
+++ b/packages/components/pie-tag/playwright-lit.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightConfig());
+export default defineConfig(getPlaywrightNativeConfig());

--- a/packages/components/pie-tag/test/accessibility/pie-tag.spec.ts
+++ b/packages/components/pie-tag/test/accessibility/pie-tag.spec.ts
@@ -1,33 +1,14 @@
-import { test, expect } from '@justeattakeaway/pie-webc-testing/src/playwright/webc-fixtures.ts';
-import { getAllPropCombinations, splitCombinationsByPropertyValue } from '@justeattakeaway/pie-webc-testing/src/helpers/get-all-prop-combos.ts';
-import { type PropObject, type WebComponentPropValues } from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
-import { PieTag } from '../../src/index.ts';
-import { type TagProps, sizes, variants } from '../../src/defs.ts';
+import { test, expect } from '@justeattakeaway/pie-webc-testing/src/playwright/playwright-fixtures.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 
-const props: PropObject<TagProps> = {
-    variant: variants,
-    size: sizes,
-    isStrong: [true, false],
-};
+test.describe('PieTag - Accessibility tests', () => {
+    test('a11y - should test the PieTag component WCAG compliance', async ({ makeAxeBuilder, page }) => {
+        const tagPage = new BasePage(page, 'tag');
 
-const componentPropsMatrix = getAllPropCombinations(props);
-const componentPropsMatrixByVariant = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
-const componentVariants = Object.keys(componentPropsMatrixByVariant);
+        await tagPage.load();
 
-componentVariants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ makeAxeBuilder, mount }) => {
-    await Promise.all(componentPropsMatrixByVariant[variant].map(async (combo: WebComponentPropValues) => {
-        await mount(
-            PieTag,
-            {
-                props: { ...combo },
-                slots: {
-                    default: 'Hello world',
-                },
-            },
-        );
-    }));
+        const results = await makeAxeBuilder().analyze();
 
-    const results = await makeAxeBuilder().analyze();
-
-    expect(results.violations).toEqual([]);
-}));
+        expect(results.violations).toEqual([]);
+    });
+});

--- a/packages/components/pie-tag/test/component/pie-tag.spec.ts
+++ b/packages/components/pie-tag/test/component/pie-tag.spec.ts
@@ -44,7 +44,11 @@ test.describe('PieTag - Component tests', () => {
         test('should render icon when size is large', async ({ page }) => {
             // Arrange
             const tagPage = new BasePage(page, 'tag--default-with-icon');
-            await tagPage.load();
+            const props: TagProps = {
+                size: 'large',
+            };
+
+            await tagPage.load({ ...props });
 
             // Act
             const tagIcon = page.getByTestId(tag.selectors.icon.dataTestId);

--- a/packages/components/pie-tag/test/component/pie-tag.spec.ts
+++ b/packages/components/pie-tag/test/component/pie-tag.spec.ts
@@ -1,9 +1,11 @@
+import { test, expect } from '@playwright/test';
 import { getShadowElementStylePropValues } from '@justeattakeaway/pie-webc-testing/src/helpers/get-shadow-element-style-prop-values.ts';
-import { test, expect } from '@sand4rt/experimental-ct-web';
-import { PieTag, type TagProps } from '../../src/index.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { type TagProps } from '../../src/defs.ts';
+
+import { tag } from '../helpers/page-object/selectors.ts';
 
 const componentSelector = '[data-test-id="pie-tag"]';
-const tagIconSelector = '[data-test-id="tag-icon"]';
 
 type VariantToBgStyle = {
     variantName: TagProps['variant'];
@@ -25,99 +27,78 @@ const variantsToIsStrongStyle: Array<VariantToBgStyle> = [
     { variantName: 'brand-06', bgStyle: '--dt-color-support-brand-06' },
 ];
 
-const icon = '<svg slot="icon" data-test-id="tag-icon" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" fill="currentColor" viewBox="0 0 16 16" class="c-pieIcon c-pieIcon--plusCircle"><path d="M8.656 4.596H7.344v2.748H4.596v1.312h2.748v2.748h1.312V8.656h2.748V7.344H8.656V4.596Z"></path><path d="M12.795 3.205a6.781 6.781 0 1 0 0 9.625 6.79 6.79 0 0 0 0-9.625Zm-.927 8.662a5.469 5.469 0 1 1-7.734-7.735 5.469 5.469 0 0 1 7.734 7.736Z"></path></svg>';
-
 test.describe('PieTag - Component tests', () => {
-    test('should render successfully', async ({ mount, page }) => {
+    test('should be visible', async ({ page }) => {
         // Arrange
-        await mount(PieTag, {
-            slots: {
-                default: 'Label',
-            },
-        });
+        const tagPage = new BasePage(page, 'tag');
+        await tagPage.load();
 
         // Act
-        const tag = page.locator(componentSelector);
+        const tagComponent = page.locator(tag.selectors.container.dataTestId, { hasText: 'Label' });
 
         // Assert
-        await expect(tag).toBeVisible();
+        await expect(tagComponent).toBeVisible();
     });
 
     test.describe('icon slot', () => {
-        test.describe('when passed', () => {
-            test.describe('if the size is large', () => {
-                test('should render the icon', async ({ mount, page }) => {
-                    // Arrange
-                    await mount(PieTag, {
-                        slots: {
-                            default: 'Label',
-                            icon,
-                        },
-                    });
+        test('should render icon when size is large', async ({ page }) => {
+            // Arrange
+            const tagPage = new BasePage(page, 'tag--default-with-icon');
+            await tagPage.load();
 
-                    // Act
-                    const tagIcon = page.locator(tagIconSelector);
+            // Act
+            const tagIcon = page.getByTestId(tag.selectors.icon.dataTestId);
 
-                    // Assert
-                    await expect(tagIcon).toBeVisible();
-                });
-            });
-
-            test.describe('if the size is small', () => {
-                test('should NOT render the icon', async ({ mount, page }) => {
-                    // Arrange
-                    await mount(PieTag, {
-                        props: {
-                            size: 'small',
-                        },
-                        slots: {
-                            default: 'Label',
-                            icon,
-                        },
-                    });
-
-                    // Act
-                    const tagIcon = page.locator(tagIconSelector);
-
-                    // Assert
-                    await expect(tagIcon).toBeHidden();
-                });
-            });
+            // Assert
+            await expect(tagIcon).toBeVisible();
         });
 
-        test.describe('when NOT passed', () => {
-            test('should NOT render the icon', async ({ mount, page }) => {
-                // Arrange
-                await mount(PieTag, {
-                    slots: {
-                        default: 'Label',
-                    },
-                });
+        test('should NOT render icon when size is small', async ({ page }) => {
+            // Arrange
+            const tagPage = new BasePage(page, 'tag--default-with-icon');
+            const props: TagProps = {
+                size: 'small',
+            };
 
-                // Act
-                const tagIcon = page.locator(tagIconSelector);
+            await tagPage.load({ ...props });
 
-                // Assert
-                await expect(tagIcon).toBeHidden();
-            });
+            // Act
+            const tagIcon = page.getByTestId(tag.selectors.icon.dataTestId);
+
+            // Assert
+            await expect(tagIcon).toBeHidden();
+        });
+
+        test('should NOT render icon when not provided', async ({ page }) => {
+            // Arrange
+            const tagPage = new BasePage(page, 'tag');
+            await tagPage.load();
+
+            // Act
+            const tagIcon = page.getByTestId(tag.selectors.icon.dataTestId);
+
+            // Assert
+            await expect(tagIcon).toBeHidden();
         });
     });
+});
 
-    variantsToIsStrongStyle.forEach(({ variantName, bgStyle }) => {
-        test(`a "${variantName}" tag variant bg colour should be equivalent to "${bgStyle}"`, async ({ mount }) => {
-            const component = await mount(PieTag, {
-                props: {
-                    variant: variantName,
-                    isStrong: true,
-                },
-                slots: {
-                    default: 'Label',
-                },
-            });
+variantsToIsStrongStyle.forEach(({ variantName, bgStyle }) => {
+    test(`a "${variantName}" tag variant bg color should be equivalent to "${bgStyle}"`, async ({ page }) => {
+        // Arrange
+        const tagPage = new BasePage(page, 'tag');
+        const props: TagProps = {
+            variant: variantName,
+            isStrong: true,
+        };
 
-            const [currentBgStyle, expectedBgStyle] = await getShadowElementStylePropValues(component, componentSelector, ['--tag-bg-color', bgStyle]);
+        await tagPage.load({ ...props });
 
-            expect(currentBgStyle).toBe(expectedBgStyle);
-        });
+        // Act
+        const tagComponent = page.locator(tag.selectors.container.dataTestId, { hasText: 'Label' });
+        const [currentBgStyle, expectedBgStyle] = await getShadowElementStylePropValues(tagComponent, componentSelector, ['--tag-bg-color', bgStyle]);
+
+        // Assert
+        expect(currentBgStyle).toBe(expectedBgStyle);
     });
 });

--- a/packages/components/pie-tag/test/helpers/page-object/selectors.ts
+++ b/packages/components/pie-tag/test/helpers/page-object/selectors.ts
@@ -1,0 +1,15 @@
+const tag = {
+    selectors: {
+        container: {
+            description: 'The selector for the tag container',
+            dataTestId: 'pie-tag',
+        },
+        icon: {
+            description: 'The selector for the tag icon',
+            dataTestId: 'tag-icon',
+        },
+    },
+};
+export {
+    tag,
+};

--- a/packages/components/pie-tag/test/visual/pie-tag.spec.ts
+++ b/packages/components/pie-tag/test/visual/pie-tag.spec.ts
@@ -1,78 +1,15 @@
-import { test } from '@sand4rt/experimental-ct-web';
+import { test } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
-import {
-    type PropObject, type WebComponentPropValues,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/defs.ts';
-import {
-    getAllPropCombinations, splitCombinationsByPropertyValue,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/get-all-prop-combos.ts';
-import {
-    createTestWebComponent,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/rendering.ts';
-import {
-    WebComponentTestWrapper,
-} from '@justeattakeaway/pie-webc-testing/src/helpers/components/web-component-test-wrapper/WebComponentTestWrapper.ts';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
-import { IconHeartFilled } from '@justeattakeaway/pie-icons-webc/dist/IconHeartFilled';
-import {
-    type TagProps, sizes, variants, iconPlacements,
-} from '../../src/defs.ts';
-import { PieTag } from '../../src/index.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { variants } from '../../src/defs.ts';
 
-const props: PropObject<TagProps & { iconSlot: string }> = {
-    variant: variants,
-    size: sizes,
-    iconPlacement: iconPlacements,
-    isInteractive: [true, false],
-    isStrong: [true, false],
-    disabled: [true, false],
-    iconSlot: ['', '<icon-heart-filled slot="icon"></icon-heart-filled>'],
-};
+variants.forEach((variant) => {
+    test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
+        const tagVariationsPage = new BasePage(page, `tag--${variant}-variations`);
 
-// Renders a <pie-tag> HTML string with the given prop values
-const renderTestPieTag = (propVals: WebComponentPropValues) => `<pie-tag variant="${propVals.variant}" size="${propVals.size}" iconPlacement="${propVals.iconPlacement}" ${propVals.isStrong ? 'isStrong' : ''} ${propVals.disabled ? 'disabled' : ''} ${propVals.isInteractive ? 'isInteractive' : ''}>${propVals.iconSlot} Hello world</pie-tag>`;
+        await tagVariationsPage.load();
 
-const componentPropsMatrix = getAllPropCombinations(props);
-const componentPropsMatrixByVariant = splitCombinationsByPropertyValue(componentPropsMatrix, 'variant');
-const componentVariants = Object.keys(componentPropsMatrixByVariant);
-
-test.beforeEach(async ({ mount }, testInfo) => {
-    testInfo.setTimeout(testInfo.timeout + 40000);
-
-    // This ensures the tag and icon components are registered in the DOM for each test.
-    // It appears to add them to a Playwright cache which we understand is required for the tests to work correctly.
-    const tagComponent = await mount(PieTag);
-    await tagComponent.unmount();
-    const iconComponent = await mount(IconHeartFilled);
-    await iconComponent.unmount();
+        await percySnapshot(page, `PIE Tag - Variant: ${variant}`, percyWidths);
+    });
 });
-
-componentVariants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page, mount }) => {
-    for (const combo of componentPropsMatrixByVariant[variant]) {
-        const testComponent = createTestWebComponent(combo, renderTestPieTag);
-        const propKeyValues = `
-            size: ${testComponent.propValues.size},
-            variant: ${testComponent.propValues.variant},
-            iconPlacement: ${testComponent.propValues.iconPlacement},
-            isStrong: ${testComponent.propValues.isStrong},
-            isInteractive: ${testComponent.propValues.isInteractive},
-            disabled: ${testComponent.propValues.disabled},
-            iconSlot: ${testComponent.propValues.iconSlot ? 'with icon' : 'no icon'}`;
-        const darkMode = ['neutral-alternative'].includes(variant);
-
-        await mount(
-            WebComponentTestWrapper,
-            {
-                props: { propKeyValues, darkMode },
-                slots: {
-                    component: testComponent.renderedString.trim(),
-                },
-            },
-        );
-    }
-
-    // Follow up to remove in Jan
-    await page.waitForTimeout(5000);
-
-    await percySnapshot(page, `PIE Tag - Variant: ${variant}`, percyWidths);
-}));

--- a/packages/components/pie-tag/turbo.json
+++ b/packages/components/pie-tag/turbo.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": [
+    "//"
+  ],
+  "pipeline": {
+    "test:browsers": {
+      "cache": true,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"
+      ]
+    },
+    "test:browsers:ci": {
+      "cache": true,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"
+      ]
+    },
+    "test:visual": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"
+      ]
+    },
+    "test:visual:ci": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Added Tag test story to Storybook testing folder
- Added turbo.json to stop component building locally
- Updated `Component`, `Accessibility` and `Visual` tests from `@sand4rt/experimental-ct-web` package to `@playwright/test` as well as corresponding `playwright-lit` configs.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
- [-] - NA I have added thorough tests where applicable (unit / component / visual).
- [-] - NA If changes will affect consumers of the package, I have created a changeset entry.
- [-] - NA If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A - I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @siggerzz 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A - I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
