### PR TITLE
format(pie-monorepo): DSW-000 fix linting config & linting issues

### DIFF
--- a/apps/pie-storybook/stories/testing/pie-radio.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-radio.test.stories.ts
@@ -91,7 +91,6 @@ const onSubmit = (event: Event) => {
     const form = document.querySelector('#testForm') as HTMLFormElement;
     const output = document.querySelector('#formDataOutput') as HTMLDivElement;
 
-    console.log('form', form);
     const formData = new FormData(form);
     const formDataObj: { [key: string]: FormDataEntryValue } = {};
     formData.forEach((value, key) => {
@@ -190,12 +189,12 @@ const radioPropsMatrix: Partial<Record<keyof RadioProps, unknown[]>> = {
 };
 
 const variantPropDisplayOptions: PropDisplayOptions<RadioProps> = {
-  propLabels: {
-      slot: {
-          [longLabel]: 'With long content',
-          [shortLabel]: 'With short content',
-      },
-  },
+    propLabels: {
+        slot: {
+            [longLabel]: 'With long content',
+            [shortLabel]: 'With short content',
+        },
+    },
 };
 
-export const Variations = createVariantStory<RadioProps>(Template, radioPropsMatrix, { ... variantPropDisplayOptions, multiColumn: true });
+export const Variations = createVariantStory<RadioProps>(Template, radioPropsMatrix, { ...variantPropDisplayOptions, multiColumn: true });

--- a/packages/tools/pie-icons-webc/test/visual/pie-icons-webc.spec.ts
+++ b/packages/tools/pie-icons-webc/test/visual/pie-icons-webc.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
 import { percyWidths } from '@justeattakeaway/pie-webc-testing/src/percy/breakpoints.ts';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';

--- a/turbo.json
+++ b/turbo.json
@@ -137,11 +137,6 @@
     },
     "lint:scripts": {
       "cache": true,
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "src/**",
-        "src/react.ts"
-      ],
       "outputs": []
     },
     "lint:scripts:fix": {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Fixes and issue where turbo would trigger a cache hit for `pie-storybook`, when a cache miss should have occured.
- Fixes existing linting issues.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---
## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] NA I have verified that all acceptance criteria for this ticket have been completed.
- [-] NA I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] NA I have verified that all acceptance criteria for this ticket have been completed.
- [-] NA I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
