### PR TITLE
refactor(pie-docs): DSW-2601 remove deprecated sass warning for usage of `color.lightness`

### DIFF
--- a/.changeset/quiet-cycles-pay.md
+++ b/.changeset/quiet-cycles-pay.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-docs": minor
+---
+
+[Fixed] - Sass deprecation warning for usage of `color.lightness`

--- a/apps/pie-docs/src/_utilities/colors.js
+++ b/apps/pie-docs/src/_utilities/colors.js
@@ -34,7 +34,7 @@ const isColorDark = (hexCode) => {
     const color = convertRGBToSassColour(rgb);
     const lightnessThreshold = 40;
 
-    return color.lightness < lightnessThreshold;
+    return color.channel('lightness', { space: 'hsl' }) < lightnessThreshold;
 };
 
 module.exports = {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Removes usage of `color.lightness` in favour of `color.channel`

>[!NOTE]
> There are still a few deprecation warnings present when building PIE Docs due to some deprecated Sass usage in `@justeat/fozzie`. DSW-3201 has been created to remove these warnings and remove `@justeat/fozzie` as a dependency in favour of `pie-css`

## Author Checklist (complete before requesting a review, do not delete any)
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [ ] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.
