### PR TITLE
docs(pie-storybook): DSW-2900 update pie-link icon slot documentation

### DIFF
--- a/.changeset/silly-shoes-rush.md
+++ b/.changeset/silly-shoes-rush.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - new pie-link story that includes an icon slot

--- a/apps/pie-docs/src/components/link/code/props.json
+++ b/apps/pie-docs/src/components/link/code/props.json
@@ -118,7 +118,7 @@
                 "type": "code",
                 "item": ["true", "false"]
             },
-            "If true, the link will apply the styles for the visited state.",
+            "If true, the link will apply the styles for the visited state. Only takes effect if `tag` is `a`.",
             {
                 "type": "code",
                 "item": ["false"]
@@ -130,7 +130,7 @@
                 "type": "code",
                 "item": ["\"leading\"", "\"trailing\""]
             },
-            "Sets the position of the icon relative to the text. Leading comes before the text and trailing comes after, taking writing direction into account. To use this, you must pass an icon into the <a href=\"#slots\">icon slot</a>.",
+            "Sets the position of the icon relative to the text. Leading comes before the text and trailing comes after, taking writing direction into account. To use this, you must pass an icon into the <a href=\"#slots\">icon slot</a>. **Will have no effect if `isStandAlone` is false.**",
             {
                 "type": "code",
                 "item": ["undefined"]

--- a/apps/pie-docs/src/components/link/code/props.json
+++ b/apps/pie-docs/src/components/link/code/props.json
@@ -130,7 +130,7 @@
                 "type": "code",
                 "item": ["\"leading\"", "\"trailing\""]
             },
-            "Sets the position of the icon relative to the text. Leading comes before the text and trailing comes after, taking writing direction into account. To use this, you must pass an icon into the <a href=\"#slots\">icon slot</a>. **Will have no effect if `isStandAlone` is false.**",
+            "Sets the position of the icon relative to the text. Leading comes before the text and trailing comes after, taking writing direction into account. To use this, you must pass an icon into the <a href=\"#slots\">icon slot</a>. **Will have no effect if `isStandalone` is false.**",
             {
                 "type": "code",
                 "item": ["undefined"]

--- a/apps/pie-docs/src/components/link/code/slots.json
+++ b/apps/pie-docs/src/components/link/code/slots.json
@@ -13,7 +13,7 @@
                 "type": "code",
                 "item": ["icon"]
             },
-            "Used to pass in an icon to the link component. The icon placement can be controlled via the <code>iconPlacement</code> prop and we recommend using pie-icons-webc for defining this icon, but this can also accept an SVG icon."
+            "Used to pass in an icon to the link component. The icon placement can be controlled via the <code>iconPlacement</code> prop and we recommend using pie-icons-webc for defining this icon. **Please note the icon size is hardcoded and cannot be overridden.**"
         ]
     ]
 }

--- a/apps/pie-storybook/stories/pie-link.stories.ts
+++ b/apps/pie-storybook/stories/pie-link.stories.ts
@@ -4,17 +4,39 @@ import { type Meta } from '@storybook/web-components';
 
 import '@justeattakeaway/pie-link';
 import {
-    type LinkProps as LinkBaseProps, sizes, variants, iconPlacements, tags, buttonTypes, underlineTypes, defaultProps,
+    type LinkProps as LinkBaseProps,
+    sizes,
+    variants,
+    iconPlacements,
+    tags,
+    buttonTypes,
+    underlineTypes,
+    defaultProps,
 } from '@justeattakeaway/pie-link';
 import '@justeattakeaway/pie-icons-webc/dist/IconPlusCircle.js';
 
 import { type SlottedComponentProps } from '../types';
-import { createStory, type TemplateFunction, sanitizeAndRenderHTML } from '../utilities';
+import {
+    createStory,
+    type TemplateFunction,
+    sanitizeAndRenderHTML,
+} from '../utilities';
 
-type LinkProps = SlottedComponentProps<LinkBaseProps>;
-type LinkStoryMeta = Meta<LinkProps>;
+/**
+ * Extend base LinkProps so that
+ * we can toggle the standalone note on/off internally.
+ */
+interface ExtendedLinkProps extends SlottedComponentProps<LinkBaseProps> {
+    /**
+     * Not exposed to Storybook controls.
+     * If `true`, display a note about needing `isStandalone`.
+     */
+    showStandaloneNote?: boolean;
+}
 
-const defaultArgs: LinkProps = {
+type LinkStoryMeta = Meta<ExtendedLinkProps>;
+
+const defaultArgs: ExtendedLinkProps = {
     ...defaultProps,
     iconPlacement: undefined,
     href: 'https://pie.design',
@@ -30,97 +52,85 @@ const linkStoryMeta: LinkStoryMeta = {
             description: 'Set the element tag of the link.',
             control: 'select',
             options: tags,
-            defaultValue: {
-                summary: defaultProps.tag,
-            },
+            defaultValue: { summary: defaultProps.tag },
         },
         variant: {
             description: 'Set the variant of the link.',
             control: 'select',
             options: variants,
-            defaultValue: {
-                summary: defaultProps.variant,
-            },
+            defaultValue: { summary: defaultProps.variant },
         },
         size: {
             description: 'Set the size of the link.',
             control: 'select',
             options: sizes,
-            defaultValue: {
-                summary: defaultProps.size,
-            },
+            defaultValue: { summary: defaultProps.size },
         },
         underline: {
-            description: 'Set the underline behavior of the link.<br /><br />The `reverse` type can only be used if `isStandalone` is set to `true`',
+            description:
+                'Set the underline behavior of the link.<br /><br />The `reverse` type can only be used if `isStandalone` is set to `true`',
             control: 'select',
             options: underlineTypes,
-            defaultValue: {
-                summary: defaultProps.underline,
-            },
-            if: { arg: 'isStandalone', eq: true },
+            defaultValue: { summary: defaultProps.underline },
         },
         iconPlacement: {
-            description: 'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br />Can only be used if `isStandalone` is set to `true`',
+            description:
+                'Show a leading or trailing icon.<br /><br />To use this with pie-link, you can pass an icon into the `icon` slot.<br /><br />Can only be used if `isStandalone` is set to `true`',
             control: 'select',
             options: [undefined, ...iconPlacements],
-            if: { arg: 'isStandalone', eq: true },
         },
         href: {
-            description: 'The URL that the hyperlink should point to.',
+            description: 'The URL that the hyperlink should point to. Only applies if `tag` is `a`.',
             control: 'text',
-            if: { arg: 'tag', eq: 'a' },
         },
         target: {
-            description: 'Set where to display the linked URL.',
+            description: 'Set where to display the linked URL. Only applies if `tag` is `a`.',
             control: 'text',
-            if: { arg: 'tag', eq: 'a' },
         },
         rel: {
-            description: 'Set what the relationship of the linked URL is.',
+            description:
+                'Set what the relationship of the linked URL is. Only applies if `tag` is `a`.',
             control: 'text',
-            if: { arg: 'tag', eq: 'a' },
         },
         type: {
-            description: 'Set the type of the button.',
+            description: 'Set the type of the button. Only applies if `tag` is `button`.',
             control: 'select',
             options: buttonTypes,
-            defaultValue: {
-                summary: defaultProps.type,
-            },
-            if: { arg: 'tag', eq: 'button' },
+            defaultValue: { summary: defaultProps.type },
         },
         isBold: {
             description: 'If `true`, makes the link text bold.',
             control: 'boolean',
-            defaultValue: {
-                summary: defaultProps.isBold,
-            },
+            defaultValue: { summary: defaultProps.isBold },
         },
         isStandalone: {
             description: 'If `true`, the link will be treated as a block element.',
             control: 'boolean',
-            defaultValue: {
-                summary: defaultProps.isStandalone,
-            },
+            defaultValue: { summary: defaultProps.isStandalone },
         },
         hasVisited: {
-            description:  'If `true`, the link will apply the styles for the visited state.',
+            description:
+                'If `true`, the link will apply the styles for the visited state. Only applies if `tag` is `a`.',
             control: 'boolean',
-            defaultValue: {
-                summary: defaultProps.hasVisited,
-            },
-            if: { arg: 'tag', eq: 'a' },
+            defaultValue: { summary: defaultProps.hasVisited },
         },
         slot: {
-            description: 'The default slot is used to pass the button text into the component.',
+            description: 'The default slot is used to pass the text into the component.',
             control: 'text',
-            defaultValue: {
-                summary: '',
-            },
+            defaultValue: { summary: '' },
         },
         aria: {
             description: 'Set the aria-label attribute of the link.',
             control: 'text',
+        },
+
+        /**
+         * IMPORTANT: This ensures `showStandaloneNote` does NOT show in Storybook Controls.
+         */
+        showStandaloneNote: {
+            table: {
+                disable: true,
+            },
         },
     },
     args: defaultArgs,
@@ -134,7 +144,7 @@ const linkStoryMeta: LinkStoryMeta = {
 
 export default linkStoryMeta;
 
-const Template : TemplateFunction<LinkProps> = ({
+const Template: TemplateFunction<ExtendedLinkProps> = ({
     aria,
     tag,
     href,
@@ -149,27 +159,53 @@ const Template : TemplateFunction<LinkProps> = ({
     hasVisited,
     slot,
     iconPlacement,
+    showStandaloneNote,
 }) => html`
-        <pie-link
-            .aria="${aria}"
-            tag="${ifDefined(tag)}"
-            variant="${ifDefined(variant)}"
-            size="${ifDefined(size)}"
-            underline="${ifDefined(underline)}"
-            iconPlacement="${ifDefined(iconPlacement)}"
-            href="${ifDefined(href)}"
-            target="${ifDefined(target)}"
-            rel="${ifDefined(rel)}"
-            type="${ifDefined(type)}"
-            ?isBold="${isBold}"
-            ?isStandalone="${isStandalone}"
-            ?hasVisited="${hasVisited}">
-            ${iconPlacement ? html`<icon-plus-circle slot="icon"></icon-plus-circle>` : nothing}
-            ${sanitizeAndRenderHTML(slot)}
-        </pie-link>`;
+    <pie-link
+        .aria="${aria}"
+        tag="${ifDefined(tag)}"
+        variant="${ifDefined(variant)}"
+        size="${ifDefined(size)}"
+        underline="${ifDefined(underline)}"
+        iconPlacement="${ifDefined(iconPlacement)}"
+        href="${ifDefined(href)}"
+        target="${ifDefined(target)}"
+        rel="${ifDefined(rel)}"
+        type="${ifDefined(type)}"
+        ?isBold="${isBold}"
+        ?isStandalone="${isStandalone}"
+        ?hasVisited="${hasVisited}"
+    >
+        ${iconPlacement
+    ? html`<icon-plus-circle slot="icon"></icon-plus-circle>`
+    : nothing}
+        ${sanitizeAndRenderHTML(slot)}
+    </pie-link>
 
-const createLinkStory = createStory<LinkProps>(Template, defaultArgs);
+    ${showStandaloneNote
+        ? html`<p>
+            The <b>isStandalone</b> property must be set to true for icons to work.
+            The icon size is hardcoded and cannot be overridden.
+        </p>`
+        : nothing}
+`;
+
+const createLinkStory = createStory<ExtendedLinkProps>(Template, defaultArgs);
 
 export const Default = createLinkStory();
-export const HighVisibility = createLinkStory({ variant:  'high-visibility' });
-export const Inverse = createLinkStory({ variant: 'inverse' }, { bgColor: 'dark (container-dark)' });
+
+export const HighVisibility = createLinkStory({
+    variant: 'high-visibility',
+});
+
+export const Inverse = createLinkStory(
+    { variant: 'inverse' },
+    { bgColor: 'dark (container-dark)' },
+);
+
+export const IconSlot = createLinkStory({
+    isStandalone: true,
+    iconPlacement: 'trailing',
+    showStandaloneNote: true,
+    slot: 'Link with Icon',
+});


### PR DESCRIPTION
- Update the pie-link props table to mention the iconPlacement won't take effect unless `isStandAlone` is set to true
- Make it clear that the icon size cannot be overridden
- Add example to Storybook