### PR TITLE
fix(pie-monorepo): DSW-3025 security patch to add scopes to private unpublished pkgs

### DIFF
--- a/.changeset/great-lemons-pull.md
+++ b/.changeset/great-lemons-pull.md
@@ -1,0 +1,8 @@
+---
+"@justeattakeaway/pie-monorepo-utils": patch
+"@justeattakeaway/pie-icons": patch
+"@justeattakeaway/pie-docs": patch
+"pie-monorepo": patch
+---
+
+[Fixed] - Security patch to add scope to pie-docs

--- a/.github/workflows/amplify-deploy.yml
+++ b/.github/workflows/amplify-deploy.yml
@@ -49,12 +49,31 @@ env:
   BRANCH_NAME: ${{ github.event_name == 'pull_request' && format('pr{0}', github.event.number) || (github.ref == 'refs/heads/main' && 'main' || github.ref == 'refs/heads/master' && 'master') }}
   BUCKET_NAME: ${{ github.event_name == 'pull_request' && inputs.bucket-name-preview || (github.ref == 'refs/heads/main' && inputs.bucket-name-main || github.ref == 'refs/heads/master' && inputs.bucket-name-main) }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  ZIP_NAME: ${{ github.event_name == 'pull_request' && format('{0}-{1}-preview.zip', inputs.package-name, github.event.number) || (github.ref == 'refs/heads/main' && format('{0}-main.zip', inputs.package-name) || github.ref == 'refs/heads/master' && format('{0}-master.zip', inputs.package-name)) }}
 
 jobs:
   deploy:
     runs-on: ${{ inputs.os }}
     steps:
+      # Process package name to remove prefix
+      - name: Process package name
+        run: |
+          PACKAGE_NAME="${{ inputs.package-name }}"
+          if [[ "$PACKAGE_NAME" == @justeattakeaway/* ]]; then
+            PACKAGE_NAME="${PACKAGE_NAME/@justeattakeaway\//}"
+          fi
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+
+      # Create ZIP_NAME environment variable
+      - name: Set ZIP_NAME
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "ZIP_NAME=${{ env.PACKAGE_NAME }}-${{ github.event.number }}-preview.zip" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "ZIP_NAME=${{ env.PACKAGE_NAME }}-main.zip" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "ZIP_NAME=${{ env.PACKAGE_NAME }}-master.zip" >> $GITHUB_ENV
+          fi
+
       # Checkout the Repo
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -118,16 +118,16 @@ jobs:
       id: generate_payload
       run: |
         PACKAGES='${{ steps.changesets-main.outputs.publishedPackages}}'
-        PRIORITIZED_PACKAGES=$(echo $PACKAGES | jq -c '[.[] | select(.name == "pie-docs" or .name == "pie-storybook")]')
-        REST_PACKAGES=$(echo $PACKAGES | jq -c '[.[] | select((.name != "pie-docs" and .name != "pie-storybook") and (.name | startswith("wc-") | not) and .name != "pie-monorepo")]')
+        PRIORITIZED_PACKAGES=$(echo $PACKAGES | jq -c '[.[] | select(.name == "@justeattakeaway/pie-docs" or .name == "pie-storybook")]')
+        REST_PACKAGES=$(echo $PACKAGES | jq -c '[.[] | select((.name != "@justeattakeaway/pie-docs" and .name != "pie-storybook") and (.name | startswith("wc-") | not) and .name != "pie-monorepo")]')
 
         PRIORITIZED_BLOCKS=$(echo $PACKAGES | jq -c '
-            map(select(.name == "pie-docs" or .name == "pie-storybook")) |
+            map(select(.name == "@justeattakeaway/pie-docs" or .name == "pie-storybook")) |
 
             if length > 0 then
               [{"type": "divider"}, {"type": "header", "text": {"type": "plain_text", "text": ":rocket: Deployment Summary"}}] +
               (map(
-                if .name == "pie-docs" then
+                if .name == "@justeattakeaway/pie-docs" then
                   {
                     "type": "section",
                     "block_id": "sectionBlockWithButton",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Verify if pie-docs has changes
         id: docs-check
         run: |
-          DOCS_CHANGE=$(npx -y turbo run build --filter='pie-docs[origin/main]' --dry=json | jq '.packages | length > 0')
+          DOCS_CHANGE=$(npx -y turbo run build --filter='@justeattakeaway/pie-docs[origin/main]' --dry=json | jq '.packages | length > 0')
           echo "Change Detected: $DOCS_CHANGE"
           echo "docs-change=$DOCS_CHANGE" >> $GITHUB_OUTPUT
       - name: Verify if web components have changes
@@ -272,7 +272,7 @@ jobs:
       os: ubuntu-latest
       node-version: 20
       amplify-app-id: dvskdcoepjoyf
-      package-name: 'pie-docs'
+      package-name: '@justeattakeaway/pie-docs'
       package-dist-directory: ./apps/pie-docs/dist
       bucket-name-preview: 'pie-docs-preview'
       bucket-name-main: 'pie-docs'
@@ -301,7 +301,7 @@ jobs:
       - name: Run All System /  a11y Tests
         uses: ./.github/actions/run-script
         with:
-          script-name: "test:browsers:ci --filter=pie-docs"
+          script-name: "test:browsers:ci --filter=@justeattakeaway/pie-docs"
       - name: Upload Playwright Report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
@@ -314,13 +314,13 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter=pie-docs[HEAD^1]"
+          script-name: "test:visual:ci --filter=@justeattakeaway/pie-docs[HEAD^1]"
           concurrency: 1
       - name: Run Changed Package Visual Tests
         uses: ./.github/actions/run-script
         if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) && github.ref != 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter=pie-docs"
+          script-name: "test:visual:ci --filter=@justeattakeaway/pie-docs"
           concurrency: 1
       - name: Upload Playwright Report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/apps/pie-docs/README.md
+++ b/apps/pie-docs/README.md
@@ -17,7 +17,7 @@
 - To run the project, start by running `yarn` from the root of the monorepo. Then whilst still at the root run:
 
   ```
-  yarn dev --filter=pie-docs
+  yarn dev --filter=@justeattakeaway/pie-docs
   ```
 
 ## Technologies used
@@ -102,9 +102,9 @@ We have route navigation tests that ensure all existing pages can be correctly n
 Route tests need a production build so that they do not fail with `draft` page routes. For this, we recommend to:
 1. Stop any local instance of the doc site
 2. Delete your `dist` folder
-3. Create a production build with `yarn build --filter=pie-docs`
+3. Create a production build with `yarn build --filter=@justeattakeaway/pie-docs`
 
-Once this is done, you can run the route tests with `yarn test --filter=pie-docs`.
+Once this is done, you can run the route tests with `yarn test --filter=@justeattakeaway/pie-docs`.
 From here, we run navigation, accessibility and visual tests against each route.
 
 #### Adding new routes
@@ -115,14 +115,14 @@ In order to fix the tests, you will need to register the routes to your newly ad
 
 Running `yarn test:browsers` will ensure that navigating to the routes stored in `expected-routes.snapshot.json` result in Status Code `200` responses.
 
-In order to run this command you will need the site to be served to localhost by running `yarn dev --filter=pie-docs` in another terminal.
+In order to run this command you will need the site to be served to localhost by running `yarn dev --filter=@justeattakeaway/pie-docs` in another terminal.
 
 ### Unit testing
 Our unit testing is quite light. We generally write unit tests for `Javascript` utilities and for `shortcodes`. With shortcodes, we often perform [snapshot tests](https://jestjs.io/docs/snapshot-testing) on the returned markup. Whilst visual tests will catch changes to how the markup looks, snapshot tests will catch any unwanted changes to things like `HTML` attributes.
 
-For testing snapshots you can run from the root of the monorepo `yarn test --filter=pie-docs`
+For testing snapshots you can run from the root of the monorepo `yarn test --filter=@justeattakeaway/pie-docs`
 
-If you would like to update snapshots because the changes are expected, you can run from the root of the monorepo `yarn test --filter=pie-docs -- -u`
+If you would like to update snapshots because the changes are expected, you can run from the root of the monorepo `yarn test --filter=@justeattakeaway/pie-docs -- -u`
 
 ## Conventions
 - If you want to create some reusable/shared content, you can add it to a markdown file using the following naming format: `**.content.md`. Eleventy knows to ignore these file types during build, so they will not turn into their own pages. Because we use Nunjucks as our markdown rendering engine, we are able to use includes in our markdown files like so: `{% include 'some/path/to/reusable-stuff.content.md' %}`. This allows us to reuse copy if needed.

--- a/apps/pie-docs/package.json
+++ b/apps/pie-docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pie-docs",
+  "name": "@justeattakeaway/pie-docs",
   "private": true,
   "description": "Documentation website for the PIE design system",
   "version": "4.32.0",

--- a/packages/tools/pie-icons/bin/create-changeset.mjs
+++ b/packages/tools/pie-icons/bin/create-changeset.mjs
@@ -122,7 +122,7 @@ export async function createPieDocsChangeset (pieDocsPath) {
 
     const changelogText = '[Changed] - updated snapshots after icons update';
     const versionBumpType = 'patch';
-    const packages = ['pie-docs'];
+    const packages = ['@justeattakeaway/pie-docs'];
     const monorepoRootPath = findMonorepoRoot();
 
     return createChangeSetFile(changelogText, versionBumpType, packages, monorepoRootPath);

--- a/packages/tools/pie-icons/bin/update-icons.mjs
+++ b/packages/tools/pie-icons/bin/update-icons.mjs
@@ -203,7 +203,7 @@ async function updateIcons () {
         updateIconData(iconsDataFilePath, changedFilesGroups.added, allFilesPathsAndCategories);
 
         console.info('updating pie-docs snapshots');
-        execSync('cd ../../../ && yarn test --filter=pie-docs -- -u');
+        execSync('cd ../../../ && yarn test --filter=@justeattakeaway/pie-docs -- -u');
 
         console.info('creating changesets');
         const pieDocsChangesetFilePath = await createPieDocsChangeset(pieDocsTestsPath);

--- a/packages/tools/pie-monorepo-utils/__tests__/changeset-snapshot/create-and-publish.spec.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/changeset-snapshot/create-and-publish.spec.js
@@ -89,7 +89,7 @@ describe('create and publish workflow', () => {
         test('should ignore monorepo/docs/storybook changes', async () => {
             // Arrange
             sampleOutput = `
-                New tag: pie-docs@0.0.0-snapshot-release-20231220110000
+                New tag: @justeattakeaway/pie-docs@0.0.0-snapshot-release-20231220110000
                 New tag: pie-monorepo@0.0.0-snapshot-release-20231220110000
                 New tag: pie-storybook@0.0.0-snapshot-release-20231220110000
             `;

--- a/packages/tools/pie-monorepo-utils/changeset-snapshot/utils.js
+++ b/packages/tools/pie-monorepo-utils/changeset-snapshot/utils.js
@@ -53,7 +53,7 @@ const publishSnapshot = async (execa) => {
     const newTags = Array
         .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
         .map(([, tag]) => tag)
-        .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)/.test(tag));
+        .filter((tag) => !/^wc-.+$|pie-(monorepo|docs|storybook)|@justeattakeaway\/pie-docs/.test(tag));
 
     return newTags;
 };

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
         "custom-elements.json"
       ],
       "outputs": [
-        "src/react.ts"
+        "src/**/react.ts"
       ]
     },
     "create:manifest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,6 +4046,38 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@justeattakeaway/pie-docs@workspace:apps/pie-docs":
+  version: 0.0.0-use.local
+  resolution: "@justeattakeaway/pie-docs@workspace:apps/pie-docs"
+  dependencies:
+    "@11ty/eleventy": 2.0.1
+    "@11ty/eleventy-navigation": 0.3.5
+    "@docsearch/css": 3.5.2
+    "@docsearch/js": 3.5.2
+    "@justeat/fozzie": 11.0.2
+    "@justeat/pie-design-tokens": 6.10.0
+    "@justeattakeaway/browserslist-config-pie": 0.2.1
+    "@justeattakeaway/pie-css": 0.16.0
+    "@justeattakeaway/pie-icons": 5.9.0
+    "@justeattakeaway/pie-monorepo-utils": 0.5.0
+    "@types/markdown-it": 13.0.2
+    autoprefixer: 10.4.20
+    cssnano: 5.1.15
+    dree: 3.4.5
+    eleventy-plugin-rev: 1.1.1
+    eleventy-plugin-toc: 1.1.5
+    eleventy-sass: 2.2.3
+    js-cookie: 2.2.1
+    markdown-it: 13.0.2
+    markdown-it-anchor: 8.6.7
+    markdown-it-attrs: 4.1.6
+    node-html-parser: 6.1.13
+    postcss: 8.4.32
+    postcss-cli: 10.1.0
+    slugify: 1.6.6
+  languageName: unknown
+  linkType: soft
+
 "@justeattakeaway/pie-form-label@0.15.1, @justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/pie-form-label@workspace:packages/components/pie-form-label"
@@ -20799,38 +20831,6 @@ __metadata:
   checksum: 371cd14bbc9bdee2a6a44596dd521dd3565e223481e0b1afffdca3f1c29831850bfa7784114dc30d245d37e7d186cec035e036256b39f75d878d19498fe0df6a
   languageName: node
   linkType: hard
-
-"pie-docs@workspace:apps/pie-docs":
-  version: 0.0.0-use.local
-  resolution: "pie-docs@workspace:apps/pie-docs"
-  dependencies:
-    "@11ty/eleventy": 2.0.1
-    "@11ty/eleventy-navigation": 0.3.5
-    "@docsearch/css": 3.5.2
-    "@docsearch/js": 3.5.2
-    "@justeat/fozzie": 11.0.2
-    "@justeat/pie-design-tokens": 6.10.0
-    "@justeattakeaway/browserslist-config-pie": 0.2.1
-    "@justeattakeaway/pie-css": 0.16.0
-    "@justeattakeaway/pie-icons": 5.9.0
-    "@justeattakeaway/pie-monorepo-utils": 0.5.0
-    "@types/markdown-it": 13.0.2
-    autoprefixer: 10.4.20
-    cssnano: 5.1.15
-    dree: 3.4.5
-    eleventy-plugin-rev: 1.1.1
-    eleventy-plugin-toc: 1.1.5
-    eleventy-sass: 2.2.3
-    js-cookie: 2.2.1
-    markdown-it: 13.0.2
-    markdown-it-anchor: 8.6.7
-    markdown-it-attrs: 4.1.6
-    node-html-parser: 6.1.13
-    postcss: 8.4.32
-    postcss-cli: 10.1.0
-    slugify: 1.6.6
-  languageName: unknown
-  linkType: soft
 
 "pie-monorepo@workspace:.":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Describe your changes

[Fixed] - Security patch to add scopes to private unpublished pkgs


## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items

- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.


---


## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 @siggerzz 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.

### Reviewer 2 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] N/A I have reviewed the Aperture changes (if added)
- [-] N/A If there are visual test updates, I have reviewed them.
