### PR TITLE
ci(pie-monorepo): DSW-2674 update actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
   browser-tests-components:
     needs: [ build-ubuntu-node-20, deploy-storybook ]
     if: needs.check-change-type.outputs.web-components-change == 'true' || github.ref == 'refs/heads/main'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout the Repo
       - name: Checkout
@@ -221,7 +221,7 @@ jobs:
         uses: ./.github/actions/setup-repo
         with:
           node-version: 20
-          os: ubuntu-20.04
+          os: ubuntu-latest
       # Setup Playwright
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
@@ -278,7 +278,7 @@ jobs:
 
   browser-tests-docs:
     needs: deploy-docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout the Repo
       - name: Checkout
@@ -290,7 +290,7 @@ jobs:
         uses: ./.github/actions/setup-repo
         with:
           node-version: 20
-          os: ubuntu-20.04
+          os: ubuntu-latest
       # Setup Playwright
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Reverts https://github.com/justeattakeaway/pie/pull/2134

Now that we've upgraded `@playwright/test`, we should be able to use the latest GHA runner images.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @fernandofranca 
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
