### PR TITLE
fix(pie-thumbnail): DSW-2585 Ensure the placeholder logic is working properly with SSR

### DIFF
--- a/.changeset/sixty-schools-collect.md
+++ b/.changeset/sixty-schools-collect.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-thumbnail": patch
+---
+
+[Changed] - Ensure the placeholder logic is working properly with SSR

--- a/packages/components/pie-thumbnail/src/index.ts
+++ b/packages/components/pie-thumbnail/src/index.ts
@@ -51,7 +51,8 @@ export class PieThumbnail extends LitElement implements ThumbnailProps {
     private img!: HTMLImageElement;
 
     /**
-     * Handles image loading errors and sets the placeholder props if provided
+     * Handles image load errors by replacing the src and alt props
+     * with the placeholder props.
      */
     private _handleImageError () {
         if (this.placeholder?.src) this.setAttribute('src', this.placeholder.src);
@@ -59,20 +60,19 @@ export class PieThumbnail extends LitElement implements ThumbnailProps {
     }
 
     /**
-     * Checks if the image failed to load before hydration and sets the placeholder
-     * This is needed as the native `onerror` event isn't triggered in SSR
+     * Detects image load status and applies the placeholder on failure.
+     * This is needed as the `onerror` event is not triggered in SSR.
      */
-    private _checkImageErrorBeforeHydration () {
-        const { img, _handleImageError } = this;
-        if (img) {
-            const { complete, naturalHeight } = img;
-            const hasErrorBeforeHydration = complete && naturalHeight === 0;
-            if (hasErrorBeforeHydration) _handleImageError.call(this);
+    private _checkImageError () {
+        if (this.img) {
+            const { complete, naturalHeight } = this.img;
+            const hasError = complete && naturalHeight === 0;
+            if (hasError) this._handleImageError.call(this);
         }
     }
 
-    firstUpdated () {
-        this._checkImageErrorBeforeHydration();
+    protected firstUpdated (): void {
+        this._checkImageError();
     }
 
     render () {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Fixes the flickering issue where the thumbnail placeholder behavior doesn't render as expected in Nuxt and Next.js when the page reloads
- The issue is that the `onerror` event isn't triggered in SSR (see [facebook/react#15446](https://github.com/facebook/react/issues/15446)) so we need to ensure that the component is hydrated with the placeholder props if the image fails on the server.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](https://github.com/justeattakeaway/pie-aperture/pull/239) |
| NextJS 14 deployment   | [🔗](https://pr239-aperture-nextjs-app-v14.pie.design/components/thumbnail) |
| Nuxt 3 deployment      | [🔗](https://pr239-aperture-nuxt-app.pie.design/components/thumbnail) |
| Vanilla deployment     | [🔗](https://pr239-aperture-vanilla-app.pie.design/components/thumbnail.html) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.

### Reviewer 2 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
