### PR TITLE
refactor(pie-toast-provider): DSW-2949 z-index css property

### DIFF
--- a/.changeset/tricky-dolls-mate.md
+++ b/.changeset/tricky-dolls-mate.md
@@ -3,4 +3,4 @@
 "pie-storybook": minor
 ---
 
-[Added] - `zIndex` property
+[Added] - `zIndex` css property

--- a/apps/pie-docs/src/components/toast/toast-provider/code.md
+++ b/apps/pie-docs/src/components/toast/toast-provider/code.md
@@ -118,7 +118,7 @@ The `toaster` utility dynamically creates toasts. It can be imported and called 
 ```js
 import { toaster } from '@justeattakeaway/pie-webc/components/toast-provider.js';
 
-toaster.createToast({
+toaster.create({
   message: 'This is a success toast!',
   variant: 'success',
   isDismissible: true,

--- a/apps/pie-docs/src/components/toast/toast-provider/code.md
+++ b/apps/pie-docs/src/components/toast/toast-provider/code.md
@@ -7,6 +7,7 @@ shouldShowContents: true
 eleventyComputed:
     props: "{% include './props.json' %}"
     events: "{% include './events.json' %}"
+    cssProperties: "{% include './css-properties.json' %}"
 ---
 
 ## Overview
@@ -51,6 +52,18 @@ yarn add @justeattakeaway/pie-webc
 
 {% componentDetailsTable {
   tableData: props
+} %}
+
+## CSS Properties
+
+{% componentDetailsTable {
+  tableData: cssProperties
+} %}
+
+{% notification {
+  type: "information",
+  iconName: "info-circle",
+  message: "CSS Custom Properties provided by the component can be overridden using standard CSS techniques. For example, using inline styles: `<pie-toast-provider style='--toast-provider-z-index: 7000;'></pie-toast-provider>`"
 } %}
 
 ## Events

--- a/apps/pie-docs/src/components/toast/toast-provider/css-properties.json
+++ b/apps/pie-docs/src/components/toast/toast-provider/css-properties.json
@@ -1,0 +1,17 @@
+{
+    "headings": [
+        "Name",
+        "Description",
+        "Default"
+    ],
+    "rows": [
+        [
+            "`--toast-provider-z-index`",
+            "Controls the stacking order of the toast provider.",
+            {
+                "type": "code",
+                "item": [["--dt-z-index-toast (6000)"]]
+            }
+        ]
+    ]
+}

--- a/apps/pie-docs/src/components/toast/toast-provider/css-properties.json
+++ b/apps/pie-docs/src/components/toast/toast-provider/css-properties.json
@@ -10,7 +10,7 @@
             "Controls the stacking order of the toast provider.",
             {
                 "type": "code",
-                "item": [["--dt-z-index-toast (6000)"]]
+                "item": ["--dt-z-index-toast (6000)"]
             }
         ]
     ]

--- a/apps/pie-storybook/stories/pie-toast-provider.stories.ts
+++ b/apps/pie-storybook/stories/pie-toast-provider.stories.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { type Meta } from '@storybook/web-components';
 import { action } from '@storybook/addon-actions';
 
@@ -33,11 +33,14 @@ const toastProviderStoryMeta: ToastProviderStoryMeta = {
                 summary: defaultProps.options,
             },
         },
-        zIndex: {
-            description: 'Defines the stacking order of the toast provider.',
+        '--toast-provider-z-index': {
+            description: 'Controls the stacking order of the toast provider.',
             control: 'text',
             defaultValue: {
                 summary: '--dt-z-index-toast (6000)',
+            },
+            table: {
+                category: 'CSS Properties',
             },
         },
     },
@@ -52,7 +55,7 @@ const toastProviderStoryMeta: ToastProviderStoryMeta = {
 
 export default toastProviderStoryMeta;
 
-const Template = ({ options, zIndex }: ToastProviderProps) => {
+const Template = ({ options, '--toast-provider-z-index': customZIndex }: ToastProviderProps & { '--toast-provider-z-index'?: string }) => {
     const onQueueUpdate = (event: CustomEvent) => {
         const queueLength = document.querySelector('#queue-length-tag') as HTMLElement;
         if (queueLength) {
@@ -63,7 +66,7 @@ const Template = ({ options, zIndex }: ToastProviderProps) => {
     return html`
     <pie-toast-provider 
         .options=${options} 
-        zIndex="${zIndex || nothing}"
+        style="${customZIndex ? `--toast-provider-z-index: ${customZIndex}` : ''}"
         @pie-toast-provider-queue-update=${onQueueUpdate}>
     </pie-toast-provider>
 

--- a/apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts
@@ -60,7 +60,7 @@ const CustomZIndexTemplate = () => {
                 @pie-toast-provider-queue-update="${onQueueUpdate}">
             </pie-toast-provider>
         </div>
-        <pie-button @click="${showToast}">Show Toast</pie-button>
+        <pie-button data-test-id="show-toast-button" @click="${showToast}">Show Toast</pie-button>
     `;
 };
 

--- a/apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts
@@ -1,8 +1,9 @@
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { type Meta } from '@storybook/web-components';
 
 import '@justeattakeaway/pie-toast-provider';
-import { type ToastProviderProps, defaultProps } from '@justeattakeaway/pie-toast-provider';
+import { type ToastProviderProps, defaultProps, toaster } from '@justeattakeaway/pie-toast-provider';
+import '@justeattakeaway/pie-button';
 
 import { createStory } from '../../utilities';
 
@@ -23,13 +24,6 @@ const toastProviderStoryMeta: ToastProviderStoryMeta = {
                 summary: defaultProps.options,
             },
         },
-        zIndex: {
-            description: 'Defines the stacking order of the toast provider.',
-            control: 'text',
-            defaultValue: {
-                summary: '--dt-z-index-toast (6000)',
-            },
-        },
     },
     args: defaultArgs,
 };
@@ -40,12 +34,35 @@ const onQueueUpdate = (queue: CustomEvent) => {
     console.info('toast provider queue:', queue.detail);
 };
 
-const Template = ({ options, zIndex }: ToastProviderProps) => html`
+const Template = ({ options }: ToastProviderProps) => html`
     <pie-toast-provider
         .options="${options}"
-        zIndex="${zIndex || nothing}"
         @pie-toast-provider-queue-update="${onQueueUpdate}">
     </pie-toast-provider>
 `;
 
+const CustomZIndexTemplate = () => {
+    const showToast = () => {
+        toaster.create({
+            title: 'Test Toast',
+            message: 'This toast should appear above the red box.',
+            duration: null,
+        });
+    };
+
+    return html`
+        <div style="position: relative; height: 200px; border: 1px dashed grey; padding: 20px; margin-bottom: 20px;">
+            <div style="position: absolute; inset: 40px; background-color: red; z-index: 6500;">
+                (z-index: 6500)
+            </div>
+            <pie-toast-provider
+                style="--toast-provider-z-index: 7000;"
+                @pie-toast-provider-queue-update="${onQueueUpdate}">
+            </pie-toast-provider>
+        </div>
+        <pie-button @click="${showToast}">Show Toast</pie-button>
+    `;
+};
+
 export const Default = createStory<ToastProviderProps>(Template, defaultArgs)();
+export const CustomZIndex = createStory(CustomZIndexTemplate, {})();

--- a/packages/components/pie-toast-provider/src/defs-react.ts
+++ b/packages/components/pie-toast-provider/src/defs-react.ts
@@ -1,8 +1,3 @@
 import type React from 'react';
-/**
- * TODO: Verify if ReactBaseType can be set as a more specific React interface
- * Use the React IntrinsicElements interface to find how to map standard HTML elements to existing React Interfaces
- * Example: an HTML button maps to `React.ButtonHTMLAttributes<HTMLButtonElement>`
- * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/react/index.d.ts#L2829
- */
+
 export type ReactBaseType = React.HTMLAttributes<HTMLElement>

--- a/packages/components/pie-toast-provider/src/defs.ts
+++ b/packages/components/pie-toast-provider/src/defs.ts
@@ -39,12 +39,11 @@ export interface ToastProviderProps {
      * Default options for all toasts; accepts all toast props.
      */
     options?: Partial<ExtendedToastProps>;
-    zIndex?: number;
 }
 
 export type DefaultProps = ComponentDefaultProps<ToastProviderProps>;
 
-export const defaultProps: Omit<DefaultProps, 'zIndex'> = {
+export const defaultProps: DefaultProps = {
     options: {},
 };
 

--- a/packages/components/pie-toast-provider/src/index.ts
+++ b/packages/components/pie-toast-provider/src/index.ts
@@ -43,9 +43,6 @@ export class PieToastProvider extends RtlMixin(PieElement) implements ToastProvi
     @property({ type: Object })
     public options = defaultProps.options;
 
-    @property({ type: Number })
-    public zIndex: ToastProviderProps['zIndex'];
-
     updated (changedProperties: PropertyValues<this>): void {
         if (changedProperties.has('_toasts' as keyof PieToastProvider)) {
             this._dispatchQueueUpdateEvent();
@@ -120,22 +117,13 @@ export class PieToastProvider extends RtlMixin(PieElement) implements ToastProvi
         this._currentToast = null;
     }
 
-    private _generateInlineStyles () {
-        const { zIndex } = this;
-
-        return typeof zIndex !== 'undefined' && typeof zIndex === 'number' ? `--toast-provider-z-index: ${zIndex}` : nothing;
-    }
-
     render () {
         const { _currentToast, _dismissToast } = this;
-
-        const styles = this._generateInlineStyles();
 
         return html`
         <div 
             class="c-toast-provider" 
-            data-test-id="pie-toast-provider" 
-            style="${styles}">
+            data-test-id="pie-toast-provider">
             ${_currentToast &&
                 html`
                 <pie-toast

--- a/packages/components/pie-toast-provider/src/index.ts
+++ b/packages/components/pie-toast-provider/src/index.ts
@@ -166,4 +166,3 @@ declare global {
         [componentSelector]: PieToastProvider;
     }
 }
-

--- a/packages/components/pie-toast-provider/src/toast-provider.scss
+++ b/packages/components/pie-toast-provider/src/toast-provider.scss
@@ -1,6 +1,9 @@
 @use '@justeattakeaway/pie-css/scss' as p;
 @use '@justeattakeaway/pie-css/scss/settings' as *;
 
+:host {
+    --toast-provider-z-index: var(--dt-z-index-toast);
+}
 
 .c-toast-provider {
     --toast-provider-offset: var(--dt-spacing-d);

--- a/packages/components/pie-toast-provider/src/toast-provider.scss
+++ b/packages/components/pie-toast-provider/src/toast-provider.scss
@@ -7,7 +7,6 @@
 
 .c-toast-provider {
     --toast-provider-offset: var(--dt-spacing-d);
-    --toast-provider-z-index: var(--dt-z-index-toast);
 
     position: absolute;
     inset-inline-start: var(--toast-provider-offset);

--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -145,35 +145,5 @@ test.describe('PieToastProvider - Component tests', () => {
                 expect(toastsQueue[1].isDismissible).toBeFalsy(); // Override should take precedence
             });
         });
-
-        test.describe('zIndex', () => {
-            test('should not apply the attribute on the toast provider element if not provided', async ({ page }) => {
-                // Arrange
-                const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
-                await pieToastProviderPage.load();
-
-                // Act
-                const toastProviderElement = page.getByTestId(toastProvider.selectors.container.dataTestId);
-
-                // Assert
-                await expect(toastProviderElement).not.toHaveAttribute('zIndex');
-            });
-
-            test('should apply the attribute on the toast provider element', async ({ page }) => {
-                // Arrange
-                const props: Partial<PieToastProvider> = {
-                    zIndex: 2000,
-                };
-
-                const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
-                await pieToastProviderPage.load({ ...props });
-
-                // Act
-                const toastProviderElement = page.getByTestId(toastProvider.selectors.container.dataTestId);
-
-                // Assert
-                await expect(toastProviderElement).toHaveAttribute('zIndex', '2000');
-            });
-        });
     });
 });

--- a/packages/components/pie-toast-provider/test/visual/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/visual/pie-toast-provider.spec.ts
@@ -4,13 +4,16 @@ import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-obj
 
 test.describe('PieToastProvider - Visual tests`', () => {
     test('should display the PieToastProvider component successfully', async ({ page }) => {
-        const basePage = new BasePage(page, 'toast-provider--default');
+        const basePage = new BasePage(page, 'toast-provider--custom-z-index');
 
         basePage.load();
 
-        // Follow up to remove in Jan
-        await page.waitForTimeout(5000);
+        const showToastButton = page.getByTestId('show-toast-button');
+        await showToastButton.click();
 
-        await percySnapshot(page, 'PieToastProvider - Visual Test');
+        const toastElement = page.locator('pie-toast');
+        await toastElement.waitFor({ state: 'visible' });
+
+        await percySnapshot(page, 'PieToastProvider - Custom Z-Index Visual Test');
     });
 });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Refactors the `zIndex` prop to be a css property

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.


## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [-] I have reviewed visual test updates properly before approving.
- [-] If changes will affect consumers of the package, I have created a changeset entry.
- [-] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [-] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")
