### PR TITLE
docs(pie-storybook): DSW-2984 icon names in story

### DIFF
--- a/.changeset/lucky-spiders-kneel.md
+++ b/.changeset/lucky-spiders-kneel.md
@@ -1,0 +1,5 @@
+---
+"pie-storybook": minor
+---
+
+[Added] - Icon tag names to the icon gallery story

--- a/apps/pie-storybook/stories/icons.stories.ts
+++ b/apps/pie-storybook/stories/icons.stories.ts
@@ -24,7 +24,6 @@ const iconGalleryTemplate: TemplateFunction<null> = () => html`
         padding: var(--dt-spacing-b);
         justify-items: center;
         text-align: center;
-        font-family: sans-serif;
     }
 
     .c-iconGallery-item {

--- a/apps/pie-storybook/stories/icons.stories.ts
+++ b/apps/pie-storybook/stories/icons.stories.ts
@@ -16,12 +16,41 @@ const iconsStoryMeta = {
 export default iconsStoryMeta;
 
 const iconGalleryTemplate: TemplateFunction<null> = () => html`
+<style>
+    .c-iconGallery {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+        gap: var(--dt-spacing-e);
+        padding: var(--dt-spacing-b);
+        justify-items: center;
+        text-align: center;
+        font-family: sans-serif;
+    }
+
+    .c-iconGallery-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--dt-spacing-b);
+    }
+
+    .c-iconGallery-item p {
+        font-size: calc(var(--dt-font-size-12) * 1px);
+        color: var(--dt-color-content);
+        margin: 0;
+        word-break: break-word;
+    }
+</style>
+
 <div class="c-iconGallery">
     ${Object.keys(icons).map((iconName) => {
     const tag = unsafeStatic(kebabCase(iconName));
     return html`
-        <${tag}></${tag}>
-    `;
+            <div class="c-iconGallery-item">
+                <${tag}></${tag}>
+                <p>${tag}</p>
+            </div>
+        `;
 })}
 </div>
 `;


### PR DESCRIPTION
When users visit the webc storybook and view the Icons gallery story, currently they must inspect elements in order to find the icons tag name. We can improve this by displaying the tag name in the story beneath each icon. This also means users can use the page search feature to find an icon.

https://pr2328-storybook.pie.design/?path=/story/icons--all-icons

<img width="1407" alt="Screenshot 2025-04-17 at 12 16 32" src="https://github.com/user-attachments/assets/7b8b8967-7fec-4927-9168-7fd572457c43" />

