### PR TITLE
chore(pie-monorepo): DSW-3205 add vite.config.timestamp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ custom-elements.json
 **/src/**/react.ts
 **/stats.html
 
+# Vite Timestamp
+**/vite.config.js.timestamp.*
+
 # Yalc
 .yalc
 yalc.lock


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Turborepo can be quite inconsistent at times when building our components, resulting in cache misses without any file modifications in the repo.

While i'm not entirely sure what the issue is, I have noticed that when building any web components, a `vite.config.js.timestamp.*` file can get generated, and then immediately deleted once the component has been built.

This is problematic, as if this file gets added to source control, it _could_ cause a chain-reaction with Turbo and invalidate a number of component caches.

By adding this file to `.gitignore`, we're telling Turborepo to ignore this file and not consider it when generating any hashes that are used for determining cache state.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
