### PR TITLE
docs(pie-docs): DSW-3100 add percy setup guide

### DIFF
--- a/.changeset/good-crabs-confess.md
+++ b/.changeset/good-crabs-confess.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": patch
+---
+
+[Added] - Percy setup guide

--- a/apps/pie-storybook/stories/contribution/overview.mdx
+++ b/apps/pie-storybook/stories/contribution/overview.mdx
@@ -65,6 +65,29 @@ Use our [Yeoman generator](https://github.com/justeattakeaway/pie/tree/main/pack
 
 Follow the README for usage.
 
+
+### Percy setup
+Once you have created the new component, you will need to also create a new project in Percy:
+
+1. You may need to ask for admin rights to Percy and the Pie repository on Github. Ask an admin if needed.
+
+2. Go to percy: https://percy.io/4bc223d1
+
+3. Create new project
+
+4. Name the project after the component (e.g. pie-avatar)
+
+5. Point the repository at Pie
+
+6. Set the *Default base branch* and *Auto-approve branches* to `main`
+
+7. Go into the Pie repository settings in Github and go to *Secrets and Variables*
+
+8. Create a new secret with the name of the percy project in the format of `PERCY_TOKEN_PIE_<COMPONENT>`
+for example `PERCY_TOKEN_PIE_LINK`
+
+9. Add this token locally using the same naming format. Where you add your environment variables will differ depending on your machine. On Mac, it could be in `~/.zshrc`, for example.
+
 ## 5. Develop and test the component
 
 ### Start storybook


### PR DESCRIPTION
- add small guide on setting up new percy projects when generating components
https://pr2450-storybook.pie.design/?path=/docs/contribution-overview--docs#4-scaffold-a-new-component