### PR TITLE
fix(pie-button): DSW-3082 fix button full width when used in a flex parent

### DIFF
--- a/.changeset/selfish-foxes-melt.md
+++ b/.changeset/selfish-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-button": patch
+---
+
+[Changed] when displayed inside a flex element, a button set with `isfullwidth` should expand to occupy the parent width

--- a/packages/components/pie-button/src/button.scss
+++ b/packages/components/pie-button/src/button.scss
@@ -7,6 +7,7 @@
 
 :host([isfullwidth]) {
     display: block;
+    flex-grow: 1;
 }
 
 /**


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- [Changed] when displayed inside a flex element, a button set with `isfullwidth` should expand to occupy the parent width

## Author Checklist (complete before requesting a review, do not delete any)
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [ ] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.
