### PR TITLE
feat(pie-select): DSW-2982 design review tasks

### DIFF
--- a/.changeset/silly-birds-cheer.md
+++ b/.changeset/silly-birds-cheer.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-select": patch
+---
+
+[Changed] - Reduce right padding on select, inherit font-family and truncate long options

--- a/packages/components/pie-select/src/select.scss
+++ b/packages/components/pie-select/src/select.scss
@@ -3,7 +3,7 @@
 .c-select {
     --select-padding-block: var(--dt-spacing-c);
     --select-padding-inline-start: var(--dt-spacing-d);
-    --select-padding-inline-end: var(--dt-spacing-h);
+    --select-padding-inline-end: 52px;
     --select-background-color: var(--dt-color-container-default);
     --select-text-color: var(--dt-color-content-default);
     --select-border-color: var(--dt-color-border-form);
@@ -27,6 +27,7 @@
         padding-block-start: var(--select-padding-block);
         padding-block-end: var(--select-padding-block);
         background-color: var(--select-background-color);
+        font-family: inherit;
         font-size: inherit;
         line-height: inherit;
         color: inherit;
@@ -35,6 +36,11 @@
         -moz-appearance: none;
         appearance: none;
         cursor: var(--select-cursor);
+
+        // Ensure longer options are truncated
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
 
         &:focus-within {
             @include p.focus;


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Small changes based on design review to:
- reduce right padding on select to 52px (not a token so it's hard coded)
- use the jet font via inheritance
- truncate longer select options 

## Author Checklist (complete before requesting a review, do not delete any)
- [x]  I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [N/A](#) |
| NextJS 14 deployment   | [N/A](#) |
| Nuxt 3 deployment      | [N/A](#) |
| Vanilla deployment     | [N/A](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 @raoufswe 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
