### PR TITLE
fix(pie-switch): DSW-2819 fix check icon vertical alignment

### DIFF
--- a/.changeset/young-mails-cross.md
+++ b/.changeset/young-mails-cross.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-switch": patch
+---
+
+[Fixed] - check icon vertical alignment

--- a/packages/components/pie-switch/src/switch.scss
+++ b/packages/components/pie-switch/src/switch.scss
@@ -102,6 +102,10 @@
         right: 2px;
     }
 
+    .c-pieIcon--check {
+        vertical-align: top;
+    }
+
     .c-switch-input:checked + & {
         @include switch-transition(transform);
         transform: translateX(var(--switch-translation));


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Fixes pie-switch check icon vertical alignment

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [ ] I have added thorough tests where applicable (unit / component / visual).

## Recording

https://github.com/user-attachments/assets/0ebcc942-3257-4695-968b-9539e15d3f08

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
