### PR TITLE
performance(pie-modal): PEW-100 improves performance by deferring tasks

### DIFF
--- a/.changeset/shiny-coats-exercise.md
+++ b/.changeset/shiny-coats-exercise.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Changed] - handleModalOpen method to help with performance


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### Before Change:
<img width="832" alt="Screenshot 2025-01-30 at 09 43 37" src="https://github.com/user-attachments/assets/dc7a7e98-b8da-48c3-9e63-6cd4cf5f348b" />

**Stats:**

_showModal() = 2.25ms / self time 0.25
disableBodyScoll = 87μs
Recalculate Styles = 1.45ms_


### After Change:

![Screenshot 2025-01-29 at 10 23 58](https://github.com/user-attachments/assets/d0e0a19c-54a7-41f6-a6f6-e6cc17615ffa)

**Stats:**

_showModal() = 0.58ms / self time 0.25ms
disableBodyScoll = defers to 3rd task
_setupEscKeyListener = defers to next task
Recalculate Styles = 11ms
Recalculate Styles  (second batch)= 81 μs_


## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @siggerzz 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 @raoufswe 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
