### PR TITLE
refactor(pie-icons-webc): DSW-2755 tests to use `@playwright/test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,13 +247,13 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter='{./packages/components/*}[HEAD^1]'"
+          script-name: "test:visual:ci --filter='{./packages/components/*}[HEAD^1]' --filter='{./packages/tools/*}[HEAD^1]'"
           concurrency: 1
       - name: Run Changed Package Visual Tests
         uses: ./.github/actions/run-script
         if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) && github.ref != 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter='{./packages/components/*}...[origin/main]'"
+          script-name: "test:visual:ci --filter='{./packages/components/*}...[origin/main]' --filter='{./packages/tools/*}...[origin/main]'"
           concurrency: 1
       - name: Upload Playwright Report
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/apps/pie-storybook/stories/testing/icons.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/icons.test.stories.ts
@@ -1,0 +1,122 @@
+import { html } from 'lit/static-html.js';
+import '@justeattakeaway/pie-icons-webc';
+import {
+    regularIconSizes, largeIconSizeDefault, regularIconSizeDefault, largeIconSizeModule, type LargeIconSize, type RegularIconSize,
+} from '@justeattakeaway/pie-icons-configs';
+import { createStory, createVariantStory, type TemplateFunction } from '../../utilities';
+
+const iconsStoryMeta = {
+    title: 'Icons',
+    parameters: {
+        layout: 'fullscreen',
+    },
+};
+
+export default iconsStoryMeta;
+
+type RegularIconProps = {
+    size: RegularIconSize
+}
+
+const defaultRegularIconProps: RegularIconProps = {
+    size: regularIconSizeDefault,
+};
+
+type LargeIconProps = {
+    size: LargeIconSize
+}
+
+const defaultLargeIconProps: LargeIconProps = {
+    size: largeIconSizeDefault,
+};
+
+const AlcoholFilledRegularIconTemplate: TemplateFunction<RegularIconProps> = ({ size }) => html`
+    <div class="c-iconGrid">
+        <icon-alcohol-filled size=${size}></icon-alcohol-filled>
+    </div>
+`;
+
+const AlcoholFilledRegularIconWithOverrideTemplate: TemplateFunction<RegularIconProps> = ({ size }) => html`
+    <div style="--icon-size-override: 200px;">
+        <p>size: ${size}</p>
+        <p>--icon-size-override: 200px</p>
+        <icon-alcohol-filled size=${size}></icon-alcohol-filled>
+    </div>
+`;
+
+const AlcoholFilledLargeIconTemplate: TemplateFunction<LargeIconProps> = ({ size }) => html`
+    <p>For large icons, size must be a number greater than or equal to \`${largeIconSizeDefault}\`, and a multiple of \`${largeIconSizeModule}\`.</p>
+    <div class="c-iconGrid">
+        <icon-alcohol-filled-large size=${size}></icon-alcohol-filled-large>
+    </div>
+`;
+
+const AlcoholFilledLargeIconWithOverrideTemplate: TemplateFunction<LargeIconProps> = ({ size }) => html`
+    <div style="--icon-size-override: 200px;">
+        <p>size: ${size}px</p>
+        <p>--icon-size-override: 200px</p>
+        <icon-alcohol-filled-large size=${size}></icon-alcohol-filled-large>
+    </div>
+`;
+
+export const AlcoholFilledRegularIcon = createStory(AlcoholFilledRegularIconTemplate, defaultRegularIconProps)({}, {
+    layout: 'centered',
+    argTypes: {
+        size: {
+            control: 'select',
+            options: regularIconSizes,
+            defaultValue: {
+                summary: regularIconSizeDefault,
+            },
+        },
+    },
+});
+
+export const AlcoholFilledRegularIconWithOverride = createStory(AlcoholFilledRegularIconWithOverrideTemplate, defaultRegularIconProps)({}, {
+    layout: 'centered',
+    argTypes: {
+        size: {
+            control: 'select',
+            options: regularIconSizes,
+            defaultValue: {
+                summary: regularIconSizeDefault,
+            },
+        },
+    },
+});
+
+export const AlcoholFilledLargeIcon = createStory(AlcoholFilledLargeIconTemplate, defaultLargeIconProps)({}, {
+    layout: 'centered',
+    argTypes: {
+        size: {
+            control: { type: 'number', min: largeIconSizeDefault, step: largeIconSizeModule },
+            defaultValue: {
+                summary: largeIconSizeDefault,
+            },
+        },
+    },
+});
+
+export const AlcoholFilledLargeIconWithOverride = createStory(AlcoholFilledLargeIconWithOverrideTemplate, defaultLargeIconProps)({}, {
+    layout: 'centered',
+    argTypes: {
+        size: {
+            control: { type: 'number', min: largeIconSizeDefault, step: largeIconSizeModule },
+            defaultValue: {
+                summary: largeIconSizeDefault,
+            },
+        },
+    },
+});
+
+const regularIconPropMatrix : Partial<Record<keyof RegularIconProps, unknown[]>> = {
+    size: [...regularIconSizes],
+};
+
+export const AlcoholFilledRegularIconVariations = createVariantStory<RegularIconProps>(AlcoholFilledRegularIconTemplate, regularIconPropMatrix);
+
+const largeIconPropMatrix : Partial<Record<keyof LargeIconProps, unknown[]>> = {
+    size: [largeIconSizeDefault, 64, 128],
+};
+
+export const AlcoholFilledLargeIconVariations = createVariantStory<LargeIconProps>(AlcoholFilledLargeIconTemplate, largeIconPropMatrix);

--- a/apps/pie-storybook/stories/testing/icons.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/icons.test.stories.ts
@@ -45,7 +45,6 @@ const AlcoholFilledRegularIconWithOverrideTemplate: TemplateFunction<RegularIcon
 `;
 
 const AlcoholFilledLargeIconTemplate: TemplateFunction<LargeIconProps> = ({ size }) => html`
-    <p>For large icons, size must be a number greater than or equal to \`${largeIconSizeDefault}\`, and a multiple of \`${largeIconSizeModule}\`.</p>
     <div class="c-iconGrid">
         <icon-alcohol-filled-large size=${size}></icon-alcohol-filled-large>
     </div>

--- a/packages/tools/pie-icons-webc/playwright-lit-visual.config.ts
+++ b/packages/tools/pie-icons-webc/playwright-lit-visual.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightVisualConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeVisualConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightVisualConfig());
+export default defineConfig(getPlaywrightNativeVisualConfig());

--- a/packages/tools/pie-icons-webc/playwright-lit.config.ts
+++ b/packages/tools/pie-icons-webc/playwright-lit.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@sand4rt/experimental-ct-web';
-import { getPlaywrightConfig } from '@justeattakeaway/pie-components-config';
+import { defineConfig } from '@playwright/test';
+import { getPlaywrightNativeConfig } from '@justeattakeaway/pie-components-config';
 
-export default defineConfig(getPlaywrightConfig());
+export default defineConfig(getPlaywrightNativeConfig());

--- a/packages/tools/pie-icons-webc/test/component/icon-webc.spec.js
+++ b/packages/tools/pie-icons-webc/test/component/icon-webc.spec.js
@@ -1,90 +1,83 @@
 
-import { test, expect } from '@sand4rt/experimental-ct-web';
+import { test, expect } from '@playwright/test';
 import { sizeToValueMap, largeIconSizeDefault, regularIconSizeDefault } from '@justeattakeaway/pie-icons-configs';
-import { IconAlcoholFilled } from '../../icons/IconAlcoholFilled.ts';
-import { IconAlcoholFilledLarge } from '../../icons/IconAlcoholFilledLarge.ts';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { icons } from '../helpers/page-object/selectors.ts';
 
-const iconAlcoholFilledSelector = 'icon-alcohol-filled';
-const iconAlcoholFilledLargeSelector = 'icon-alcohol-filled-large';
-
-test('regular icon should use the default width and height when not provided', async ({ mount, page }) => {
+test('regular icon should use the default width and height when not provided', async ({ page }) => {
     // Arrange
-    await mount(IconAlcoholFilled);
-    await page.waitForSelector(iconAlcoholFilledSelector);
+    const regularIconPage = new BasePage(page, 'icons--alcohol-filled-regular-icon');
+    await regularIconPage.load();
+    await page.waitForSelector(icons.selectors.alcoholFilled.dataTestId);
 
     // Assert
     const exepectedValue = sizeToValueMap[regularIconSizeDefault].toString();
 
-    const svg = await page.locator(`${iconAlcoholFilledSelector} svg`);
+    const svg = page.locator(`${icons.selectors.alcoholFilled.dataTestId} svg`);
     await expect(svg).toHaveAttribute('width', exepectedValue);
     await expect(svg).toHaveAttribute('height', exepectedValue);
 });
 
-test('regular icon should fall back to the default width and height if an invalid value is given', async ({ mount, page }) => {
+test('regular icon should fall back to the default width and height if an invalid value is given', async ({ page }) => {
     // Arrange
-    await mount(IconAlcoholFilled, {
-        props: {
-            size: 'xm',
-        },
-    });
-
-    await page.waitForSelector(iconAlcoholFilledSelector);
+    const regularIconPage = new BasePage(page, 'icons--alcohol-filled-regular-icon');
+    await regularIconPage.load({ size: 'xm' });
+    await page.waitForSelector(icons.selectors.alcoholFilled.dataTestId);
 
     // Assert
     const exepectedValue = sizeToValueMap[regularIconSizeDefault].toString();
 
-    const svg = await page.locator(`${iconAlcoholFilledSelector} svg`);
+    const svg = page.locator(`${icons.selectors.alcoholFilled.dataTestId} svg`);
     await expect(svg).toHaveAttribute('width', exepectedValue);
     await expect(svg).toHaveAttribute('height', exepectedValue);
 });
 
-test('regular should have the default classes applied', async ({ mount, page }) => {
+test('regular should have the default classes applied', async ({ page }) => {
     // Arrange
-    await mount(IconAlcoholFilled);
-    await page.waitForSelector(iconAlcoholFilledSelector);
+    const regularIconPage = new BasePage(page, 'icons--alcohol-filled-regular-icon');
+    await regularIconPage.load();
+    await page.waitForSelector(icons.selectors.alcoholFilled.dataTestId);
 
-    const icon = await page.locator(iconAlcoholFilledSelector);
-
+    // Assert
+    const icon = page.locator(icons.selectors.alcoholFilled.dataTestId);
     await expect(icon).toHaveClass('c-pieIcon c-pieIcon--alcoholFilled');
 });
 
-test('large icon should use the default width and height when not provided', async ({ mount, page }) => {
+test('large icon should use the default width and height when not provided', async ({ page }) => {
     // Arrange
-    await mount(IconAlcoholFilledLarge);
-    await page.waitForSelector(iconAlcoholFilledLargeSelector);
+    const largeIconPage = new BasePage(page, 'icons--alcohol-filled-large-icon');
+    await largeIconPage.load();
+    await page.waitForSelector(icons.selectors.alcoholFilledLarge.dataTestId);
 
     // Assert
     const exepectedValue = largeIconSizeDefault.toString();
 
-    const svg = await page.locator(`${iconAlcoholFilledLargeSelector} svg`);
+    const svg = page.locator(`${icons.selectors.alcoholFilledLarge.dataTestId} svg`);
     await expect(svg).toHaveAttribute('width', exepectedValue);
     await expect(svg).toHaveAttribute('height', exepectedValue);
 });
 
-test('large icon should fall back to the default width and height if an invalid value is given', async ({ mount, page }) => {
+test('large icon should fall back to the default width and height if an invalid value is given', async ({ page }) => {
     // Arrange
-    await mount(IconAlcoholFilledLarge, {
-        props: {
-            size: '55',
-        },
-    });
-
-    await page.waitForSelector(iconAlcoholFilledLargeSelector);
+    const largeIconPage = new BasePage(page, 'icons--alcohol-filled-large-icon');
+    await largeIconPage.load({ size: '55' });
+    await page.waitForSelector(icons.selectors.alcoholFilledLarge.dataTestId);
 
     // Assert
     const exepectedValue = largeIconSizeDefault.toString();
 
-    const svg = await page.locator(`${iconAlcoholFilledLargeSelector} svg`);
+    const svg = page.locator(`${icons.selectors.alcoholFilledLarge.dataTestId} svg`);
     await expect(svg).toHaveAttribute('width', exepectedValue);
     await expect(svg).toHaveAttribute('height', exepectedValue);
 });
 
-test('large should have the default classes applied', async ({ mount, page }) => {
+test('large should have the default classes applied', async ({ page }) => {
     // Arrange
-    await mount(IconAlcoholFilledLarge);
-    await page.waitForSelector(iconAlcoholFilledLargeSelector);
+    const largeIconPage = new BasePage(page, 'icons--alcohol-filled-large-icon');
+    await largeIconPage.load();
+    await page.waitForSelector(icons.selectors.alcoholFilledLarge.dataTestId);
 
-    const icon = await page.locator(iconAlcoholFilledLargeSelector);
-
+    // Assert
+    const icon = page.locator(icons.selectors.alcoholFilledLarge.dataTestId);
     await expect(icon).toHaveClass('c-pieIcon c-pieIcon--alcoholFilledLarge');
 });

--- a/packages/tools/pie-icons-webc/test/helpers/page-object/selectors.ts
+++ b/packages/tools/pie-icons-webc/test/helpers/page-object/selectors.ts
@@ -1,11 +1,9 @@
 const icons = {
     selectors: {
         alcoholFilled: {
-            description: 'The selector for the alcohol filled icon',
             dataTestId: 'icon-alcohol-filled',
         },
         alcoholFilledLarge: {
-            description: 'The selector for the alcohol filled large icon',
             dataTestId: 'icon-alcohol-filled-large',
         },
     },

--- a/packages/tools/pie-icons-webc/test/helpers/page-object/selectors.ts
+++ b/packages/tools/pie-icons-webc/test/helpers/page-object/selectors.ts
@@ -1,0 +1,15 @@
+const icons = {
+  selectors: {
+      alcoholFilled: {
+          description: 'The selector for the alcohol filled icon',
+          dataTestId: 'icon-alcohol-filled',
+      },
+      alcoholFilledLarge: {
+          description: 'The selector for the alcohol filled large icon',
+          dataTestId: 'icon-alcohol-filled-large',
+      },
+  },
+};
+export {
+  icons,
+};

--- a/packages/tools/pie-icons-webc/test/helpers/page-object/selectors.ts
+++ b/packages/tools/pie-icons-webc/test/helpers/page-object/selectors.ts
@@ -1,15 +1,15 @@
 const icons = {
-  selectors: {
-      alcoholFilled: {
-          description: 'The selector for the alcohol filled icon',
-          dataTestId: 'icon-alcohol-filled',
-      },
-      alcoholFilledLarge: {
-          description: 'The selector for the alcohol filled large icon',
-          dataTestId: 'icon-alcohol-filled-large',
-      },
-  },
+    selectors: {
+        alcoholFilled: {
+            description: 'The selector for the alcohol filled icon',
+            dataTestId: 'icon-alcohol-filled',
+        },
+        alcoholFilledLarge: {
+            description: 'The selector for the alcohol filled large icon',
+            dataTestId: 'icon-alcohol-filled-large',
+        },
+    },
 };
 export {
-  icons,
+    icons,
 };

--- a/packages/tools/pie-icons-webc/test/visual/pie-icons-webc.spec.ts
+++ b/packages/tools/pie-icons-webc/test/visual/pie-icons-webc.spec.ts
@@ -9,7 +9,7 @@ test.describe('PIE Icons Webc - Visual tests`', () => {
         // Arrange
         const regularIconPage = new BasePage(page, 'icons--alcohol-filled-regular-icon-variations');
         await regularIconPage.load();
-        await expect.soft(page.locator(icons.selectors.alcoholFilled.dataTestId).first()).toBeVisible();
+        await page.waitForSelector(icons.selectors.alcoholFilled.dataTestId, { strict: false});
 
         // Assert
         await percySnapshot(page, 'PIE Icons Webc - Regular icon renders', percyWidths);
@@ -19,9 +19,8 @@ test.describe('PIE Icons Webc - Visual tests`', () => {
         // Arrange
         const largeIconPage = new BasePage(page, 'icons--alcohol-filled-large-icon-variations');
         await largeIconPage.load();
-
+        await page.waitForSelector(icons.selectors.alcoholFilledLarge.dataTestId, { strict: false});
         // Assert
-        await expect.soft(page.locator(icons.selectors.alcoholFilledLarge.dataTestId).first()).toBeVisible();
         await percySnapshot(page, 'PIE Icons Webc - Large icon renders', percyWidths);
     });
 
@@ -29,9 +28,9 @@ test.describe('PIE Icons Webc - Visual tests`', () => {
         // Arrange
         const regularIconOverridePage = new BasePage(page, 'icons--alcohol-filled-regular-icon-with-override');
         await regularIconOverridePage.load({ size: 'm' });
+        await page.waitForSelector(icons.selectors.alcoholFilled.dataTestId, { strict: false});
 
         // Assert
-        await expect.soft(page.locator(icons.selectors.alcoholFilled.dataTestId)).toBeVisible();
         await percySnapshot(page, 'Regular icon can be sized with the override CSS variable', percyWidths);
     });
 
@@ -39,9 +38,9 @@ test.describe('PIE Icons Webc - Visual tests`', () => {
         // Arrange
         const largeIconOverridePage = new BasePage(page, 'icons--alcohol-filled-large-icon-with-override');
         await largeIconOverridePage.load({ size: '80' });
+        await page.waitForSelector(icons.selectors.alcoholFilledLarge.dataTestId, { strict: false});
 
         // Assert
-        await expect.soft(page.locator(icons.selectors.alcoholFilledLarge.dataTestId)).toBeVisible();
         await percySnapshot(page, 'Large icon can be sized with the override CSS variable', percyWidths);
     });
 });

--- a/packages/tools/pie-icons-webc/test/visual/pie-icons-webc.spec.ts
+++ b/packages/tools/pie-icons-webc/test/visual/pie-icons-webc.spec.ts
@@ -1,50 +1,47 @@
-import { test } from '@sand4rt/experimental-ct-web';
+import { test, expect } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
-import { IconChatConversation } from '@justeattakeaway/pie-icons-webc/dist/IconChatConversation';
-import { IconChatConversationLarge } from '@justeattakeaway/pie-icons-webc/dist/IconChatConversationLarge';
-
-// This ensures the component is registered in the DOM for each test
-// This is not required if your tests mount the web component directly in the tests
-test.beforeEach(async ({ mount }) => {
-    const iconChatConversation = await mount(IconChatConversation);
-    await iconChatConversation.unmount();
-    const iconChatConversationLarge = await mount(IconChatConversationLarge);
-    await iconChatConversationLarge.unmount();
-});
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { icons } from '../helpers/page-object/selectors.ts';
 
 test.describe('PIE Icons Webc - Visual tests`', () => {
-    test('Regular and Large icons render', async ({ page, mount }) => {
-        await mount(IconChatConversation);
-        await mount(IconChatConversationLarge);
+    test('Regular icon renders', async ({ page }) => {
+        // Arrange
+        const regularIconPage = new BasePage(page, 'icons--alcohol-filled-regular-icon-variations');
+        await regularIconPage.load();
+        await expect.soft(page.locator(icons.selectors.alcoholFilled.dataTestId).first()).toBeVisible();
 
-        await percySnapshot(page, 'PIE Icons Webc - Regular and Large icons render', percyWidths);
+        // Assert
+        await percySnapshot(page, 'PIE Icons Webc - Regular icon renders', percyWidths);
     });
 
-    test('Regular and Large icons resize based on size prop', async ({ page, mount }) => {
-        await mount(IconChatConversation, {
-            props: {
-                size: 'xxl',
-            },
-        });
+    test('Large icon renders', async ({ page }) => {
+        // Arrange
+        const largeIconPage = new BasePage(page, 'icons--alcohol-filled-large-icon-variations');
+        await largeIconPage.load();
 
-        await mount(IconChatConversationLarge, {
-            props: {
-                size: 80,
-            },
-        });
-
-        await percySnapshot(page, 'Regular and Large icons resize based on size prop', percyWidths);
+        // Assert
+        await expect.soft(page.locator(icons.selectors.alcoholFilledLarge.dataTestId).first()).toBeVisible();
+        await percySnapshot(page, 'PIE Icons Webc - Large icon renders', percyWidths);
     });
 
-    test('Regular and Large icons can be sized with the override CSS variable', async ({ page }) => {
-        await page.setContent(`
-            <div style="--icon-size-override: 200px;">
-                <icon-chat-conversation size="m"></icon-chat-conversation>
-                <icon-chat-conversation-large size="80"></icon-chat-conversation-large>
-            </div>
-        `);
+    test('Regular icon can be sized with the override CSS variable', async ({ page }) => {
+        // Arrange
+        const regularIconOverridePage = new BasePage(page, 'icons--alcohol-filled-regular-icon-with-override');
+        await regularIconOverridePage.load({ size: 'm' });
 
-        await percySnapshot(page, 'Regular and Large icons can be sized with the override CSS variable', percyWidths);
+        // Assert
+        await expect.soft(page.locator(icons.selectors.alcoholFilled.dataTestId)).toBeVisible();
+        await percySnapshot(page, 'Regular icon can be sized with the override CSS variable', percyWidths);
+    });
+
+    test('Large icon can be sized with the override CSS variable', async ({ page }) => {
+        // Arrange
+        const largeIconOverridePage = new BasePage(page, 'icons--alcohol-filled-large-icon-with-override');
+        await largeIconOverridePage.load({ size: '80' });
+
+        // Assert
+        await expect.soft(page.locator(icons.selectors.alcoholFilledLarge.dataTestId)).toBeVisible();
+        await percySnapshot(page, 'Large icon can be sized with the override CSS variable', percyWidths);
     });
 });

--- a/packages/tools/pie-icons-webc/turbo.json
+++ b/packages/tools/pie-icons-webc/turbo.json
@@ -28,20 +28,44 @@
       ]
     },
     "test:browsers": {
-      "cache": false,
+      "cache": true,
       "dependsOn": [
         "^build",
         "test:browsers-setup"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/icons.test.stories.ts"
       ],
       "outputs": [
         "__snapshots__/**"
       ]
     },
     "test:browsers:ci": {
-      "cache": false,
+      "cache": true,
       "dependsOn": [
         "^build",
         "test:browsers-setup"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/icons.test.stories.ts"
+      ]
+    },
+    "test:visual": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/icons.test.stories.ts"
+      ]
+    },
+    "test:visual:ci": {
+      "cache": false,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/icons.test.stories.ts"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,7 +5206,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-thumbnail@0.2.0, @justeattakeaway/pie-thumbnail@workspace:packages/components/pie-thumbnail":
+"@justeattakeaway/pie-thumbnail@0.3.0, @justeattakeaway/pie-thumbnail@workspace:packages/components/pie-thumbnail":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-thumbnail@workspace:packages/components/pie-thumbnail"
   dependencies:
@@ -5266,7 +5266,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/pie-webc@0.6.4, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
+"@justeattakeaway/pie-webc@0.6.5, @justeattakeaway/pie-webc@workspace:packages/components/pie-webc":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-webc@workspace:packages/components/pie-webc"
   dependencies:
@@ -5292,7 +5292,7 @@ __metadata:
     "@justeattakeaway/pie-tag": 0.12.0
     "@justeattakeaway/pie-text-input": 0.25.0
     "@justeattakeaway/pie-textarea": 0.13.1
-    "@justeattakeaway/pie-thumbnail": 0.2.0
+    "@justeattakeaway/pie-thumbnail": 0.3.0
     "@justeattakeaway/pie-toast": 0.7.0
     "@justeattakeaway/pie-toast-provider": 0.2.0
     chalk: 5.3.0
@@ -23070,7 +23070,7 @@ __metadata:
     "@justeattakeaway/pie-tag": 0.12.0
     "@justeattakeaway/pie-text-input": 0.25.0
     "@justeattakeaway/pie-textarea": 0.13.1
-    "@justeattakeaway/pie-thumbnail": 0.2.0
+    "@justeattakeaway/pie-thumbnail": 0.3.0
     "@justeattakeaway/pie-toast": 0.7.0
     "@justeattakeaway/pie-toast-provider": 0.2.0
     "@storybook/addon-a11y": 8.4.5
@@ -29911,7 +29911,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.2.0
     "@angular/router": 15.2.0
     "@justeattakeaway/pie-css": 0.14.1
-    "@justeattakeaway/pie-webc": 0.6.4
+    "@justeattakeaway/pie-webc": 0.6.5
     rxjs: 7.8.0
     tslib: 2.3.0
     typescript: 4.9.4
@@ -29925,7 +29925,7 @@ __metadata:
   dependencies:
     "@babel/preset-env": 7.24.5
     "@justeattakeaway/pie-css": 0.14.1
-    "@justeattakeaway/pie-webc": 0.6.4
+    "@justeattakeaway/pie-webc": 0.6.5
     babel-loader: 8
     core-js: 3.30.0
     nuxt: 2.17.0
@@ -29940,7 +29940,7 @@ __metadata:
   resolution: "wc-react17@workspace:apps/examples/wc-react17"
   dependencies:
     "@justeattakeaway/pie-css": 0.14.1
-    "@justeattakeaway/pie-webc": 0.6.4
+    "@justeattakeaway/pie-webc": 0.6.5
     "@lit/react": 1.0.5
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -29960,7 +29960,7 @@ __metadata:
   resolution: "wc-react18@workspace:apps/examples/wc-react18"
   dependencies:
     "@justeattakeaway/pie-css": 0.14.1
-    "@justeattakeaway/pie-webc": 0.6.4
+    "@justeattakeaway/pie-webc": 0.6.5
     "@lit/react": 1.0.5
     "@types/react": 18.3.3
     "@types/react-dom": 18.3.0
@@ -29980,7 +29980,7 @@ __metadata:
   resolution: "wc-vue3@workspace:apps/examples/wc-vue3"
   dependencies:
     "@justeattakeaway/pie-css": 0.14.1
-    "@justeattakeaway/pie-webc": 0.6.4
+    "@justeattakeaway/pie-webc": 0.6.5
     "@types/node": 18.15.11
     "@vitejs/plugin-vue": 4.0.0
     "@vue/tsconfig": 0.1.3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Refactors pie-icons-webc to use `@playwright/test`

Percy build - https://percy.io/4bc223d1/web/pie-icons-webc/builds/38438247/

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [] If there are visual test updates, I have reviewed them.
