### PR TITLE
fix(pie-text-input): WCP-000 missing validPropertyValues decorator for size prop

### DIFF
--- a/.changeset/warm-snakes-press.md
+++ b/.changeset/warm-snakes-press.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-text-input": patch
+---
+
+[Added] - Missing `validPropertyValues` decorator for `size` prop

--- a/packages/components/pie-text-input/src/index.ts
+++ b/packages/components/pie-text-input/src/index.ts
@@ -14,6 +14,7 @@ import '@justeattakeaway/pie-assistive-text';
 import styles from './text-input.scss?inline';
 import {
     type TextInputProps, types, statusTypes, defaultProps,
+    sizes,
 } from './defs';
 import 'element-internals-polyfill';
 
@@ -92,6 +93,7 @@ export class PieTextInput extends FormControlMixin(RtlMixin(LitElement)) impleme
     public max: TextInputProps['max'];
 
     @property({ type: String })
+    @validPropertyValues(componentSelector, sizes, defaultProps.size)
     public size = defaultProps.size;
 
     @property({ type: Boolean })


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @raoufswe 
- [X] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
