### PR TITLE
docs(pie-cookie-banner): DSW-2679 add a CDN usage block to readme

### DIFF
--- a/.changeset/swift-buckets-press.md
+++ b/.changeset/swift-buckets-press.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-cookie-banner": patch
+---
+
+[Added] - CDN readme

--- a/packages/components/pie-cookie-banner/README.md
+++ b/packages/components/pie-cookie-banner/README.md
@@ -30,6 +30,30 @@ yarn add @justeattakeaway/pie-cookie-banner
 
 For full information on using PIE components as part of an application, check out the [Getting Started Guide](https://github.com/justeattakeaway/pie/wiki/Getting-started-with-PIE-Web-Components).
 
+## CDN Usage
+
+This is not the recommended way to use the component. However, it may be appropriate for some consumers if they are unable to install the package into their application.
+
+Example (without typography) can be seen in this [Codepen](https://codepen.io/JamieMaguire/pen/emYGwgy)
+
+To check for the most up-to-date versions of our cookie banner and css, check their npm pages [here](https://www.npmjs.com/package/@justeattakeaway/pie-cookie-banner) and [here](https://www.npmjs.com/package/@justeattakeaway/pie-css). It is important to stay up to date. These will be the versions you use in the CDN links.
+
+### Setup
+
+1. Please add the `pie-css` stylesheet to your application. This can be imported from our CDN like so:
+
+```html
+<link rel="stylesheet" href="https://pie-design-system-cdn.production.jet-external.com/pie-css/v0.16.0/index.css">
+```
+
+2. Now you can add the Cookie Banner script to your application. This can also be imported from our CDN like so:
+
+```html
+<script src="https://pie-design-system-cdn.production.jet-external.com/pie-cookie-banner/1.3.0/index.js"></script>
+```
+
+We would recommend placing this script somewhere in the bottom of your HTML body tag. However what works for each application will be different. Please consider how this could affect the loading of your page.
+
 ## Documentation
 
 Visit  [Cookie Banner | PIE Design System](https://pie.design/patterns/cookie-banner/code/) to view more information on this component.


### PR DESCRIPTION
Adds a section to the readme on how to use the component with our CDN