### PR TITLE
fix(pie-radio-group): DSW-3076 fix keyboard focus handling when radio is disabled

### DIFF
--- a/.changeset/pink-elephants-dance.md
+++ b/.changeset/pink-elephants-dance.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": patch
+---
+
+[Added] - new test stories for `PieRadioGroup` component

--- a/.changeset/violet-pumas-perform.md
+++ b/.changeset/violet-pumas-perform.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-radio-group": patch
+---
+
+[Fixed] keyboard focus handling when one or more radio buttons are disabled

--- a/apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts
@@ -130,6 +130,58 @@ const DisabledRadioTemplate = () => html`
       </div>
   `;
 
+const KeyboardNavigationAllDisabledTemplate = () => html`
+      <div style="max-width: 400px">
+            <p><pie-button size="small-productive" data-test-id="btn-1">Button 1</pie-button></p>
+            <pie-radio-group data-test-id="pie-radio-group">
+                  <pie-radio data-test-id="radio-1" disabled value="radio-one">radio 1</pie-radio>
+                  <pie-radio data-test-id="radio-2" disabled value="radio-two">radio 2</pie-radio>
+                  <pie-radio data-test-id="radio-3" disabled value="radio-three">radio 3</pie-radio>
+                  <pie-radio data-test-id="radio-4" disabled value="radio-four">radio 4</pie-radio>
+            </pie-radio-group>
+            <p><pie-button size="small-productive" data-test-id="btn-2">Button 2</pie-button></p>
+      </div>
+  `;
+
+const KeyboardNavigationAllDisabledAndCheckedTemplate = () => html`
+      <div style="max-width: 400px">
+            <p><pie-button size="small-productive" data-test-id="btn-1">Button 1</pie-button></p>
+            <pie-radio-group data-test-id="pie-radio-group" value="radio-two">
+                  <pie-radio data-test-id="radio-1" disabled value="radio-one">radio 1</pie-radio>
+                  <pie-radio data-test-id="radio-2" disabled value="radio-two">radio 2</pie-radio>
+                  <pie-radio data-test-id="radio-3" disabled value="radio-three">radio 3</pie-radio>
+                  <pie-radio data-test-id="radio-4" disabled value="radio-four">radio 4</pie-radio>
+            </pie-radio-group>
+            <p><pie-button size="small-productive" data-test-id="btn-2">Button 2</pie-button></p>
+      </div>
+  `;
+
+const KeyboardNavigationDisabledAndCheckedTemplate = () => html`
+      <div style="max-width: 400px">
+            <p><pie-button size="small-productive" data-test-id="btn-1">Button 1</pie-button></p>
+            <pie-radio-group data-test-id="pie-radio-group" value="radio-two">
+                  <pie-radio data-test-id="radio-1" value="radio-one">radio 1</pie-radio>
+                  <pie-radio data-test-id="radio-2" disabled value="radio-two">radio 2</pie-radio>
+                  <pie-radio data-test-id="radio-3" value="radio-three">radio 3</pie-radio>
+                  <pie-radio data-test-id="radio-4" value="radio-four">radio 4</pie-radio>
+            </pie-radio-group>
+            <p><pie-button size="small-productive" data-test-id="btn-2">Button 2</pie-button></p>
+      </div>
+  `;
+
+const KeyboardNavigationDisabledRadiosAndCheckedTemplate = () => html`
+      <div style="max-width: 400px">
+            <p><pie-button size="small-productive" data-test-id="btn-1">Button 1</pie-button></p>
+            <pie-radio-group data-test-id="pie-radio-group" value="radio-two">
+                  <pie-radio data-test-id="radio-1" disabled value="radio-one">radio 1</pie-radio>
+                  <pie-radio data-test-id="radio-2" value="radio-two">radio 2</pie-radio>
+                  <pie-radio data-test-id="radio-3" disabled value="radio-three">radio 3</pie-radio>
+                  <pie-radio data-test-id="radio-4" disabled value="radio-four">radio 4</pie-radio>
+            </pie-radio-group>
+            <p><pie-button size="small-productive" data-test-id="btn-2">Button 2</pie-button></p>
+      </div>
+  `;
+
 const KeyboardNavigationTemplate = () => html`
     <h2>Radio group 1</h2>
     <p><pie-button size="small-productive" data-test-id="btn-1">Button 1</pie-button></p>
@@ -189,6 +241,10 @@ const DynamicSlotsTemplate = () => {
 export const Default = createStory<RadioGroupProps>(DefaultTemplate, defaultArgs)();
 export const DisabledRadio = createStory<RadioGroupProps>(DisabledRadioTemplate, defaultArgs)();
 export const KeyboardNavigation = createStory<RadioGroupProps>(KeyboardNavigationTemplate, defaultArgs)();
+export const KeyboardNavigationDisabledAndChecked = createStory<RadioGroupProps>(KeyboardNavigationDisabledAndCheckedTemplate, defaultArgs)();
+export const KeyboardNavigationDisabledRadiosAndChecked = createStory<RadioGroupProps>(KeyboardNavigationDisabledRadiosAndCheckedTemplate, defaultArgs)();
+export const KeyboardNavigationAllDisabledAndChecked = createStory<RadioGroupProps>(KeyboardNavigationAllDisabledAndCheckedTemplate, defaultArgs)();
+export const KeyboardNavigationAllDisabled = createStory<RadioGroupProps>(KeyboardNavigationAllDisabledTemplate, defaultArgs)();
 export const DynamicSlots = createStory<RadioGroupProps>(DynamicSlotsTemplate, defaultArgs)();
 
 const radioGroupPropsMatrix : Partial<Record<keyof RadioGroupProps, unknown[]>> = {

--- a/packages/components/pie-radio-group/src/index.ts
+++ b/packages/components/pie-radio-group/src/index.ts
@@ -47,6 +47,9 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(PieElement)) implem
     @state()
     private _fieldSetTabIndex = 0;
 
+    @state()
+    private _allRadiosDisabled = false;
+
     @property({ type: String, reflect: true })
     public name: RadioGroupProps['name'];
 
@@ -80,6 +83,8 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(PieElement)) implem
         this._slottedChildren.forEach((child) => child.dispatchEvent(new CustomEvent(ON_RADIO_GROUP_DISABLED, {
             bubbles: false, composed: false, detail: { disabled: this.disabled },
         })));
+
+        this._allRadiosDisabled = this._slottedChildren.every((item) => item.disabled);
     }
 
     /**
@@ -398,8 +403,8 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(PieElement)) implem
             status,
             assistiveText,
             _fieldSetTabIndex,
+            _allRadiosDisabled,
         } = this;
-
         const hasAssistiveText = Boolean(assistiveText?.length);
 
         const classes = {
@@ -410,7 +415,7 @@ export class PieRadioGroup extends FormControlMixin(RtlMixin(PieElement)) implem
 
         return html`
             <fieldset
-                tabindex=${_fieldSetTabIndex}
+                tabindex=${_allRadiosDisabled ? -1 : _fieldSetTabIndex}
                 role="radiogroup"
                 name=${ifDefined(name)}
                 ?disabled=${disabled}

--- a/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
+++ b/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
@@ -36,6 +36,20 @@ const keyboardNavigationStorySelectors = {
     button4: 'btn-4',
 };
 
+const keyboardNavigationDisabledStorySelectors = {
+    button1: 'btn-1',
+    radioGroup: {
+        self: 'pie-radio-group',
+        radios: {
+            1: 'radio-1',
+            2: 'radio-2',
+            3: 'radio-3',
+            4: 'radio-4',
+        },
+    },
+    button2: 'btn-2',
+};
+
 const dynamicSlotsStorySelectors = {
     radioGroup1: {
         self: 'radio-group-1',
@@ -307,6 +321,98 @@ test.describe('PieRadioGroup - Component tests new', () => {
                     const button = page.getByTestId(keyboardNavigationStorySelectors.button2);
 
                     await expect(button).toBeFocused();
+                });
+
+                test.describe('Radio is checked but disabled', () => {
+                    test.beforeEach(async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-disabled-and-checked');
+                        await pageObject.load();
+                    });
+
+                    test('Tab should focus the first available radio, not the selected one', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[1]);
+                        await expect(radio).toBeFocused();
+                    });
+
+                    test('Shift + Tab should focus the last available radio, not the selected one', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        await page.keyboard.press('Shift+Tab');
+
+                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[4]);
+                        await expect(radio).toBeFocused();
+                    });
+                });
+
+                test.describe('All but one radio is disabled', () => {
+                    test.beforeEach(async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-disabled-radios-and-checked');
+                        await pageObject.load();
+                    });
+                    test('Tab should focus the single enabled radio', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[2]);
+                        await expect(radio).toBeFocused();
+                    });
+                    test('Shift + Tab should focus the single enabled radio', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        await page.keyboard.press('Shift+Tab');
+
+                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[2]);
+                        await expect(radio).toBeFocused();
+                    });
+                });
+                test.describe('All radios are disabled, but one is checked', () => {
+                    test.beforeEach(async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-all-disabled-and-checked');
+                        await pageObject.load();
+                    });
+                    test('Tab should not focus the radio group', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button2);
+                        await expect(button).toBeFocused();
+                    });
+                    test('Shift + Tab should not focus the radio group', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Shift+Tab');
+
+                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button1);
+                        await expect(button).toBeFocused();
+                    });
+                });
+                test.describe('All radios are disabled', () => {
+                    test.beforeEach(async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-all-disabled');
+                        await pageObject.load();
+                    });
+                    test('Tab should not focus the radio group', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button2);
+                        await expect(button).toBeFocused();
+                    });
+                    test('Shift + Tab should not focus the radio group', async ({ page }) => {
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Shift+Tab');
+
+                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button1);
+                        await expect(button).toBeFocused();
+                    });
                 });
             });
 

--- a/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
+++ b/packages/components/pie-radio-group/test/component/pie-radio-group-new.spec.ts
@@ -324,93 +324,51 @@ test.describe('PieRadioGroup - Component tests new', () => {
                 });
 
                 test.describe('Radio is checked but disabled', () => {
-                    test.beforeEach(async ({ page }) => {
+                    test('Tab should focus the first available radio, not the selected one', async ({ page }) => {
                         pageObject = new BasePage(page, 'radio-group--keyboard-navigation-disabled-and-checked');
                         await pageObject.load();
-                    });
 
-                    test('Tab should focus the first available radio, not the selected one', async ({ page }) => {
                         await page.keyboard.press('Tab');
                         await page.keyboard.press('Tab');
 
                         const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[1]);
                         await expect(radio).toBeFocused();
                     });
-
-                    test('Shift + Tab should focus the last available radio, not the selected one', async ({ page }) => {
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Tab');
-
-                        await page.keyboard.press('Shift+Tab');
-
-                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[4]);
-                        await expect(radio).toBeFocused();
-                    });
                 });
 
                 test.describe('All but one radio is disabled', () => {
-                    test.beforeEach(async ({ page }) => {
+                    test('Tab should focus the single enabled radio', async ({ page }) => {
                         pageObject = new BasePage(page, 'radio-group--keyboard-navigation-disabled-radios-and-checked');
                         await pageObject.load();
-                    });
-                    test('Tab should focus the single enabled radio', async ({ page }) => {
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Tab');
 
-                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[2]);
-                        await expect(radio).toBeFocused();
-                    });
-                    test('Shift + Tab should focus the single enabled radio', async ({ page }) => {
                         await page.keyboard.press('Tab');
                         await page.keyboard.press('Tab');
-                        await page.keyboard.press('Tab');
-
-                        await page.keyboard.press('Shift+Tab');
 
                         const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[2]);
                         await expect(radio).toBeFocused();
                     });
                 });
                 test.describe('All radios are disabled, but one is checked', () => {
-                    test.beforeEach(async ({ page }) => {
+                    test('Tab should not focus the radio group', async ({ page }) => {
                         pageObject = new BasePage(page, 'radio-group--keyboard-navigation-all-disabled-and-checked');
                         await pageObject.load();
-                    });
-                    test('Tab should not focus the radio group', async ({ page }) => {
+
                         await page.keyboard.press('Tab');
                         await page.keyboard.press('Tab');
 
                         const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button2);
-                        await expect(button).toBeFocused();
-                    });
-                    test('Shift + Tab should not focus the radio group', async ({ page }) => {
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Shift+Tab');
-
-                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button1);
                         await expect(button).toBeFocused();
                     });
                 });
                 test.describe('All radios are disabled', () => {
-                    test.beforeEach(async ({ page }) => {
+                    test('Tab should not focus the radio group', async ({ page }) => {
                         pageObject = new BasePage(page, 'radio-group--keyboard-navigation-all-disabled');
                         await pageObject.load();
-                    });
-                    test('Tab should not focus the radio group', async ({ page }) => {
+
                         await page.keyboard.press('Tab');
                         await page.keyboard.press('Tab');
 
                         const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button2);
-                        await expect(button).toBeFocused();
-                    });
-                    test('Shift + Tab should not focus the radio group', async ({ page }) => {
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Tab');
-                        await page.keyboard.press('Shift+Tab');
-
-                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button1);
                         await expect(button).toBeFocused();
                     });
                 });
@@ -498,6 +456,64 @@ test.describe('PieRadioGroup - Component tests new', () => {
                     await page.keyboard.press('Shift+Tab');
                     const button = page.getByTestId(keyboardNavigationStorySelectors.button1);
                     await expect(button).toBeFocused();
+                });
+
+                test.describe('Radio is checked but disabled', () => {
+                    test('Shift + Tab should focus the last available radio, not the selected one', async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-disabled-and-checked');
+                        await pageObject.load();
+
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        await page.keyboard.press('Shift+Tab');
+
+                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[4]);
+                        await expect(radio).toBeFocused();
+                    });
+                });
+
+                test.describe('All but one radio is disabled', () => {
+                    test('Shift + Tab should focus the single enabled radio', async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-disabled-radios-and-checked');
+                        await pageObject.load();
+
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+
+                        await page.keyboard.press('Shift+Tab');
+
+                        const radio = page.getByTestId(keyboardNavigationDisabledStorySelectors.radioGroup.radios[2]);
+                        await expect(radio).toBeFocused();
+                    });
+                });
+                test.describe('All radios are disabled, but one is checked', () => {
+                    test('Shift + Tab should not focus the radio group', async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-all-disabled-and-checked');
+                        await pageObject.load();
+
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Shift+Tab');
+
+                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button1);
+                        await expect(button).toBeFocused();
+                    });
+                });
+                test.describe('All radios are disabled', () => {
+                    test('Shift + Tab should not focus the radio group', async ({ page }) => {
+                        pageObject = new BasePage(page, 'radio-group--keyboard-navigation-all-disabled');
+                        await pageObject.load();
+
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Tab');
+                        await page.keyboard.press('Shift+Tab');
+
+                        const button = page.getByTestId(keyboardNavigationDisabledStorySelectors.button1);
+                        await expect(button).toBeFocused();
+                    });
                 });
             });
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### @justeattakeaway/pie-radio-group 

[Fixed] keyboard focus handling when one or more radio buttons are disabled

### @justeattakeaway/pie-storybook

[Added] - new test stories for `PieRadioGroup` component

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
[-] If there are visual test updates, I have reviewed them.
