### PR TITLE
refactor(pie-webc-core): DSW-2777 tests to use `@playwright/test`

### DIFF
--- a/apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts
@@ -1,0 +1,73 @@
+import { html } from 'lit';
+import '@justeattakeaway/pie-webc-core/src/test/functions/dispatchCustomElement/MockComponent';
+import '@justeattakeaway/pie-webc-core/src/test/mixins/formControlMixin/MockComponent';
+import { EXPECTED_MOCK_EVENT_MESSAGE } from '@justeattakeaway/pie-webc-core/src/test/functions/dispatchCustomElement/constants';
+/**
+ * Mock stories for testing pie-webc-core functionality
+ */
+export default {
+    title: 'webc-core',
+};
+
+/**
+ * Story for testing the dispatchCustomEvent functionality
+ */
+export const DispatchCustomEvent = () => {
+    function onDispatchCustomEvent () {
+        console.info(EXPECTED_MOCK_EVENT_MESSAGE);
+    }
+
+    return html`
+    <dispatch-custom-event-mock
+      @pie-mock-event="${onDispatchCustomEvent}"
+    ></dispatch-custom-event-mock>
+`;
+};
+
+DispatchCustomEvent.storyName = 'Dispatch Custom Event Mock';
+
+/**
+ * Story for testing the dispatchCustomEvent functionality
+ */
+export const InvalidEventNameEvent = () => html`
+    <dispatch-custom-event-mock
+      eventName="mock-event"
+    ></dispatch-custom-event-mock>
+`;
+
+InvalidEventNameEvent.storyName = 'Invalid Event Name';
+
+/**
+ * Story for testing FormControlMixin with no form
+ */
+export const FormControlMixinMock = () => html`
+    <form-control-mixin-mock></form-control-mixin-mock>
+`;
+
+FormControlMixinMock.storyName = 'Form Control Mixin Mock';
+
+/**
+ * Story for testing FormControlMixin with a complete form
+ */
+export const FormControlMixinInForm = () => html`
+    <form id="testForm" action="/foo" method="POST">
+        <input type="text" id="username" name="username" required>
+        <input type="password" id="password" name="password" required>
+        <form-control-mixin-mock></form-control-mixin-mock>
+    </form>
+`;
+
+FormControlMixinInForm.storyName = 'Form Control Mixin - Inside Form';
+
+/**
+ * Story for testing FormControlMixin with a sibling form
+ */
+export const FormControlMixinOutsideForm = () => html`
+    <form id="siblingForm" action="/foo" method="POST">
+        <input type="text" id="username" name="username" required>
+        <input type="password" id="password" name="password" required>
+    </form>
+    <form-control-mixin-mock></form-control-mixin-mock>
+`;
+
+FormControlMixinOutsideForm.storyName = 'Form Control Mixin - Outside Form';

--- a/packages/components/pie-webc-core/playwright-lit.config.ts
+++ b/packages/components/pie-webc-core/playwright-lit.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@sand4rt/experimental-ct-web';
+import { defineConfig, devices } from '@playwright/test';
 import { getPlaywrightConfig as getPlaywrightConfigOG } from '@justeattakeaway/pie-components-config';
 import type { PlaywrightTestConfig } from '@playwright/test';
 

--- a/packages/components/pie-webc-core/src/test/functions/dispatchCustomElement/MockComponent.ts
+++ b/packages/components/pie-webc-core/src/test/functions/dispatchCustomElement/MockComponent.ts
@@ -13,7 +13,7 @@ export class MockComponent extends LitElement {
         return html`
             <button
                 @click="${() => dispatchCustomEvent(this, this.eventName)}"
-                data-test-id="dispatch-custom-event-mock">
+                data-test-id="dispatch-custom-event-mock-button">
                 Component with the event to dispatch
             </button>`;
     }

--- a/packages/components/pie-webc-core/src/test/functions/dispatchCustomElement/constants.ts
+++ b/packages/components/pie-webc-core/src/test/functions/dispatchCustomElement/constants.ts
@@ -1,0 +1,1 @@
+export const EXPECTED_MOCK_EVENT_MESSAGE = 'pie-mock-event dispatched';

--- a/packages/components/pie-webc-core/src/test/functions/dispatchCustomElement/dispatchCustomEvent.browser.spec.ts
+++ b/packages/components/pie-webc-core/src/test/functions/dispatchCustomElement/dispatchCustomEvent.browser.spec.ts
@@ -1,45 +1,49 @@
-import { test, expect } from '@sand4rt/experimental-ct-web';
-import { MockComponent } from './MockComponent.ts';
+import { test, expect } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+import { EXPECTED_MOCK_EVENT_MESSAGE } from './constants.ts';
 
 test.describe('dispatchCustomEvent function', () => {
-    test('should dispatch an event when clicked', async ({ mount, page }) => {
+    test('should dispatch an event when clicked', async ({ page }) => {
         // Arrange
-        const events : Array<Event> = [];
+        const mockComponentPage = new BasePage(page, 'webc-core--dispatch-custom-event');
+        await mockComponentPage.load();
 
-        await mount(MockComponent, {
-            on: {
-                'pie-mock-event': (event: Event) => events.push(event),
-            },
-        });
-
-        // Act
-        await page.locator('[data-test-id="dispatch-custom-event-mock"]').click();
-
-        // Assert
-        expect(events).toHaveLength(1);
-    });
-
-    test('should call console.warn when event name do not start with "pie-"', async ({ mount, page }) => {
-        // Arrange
-        let result = '';
-        const expected = 'A custom event name should start with `pie-`';
-
-        await mount(MockComponent, {
-            props: {
-                eventName: 'mock-event',
-            },
-        });
-
-        page.on('console', (msg) => {
-            if (msg.type() === 'warning') {
-                result = msg.text();
+        // Set up a listener for console messages
+        const consoleMessages: string[] = [];
+        page.on('console', (message) => {
+            if (message.type() === 'info') {
+                consoleMessages.push(message.text());
             }
         });
 
         // Act
-        await page.locator('[data-test-id="dispatch-custom-event-mock"]').click();
+        await page.getByTestId('dispatch-custom-event-mock-button').click();
 
         // Assert
-        expect(result).toMatch(expected);
+        expect(consoleMessages).toHaveLength(1);
+        expect(consoleMessages[0]).toContain(EXPECTED_MOCK_EVENT_MESSAGE);
+    });
+
+    test('should call console.warn when event name do not start with "pie-"', async ({ page }) => {
+        // Arrange
+        const expected = 'A custom event name should start with `pie-`';
+
+        const mockComponentPage = new BasePage(page, 'webc-core--invalid-event-name-event');
+        await mockComponentPage.load();
+
+        // Set up a listener for console messages
+        const consoleMessages: string[] = [];
+        page.on('console', (msg) => {
+            if (msg.type() === 'warning') {
+                consoleMessages.push(msg.text());
+            }
+        });
+
+        // Act
+        await page.getByTestId('dispatch-custom-event-mock-button').click();
+
+        // Assert
+        expect(consoleMessages).toHaveLength(1);
+        expect(consoleMessages[0]).toMatch(expected);
     });
 });

--- a/packages/components/pie-webc-core/src/test/mixins/formControlMixin/formControlMixin.browser.spec.ts
+++ b/packages/components/pie-webc-core/src/test/mixins/formControlMixin/formControlMixin.browser.spec.ts
@@ -1,76 +1,48 @@
-import { test, expect } from '@sand4rt/experimental-ct-web';
-import { MockComponent } from './MockComponent.ts';
+import { test, expect } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 
 test.describe('FormControlMixin', () => {
-    // IMPORTANT: Mounting and Unmounting the component before each test ensures that any tests that do not explicitly
-    // mount the component will still have it available in Playwright's cache (loaded and registered in the test browser)
-    test.beforeEach(async ({ mount }) => {
-        const component = await mount(MockComponent);
-        await component.unmount();
-    });
-
     test.describe('form property', () => {
-        test.describe('when no form exists', () => {
-            test('should not have an associated form', async ({ page, mount }) => {
-                // Arrange
-                await mount(MockComponent);
+        test('should not have an associated form when no form exists', async ({ page }) => {
+            // Arrange
+            const mockComponentPage = new BasePage(page, 'webc-core--form-control-mixin-mock');
+            await mockComponentPage.load();
 
-                const isFormAssociated = await page.evaluate(() => {
-                    const component = document.querySelector('form-control-mixin-mock');
-                    const form = component?.form;
-
-                    return !!form;
-                });
-
-                // Assert
-                expect(isFormAssociated).toBe(false);
+            const isFormAssociated = await page.evaluate(() => {
+                const component = document.querySelector('form-control-mixin-mock');
+                return component?.form !== null;
             });
+
+            // Assert
+            expect(isFormAssociated).toBe(false);
         });
 
-        test.describe('when inside of a form', () => {
-            test('should return the associated form', async ({ page }) => {
-                // Arrange
-                await page.setContent(`
-                    <form id="testForm" action="/foo" method="POST">
-                        <input type="text" id="username" name="username" required>
-                        <input type="password" id="password" name="password" required>
-                        <form-control-mixin-mock></form-control-mixin-mock>
-                    </form>
-                `);
+        test('should return the associated form when inside a form', async ({ page }) => {
+            // Arrange
+            const mockComponentPage = new BasePage(page, 'webc-core--form-control-mixin-in-form');
+            await mockComponentPage.load();
 
-                const formId = await page.evaluate(() => {
-                    const component = document.querySelector('form-control-mixin-mock');
-                    const form = component?.form;
-
-                    return form?.id;
-                });
-
-                // Assert
-                expect(formId).toContain('testForm');
+            const formId = await page.evaluate(() => {
+                const component = document.querySelector('form-control-mixin-mock');
+                return component?.form?.id;
             });
+
+            // Assert
+            expect(formId).toBe('testForm');
         });
 
-        test.describe('when not inside of an existing form', () => {
-            test('should not have an associated form', async ({ page }) => {
-                // Arrange
-                await page.setContent(`
-                    <form id="siblingForm" action="/foo" method="POST">
-                        <input type="text" id="username" name="username" required>
-                        <input type="password" id="password" name="password" required>
-                    </form>
-                    <form-control-mixin-mock></form-control-mixin-mock>
-                `);
+        test('should not have an associated form when outside a form', async ({ page }) => {
+            // Arrange
+            const mockComponentPage = new BasePage(page, 'webc-core--form-control-mixin-outside-form');
+            await mockComponentPage.load();
 
-                const isFormAssociated = await page.evaluate(() => {
-                    const component = document.querySelector('form-control-mixin-mock');
-                    const form = component?.form;
-
-                    return !!form;
-                });
-
-                // Assert
-                expect(isFormAssociated).toBe(false);
+            const isFormAssociated = await page.evaluate(() => {
+                const component = document.querySelector('form-control-mixin-mock');
+                return component?.form !== null;
             });
+
+            // Assert
+            expect(isFormAssociated).toBe(false);
         });
     });
 });

--- a/packages/components/pie-webc-core/turbo.json
+++ b/packages/components/pie-webc-core/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": [
+    "//"
+  ],
+  "pipeline": {
+    "test:browsers": {
+      "cache": true,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts"
+      ]
+    },
+    "test:browsers:ci": {
+      "cache": true,
+      "dependsOn": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Refactors webc-core tests to use `@playwright/test`

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @fernandofranca 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
