### PR TITLE
ci(pie-monorepo): DSW-000 upgrade `actions@setup-node@v4.4.0`

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
       # Setup Node
       - name: Setup Node
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: "yarn"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,9 @@ updates:
           - "storybook"
 
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
+    directories:
+      - ".github/workflows"
+      - ".github/actions"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
The version of this action we're using it currently reliant on a GitHub Service that was deprecated as of last week, causing timeout issues when trying to restore Node cache. - https://github.com/orgs/community/discussions/160793

This is visible in the logs for any `Setup Node` step in our CI:

Currently, this timeout cause this step to take ~6 minutes, resulting in slower CI time.
![Screenshot 2025-06-04 at 14 27 18](https://github.com/user-attachments/assets/b4b47fc0-1fae-46bd-a22e-2dadf1e72ceb)

As you can see, this change no longer results in the error and only takes ~1min 30s
![Screenshot 2025-06-04 at 14 30 24](https://github.com/user-attachments/assets/8644ddbb-6e32-417e-8a1c-c963e807ba1b)


This change will also bring a `main` build back to a reasonable total duration. All the ~1hr times are since the deprecation
![Screenshot 2025-06-04 at 14 37 40](https://github.com/user-attachments/assets/4d020f90-6eda-4dbc-b51a-2689235e5759)

