### PR TITLE
fix(pie-monorepo): DSW-2856 typescript compatibility issues with form element events in React

### DIFF
--- a/.changeset/happy-eels-cough.md
+++ b/.changeset/happy-eels-cough.md
@@ -1,0 +1,11 @@
+---
+"@justeattakeaway/pie-radio-group": patch
+"@justeattakeaway/pie-text-input": patch
+"@justeattakeaway/pie-checkbox": patch
+"@justeattakeaway/pie-textarea": patch
+"@justeattakeaway/pie-select": patch
+"@justeattakeaway/pie-switch": patch
+"@justeattakeaway/pie-radio": patch
+---
+
+[Fixed] - typescript compatibility issues with pie form element events in React

--- a/packages/components/pie-checkbox/src/defs-react.ts
+++ b/packages/components/pie-checkbox/src/defs-react.ts
@@ -1,3 +1,3 @@
 import type React from 'react';
 
-export type ReactBaseType = React.InputHTMLAttributes<HTMLInputElement>
+export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-checkbox/src/defs-react.ts
+++ b/packages/components/pie-checkbox/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieCheckbox's type definition
+// Omit event types to avoid conflicting with PieCheckbox's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-checkbox/src/defs-react.ts
+++ b/packages/components/pie-checkbox/src/defs-react.ts
@@ -1,3 +1,4 @@
 import type React from 'react';
 
+// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-checkbox/src/defs-react.ts
+++ b/packages/components/pie-checkbox/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit event types from HTMLInputElement to avoid conflicting with PieCheckbox's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-radio-group/src/defs-react.ts
+++ b/packages/components/pie-radio-group/src/defs-react.ts
@@ -5,5 +5,5 @@ import type React from 'react';
  * Example: an HTML button maps to `React.ButtonHTMLAttributes<HTMLButtonElement>`
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/react/index.d.ts#L2829
  */
-// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit event types from HTMLInputElement to avoid conflicting with PieRadioGroup's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLElement>, 'onChange'>

--- a/packages/components/pie-radio-group/src/defs-react.ts
+++ b/packages/components/pie-radio-group/src/defs-react.ts
@@ -5,4 +5,4 @@ import type React from 'react';
  * Example: an HTML button maps to `React.ButtonHTMLAttributes<HTMLButtonElement>`
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/react/index.d.ts#L2829
  */
-export type ReactBaseType = React.HTMLAttributes<HTMLElement>
+export type ReactBaseType = Omit<React.HTMLAttributes<HTMLElement>, 'onChange'>

--- a/packages/components/pie-radio-group/src/defs-react.ts
+++ b/packages/components/pie-radio-group/src/defs-react.ts
@@ -5,5 +5,5 @@ import type React from 'react';
  * Example: an HTML button maps to `React.ButtonHTMLAttributes<HTMLButtonElement>`
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/react/index.d.ts#L2829
  */
-// Omit event types from HTMLInputElement to avoid conflicting with PieRadioGroup's type definition
+// Omit event types to avoid conflicting with PieRadioGroup's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLElement>, 'onChange'>

--- a/packages/components/pie-radio-group/src/defs-react.ts
+++ b/packages/components/pie-radio-group/src/defs-react.ts
@@ -5,4 +5,5 @@ import type React from 'react';
  * Example: an HTML button maps to `React.ButtonHTMLAttributes<HTMLButtonElement>`
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/react/index.d.ts#L2829
  */
+// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLElement>, 'onChange'>

--- a/packages/components/pie-radio/src/defs-react.ts
+++ b/packages/components/pie-radio/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit event types from HTMLInputElement to avoid conflicting with PieRadio's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput'>;

--- a/packages/components/pie-radio/src/defs-react.ts
+++ b/packages/components/pie-radio/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieRadio's type definition
+// Omit event types to avoid conflicting with PieRadio's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput'>;

--- a/packages/components/pie-radio/src/defs-react.ts
+++ b/packages/components/pie-radio/src/defs-react.ts
@@ -1,3 +1,4 @@
 import type React from 'react';
 
+// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput'>;

--- a/packages/components/pie-radio/src/defs-react.ts
+++ b/packages/components/pie-radio/src/defs-react.ts
@@ -1,3 +1,3 @@
 import type React from 'react';
 
-export type ReactBaseType = React.InputHTMLAttributes<HTMLInputElement>;
+export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput'>;

--- a/packages/components/pie-select/src/defs-react.ts
+++ b/packages/components/pie-select/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit event types from HTMLInputElement to avoid conflicting with PieSelect's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLSelectElement>, 'onChange'>

--- a/packages/components/pie-select/src/defs-react.ts
+++ b/packages/components/pie-select/src/defs-react.ts
@@ -1,3 +1,4 @@
 import type React from 'react';
 
+// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLSelectElement>, 'onChange'>

--- a/packages/components/pie-select/src/defs-react.ts
+++ b/packages/components/pie-select/src/defs-react.ts
@@ -1,3 +1,3 @@
 import type React from 'react';
 
-export type ReactBaseType = React.HTMLAttributes<HTMLSelectElement>
+export type ReactBaseType = Omit<React.HTMLAttributes<HTMLSelectElement>, 'onChange'>

--- a/packages/components/pie-select/src/defs-react.ts
+++ b/packages/components/pie-select/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieSelect's type definition
+// Omit event types to avoid conflicting with PieSelect's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLSelectElement>, 'onChange'>

--- a/packages/components/pie-switch/src/defs-react.ts
+++ b/packages/components/pie-switch/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit event types from HTMLInputElement to avoid conflicting with PieSwitch's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-switch/src/defs-react.ts
+++ b/packages/components/pie-switch/src/defs-react.ts
@@ -1,3 +1,3 @@
 import type React from 'react';
 
-export type ReactBaseType = React.InputHTMLAttributes<HTMLInputElement>
+export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-switch/src/defs-react.ts
+++ b/packages/components/pie-switch/src/defs-react.ts
@@ -1,3 +1,4 @@
 import type React from 'react';
 
+// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-switch/src/defs-react.ts
+++ b/packages/components/pie-switch/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieSwitch's type definition
+// Omit event types to avoid conflicting with PieSwitch's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>

--- a/packages/components/pie-text-input/src/defs-react.ts
+++ b/packages/components/pie-text-input/src/defs-react.ts
@@ -1,3 +1,3 @@
 import type React from 'react';
 
-export type ReactBaseType = React.InputHTMLAttributes<HTMLInputElement>
+export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput' | 'size'>

--- a/packages/components/pie-text-input/src/defs-react.ts
+++ b/packages/components/pie-text-input/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit `size` and event types to avoid conflicting with PieInput's type definition
+// Omit `size` and event types to avoid conflicting with PieTextInput's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput' | 'size'>

--- a/packages/components/pie-text-input/src/defs-react.ts
+++ b/packages/components/pie-text-input/src/defs-react.ts
@@ -1,3 +1,4 @@
 import type React from 'react';
 
+// Omitting the native input 'size' type to avoid conflicts with our custom 'size' prop.
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput' | 'size'>

--- a/packages/components/pie-text-input/src/defs-react.ts
+++ b/packages/components/pie-text-input/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit `size` and event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit `size` and event types to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput' | 'size'>

--- a/packages/components/pie-text-input/src/defs-react.ts
+++ b/packages/components/pie-text-input/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omitting the native input 'size' type to avoid conflicts with our custom 'size' prop.
+// Omit `size` and event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'onInput' | 'size'>

--- a/packages/components/pie-textarea/src/defs-react.ts
+++ b/packages/components/pie-textarea/src/defs-react.ts
@@ -1,3 +1,3 @@
 import type React from 'react';
 
-export type ReactBaseType = React.HTMLAttributes<HTMLTextAreaElement>
+export type ReactBaseType = Omit<React.HTMLAttributes<HTMLTextAreaElement>, 'onChange' | 'onInput'>

--- a/packages/components/pie-textarea/src/defs-react.ts
+++ b/packages/components/pie-textarea/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieTextarea's type definition
+// Omit event types to avoid conflicting with PieTextarea's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLTextAreaElement>, 'onChange' | 'onInput'>

--- a/packages/components/pie-textarea/src/defs-react.ts
+++ b/packages/components/pie-textarea/src/defs-react.ts
@@ -1,3 +1,4 @@
 import type React from 'react';
 
+// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLTextAreaElement>, 'onChange' | 'onInput'>

--- a/packages/components/pie-textarea/src/defs-react.ts
+++ b/packages/components/pie-textarea/src/defs-react.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-// Omit event types from HTMLInputElement to avoid conflicting with PieInput's type definition
+// Omit event types from HTMLInputElement to avoid conflicting with PieTextarea's type definition
 export type ReactBaseType = Omit<React.HTMLAttributes<HTMLTextAreaElement>, 'onChange' | 'onInput'>


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Fixes the following TypeScript error when attaching any event to our React wrapper form elements.

```
Type '(event: InputEvent) => void' is not assignable to type '((event: InputEvent) => void) & FormEventHandler<HTMLInputElement>'.
```

- This happens because our React wrapper extends our component [types](https://github.com/justeattakeaway/pie/blob/main/packages/components/pie-text-input/src/defs-react.ts#L3) with `React.HTMLAttributes<HTMLInputElement>`, which automatically includes React-specific event handlers types like `onInput` and `onChange`.
- As a result, our component types end up with a union of event types we declare from Lit (InputEvent / CustomEvent) and React (SyntheticEvent), leading to a type conflict.
- The fix omits the React event types from the wrapper, as we only expect native InputEvent or CustomEvent in our components to be used.

the fix is valideted in aperture [here](https://github.com/justeattakeaway/pie-aperture/pull/280) 

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed visual test updates properly before approving.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](https://github.com/justeattakeaway/pie-aperture/pull/280) |
| NextJS 14 deployment   | [🔗](https://pr280-aperture-nextjs-app-v14.pie.design/integrations/controlled-form) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @jamieomaguire 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @xander-marjoram 
- [-] N/A I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.
