### PR TITLE
fix(pie-radio): DSW-000 ensure focus ring only appears on keyboard focus

### DIFF
--- a/.changeset/large-coins-design.md
+++ b/.changeset/large-coins-design.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-radio": patch
+---
+
+[Fixed] - Ensure focus ring does not appear on click

--- a/packages/components/pie-radio/src/radio.scss
+++ b/packages/components/pie-radio/src/radio.scss
@@ -148,7 +148,7 @@
     }
 }
 
-:host(:focus) {
+:host(:focus-visible) {
     outline: none;
 
     .c-radio .c-radio-input {


### PR DESCRIPTION
Please click the `Preview` tab and select a different PR template if your change isn't for an                                            existing web component.

[PIE Docs Template](?expand=1&template=docs_template.md)
[New Web Component Template](?expand=1&template=new_component_template.md)

═══════════════════════════════════════════════════════════

## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.
- [ ] - [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [N/A](#) |
| NextJS 14 deployment   | N/A](#) |
| Nuxt 3 deployment      | N/A](#) |
| Vanilla deployment     | N/A](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] N/A I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.

### Reviewer 2 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] N/A I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.
