### PR TITLE
docs(pie-storybook): DSW-3061 add next.js 14 integration guide to sb

### DIFF
--- a/.changeset/plenty-taxis-kneel.md
+++ b/.changeset/plenty-taxis-kneel.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": patch
+---
+
+[Added] - Next.js 14 integration guide

--- a/apps/pie-storybook/.storybook/preview.ts
+++ b/apps/pie-storybook/.storybook/preview.ts
@@ -71,6 +71,10 @@ export default {
                         'Events',
                         'Browser support',
                     ],
+                    'Integration guides',
+                    [
+                        'Next.js 14',
+                    ],
                     'Components',
                 ]
             }

--- a/apps/pie-storybook/stories/integration-guides/nextjs-14.mdx
+++ b/apps/pie-storybook/stories/integration-guides/nextjs-14.mdx
@@ -1,0 +1,78 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Integration guides/Next.js 14" />
+
+# Next.js 14
+
+This guide will show you how to set up the PIE Web Components in a Next.js 14 application.
+
+> This guide assumes you have first followed the [Getting started](?path=/docs/introduction-getting-started--docs), [Typography](?path=/docs/introduction-typography--docs) and [CSS setup](?path=/docs/introduction-css-setup--docs) guides.
+> Please make sure to follow them before continuing with this guide.
+
+## Table of Contents
+
+- [Dependencies](#dependencies)
+- [Next.js config](#nextjs-config)
+- [Usage](#usage)
+
+
+## Dependencies
+The first step is to install some React and Next.js specific dependencies:
+
+**Using Yarn:**
+
+```bash
+yarn add @lit-labs/nextjs @lit/react
+```
+
+**Using NPM:**
+
+```bash
+npm install @lit-labs/nextjs @lit/react
+```
+
+## Next.js config
+
+We need to update our `next.config.js` file to enable server-side rendering (SSR).
+
+Example minimal config file:
+
+```js
+// Example - ./next.config.js
+const withLitSSR = require('@lit-labs/nextjs')();
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+    reactStrictMode: true,
+    swcMinify: true,
+}
+
+module.exports = withLitSSR(nextConfig);
+```
+
+## Usage
+
+> If you are using the app router structure, please ensure you add `use client` to the top of the files that directly import the PIE components. This does **not** prevent SSR, it just means that PIE components cannot be used directly in React server-components. These client components can then be imported into RSCs.
+
+For React-based applications, there is a `/react/` entry point in both `@justeattakeaway/pie-webc` and `@justeattakeaway/pie-icons-webc` as shown in the example code below:
+
+```jsx
+"use client"
+
+import { PieButton } from "@justeattakeaway/pie-webc/react/button.js";
+import { PieLink } from "@justeattakeaway/pie-webc/react/link.js";
+import { IconCamera } from "@justeattakeaway/pie-icons-webc/dist/react/IconCamera";
+
+export default function SomeComponent() {
+    return (
+        <div>
+            <PieButton size="small-productive" iconPlacement="leading">
+                <IconCamera slot="icon"></IconCamera>
+                Camera Button
+            </PieButton>
+        </div>
+    );
+}
+```
+
+You should now be able to use any components you need in your Next.js application!

--- a/apps/pie-storybook/stories/introduction/getting-started.mdx
+++ b/apps/pie-storybook/stories/introduction/getting-started.mdx
@@ -28,21 +28,22 @@ PIE Web Components is the web variant of the Just Eat Takeaway.com (JET) Design 
 
 Setting up our web components differs slightly depending on your framework. However, regardless of your tech stack, the **first step** is to install our core packages:
 
-- [@justeattakeaway/pie-webc](https://www.npmjs.com/package/@justeattakeaway/pie-webc)
-- [@justeattakeaway/pie-css](https://www.npmjs.com/package/@justeattakeaway/pie-css)
+- The core component library: [@justeattakeaway/pie-webc](https://www.npmjs.com/package/@justeattakeaway/pie-webc)
+- Base styles used by the components: [@justeattakeaway/pie-css](https://www.npmjs.com/package/@justeattakeaway/pie-css)
+- Icons used by some of the components: [@justeattakeaway/pie-icons-webc](https://www.npmjs.com/package/@justeattakeaway/pie-icons-webc)
 
 > 💡 While components are also available as individual packages, we recommend using `@justeattakeaway/pie-webc` as the **single entry point**. This approach is the easiest way to get started with and ensures you stay up to date.
 
 **Using Yarn:**
 
 ```bash
-yarn add @justeattakeaway/pie-webc @justeattakeaway/pie-css
+yarn add @justeattakeaway/pie-webc @justeattakeaway/pie-css @justeattakeaway/pie-icons-webc
 ```
 
 **Using NPM:**
 
 ```bash
-npm install @justeattakeaway/pie-webc @justeattakeaway/pie-css
+npm install @justeattakeaway/pie-webc @justeattakeaway/pie-css @justeattakeaway/pie-icons-webc
 ```
 
 From here, you will need to set up Typography and base CSS styles. Please read the [Typography](?path=/docs/introduction-typography--docs) and [CSS setup](?path=/docs/introduction-css-setup--docs) pages for more information.


### PR DESCRIPTION
- Adds a next.js 14 integration guide to storybook
- Updates the getting started guide to mention `@justeattakeaway/pie-icons-webc`