### PR TITLE
fix(pie-icons-webc): DSW-3175 ensure custom classes don't override base classes

### DIFF
--- a/.changeset/early-hounds-draw.md
+++ b/.changeset/early-hounds-draw.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-webc": patch
+---
+
+[Fixed] class prop behaviour to ensure base classes are never removed

--- a/.changeset/twelve-spies-joke.md
+++ b/.changeset/twelve-spies-joke.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icons-webc": patch
+---
+
+[Fixed] size prop behaviour on large icons

--- a/.changeset/warm-hornets-turn.md
+++ b/.changeset/warm-hornets-turn.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": patch
+---
+
+[Added] story for testing custom classes

--- a/apps/pie-storybook/stories/testing/icons.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/icons.test.stories.ts
@@ -58,6 +58,12 @@ const AlcoholFilledLargeIconWithOverrideTemplate: TemplateFunction<LargeIconProp
     </div>
 `;
 
+const AlcoholFilledIconWithClassTemplate: TemplateFunction<RegularIconProps> = ({ size }) => html`
+    <div class="c-iconGrid">
+        <icon-alcohol-filled size=${size} class="custom-class"></icon-alcohol-filled>
+    </div>
+`;
+
 export const AlcoholFilledRegularIcon = createStory(AlcoholFilledRegularIconTemplate, defaultRegularIconProps)({}, {
     layout: 'centered',
     argTypes: {
@@ -119,3 +125,16 @@ const largeIconPropMatrix : Partial<Record<keyof LargeIconProps, unknown[]>> = {
 };
 
 export const AlcoholFilledLargeIconVariations = createVariantStory<LargeIconProps>(AlcoholFilledLargeIconTemplate, largeIconPropMatrix);
+
+export const AlcoholFilledIconWithClass = createStory(AlcoholFilledIconWithClassTemplate, defaultRegularIconProps)({}, {
+    layout: 'centered',
+    argTypes: {
+        size: {
+            control: 'select',
+            options: regularIconSizes,
+            defaultValue: {
+                summary: regularIconSizeDefault,
+            },
+        },
+    },
+});

--- a/packages/tools/pie-icons-webc/PieIconComponent.ts
+++ b/packages/tools/pie-icons-webc/PieIconComponent.ts
@@ -57,7 +57,7 @@ export abstract class PieIconComponent extends LitElement {
     }
 
     updateIconSize (): void {
-        const svgSize = getSvgProps(this.class, '', this.size, this.name);
+        const svgSize = getSvgProps(this.className, '', this.size, this.name);
         this._svgWidth = svgSize.width;
         this._svgHeight = svgSize.height;
     }

--- a/packages/tools/pie-icons-webc/PieIconComponent.ts
+++ b/packages/tools/pie-icons-webc/PieIconComponent.ts
@@ -38,7 +38,13 @@ export abstract class PieIconComponent extends LitElement {
     protected _svgHeight!: string | number;
 
     protected abstract name: string;
+
     public abstract class: string;
+
+    /**
+     * These are the base classes and come from the SVG file during the build phase
+     */
+    protected defaultClasses = '';
 
     firstUpdated (): void {
         this.updateIconSize();
@@ -54,6 +60,15 @@ export abstract class PieIconComponent extends LitElement {
         const svgSize = getSvgProps(this.class, '', this.size, this.name);
         this._svgWidth = svgSize.width;
         this._svgHeight = svgSize.height;
+    }
+
+    attributeChangedCallback (name: string, oldVal: string | null, newVal: string | null) {
+        if (name === 'class' && newVal !== null) {
+            const incomingClasses = newVal.trim().split(' ').filter((cls) => !this.defaultClasses.split(' ').includes(cls));
+            this.class = [this.defaultClasses, ...incomingClasses].join(' ');
+        } else {
+            super.attributeChangedCallback(name, oldVal, newVal);
+        }
     }
 
     abstract render(): TemplateResult;

--- a/packages/tools/pie-icons-webc/build.js
+++ b/packages/tools/pie-icons-webc/build.js
@@ -42,6 +42,8 @@ const componentTemplate = (name, svg) => {
         @property({ type: String, reflect: true })
         public size: ${sizeType} = ${defaultSize};
 
+        protected defaultClasses = '${svgClasses}';
+
         // These classes also exist on the internal SVG element. However they are not used for anything on the SVG.
         @property({ type: String, reflect: true })
         public class = '${svgClasses}';

--- a/packages/tools/pie-icons-webc/test/component/icon-webc.spec.js
+++ b/packages/tools/pie-icons-webc/test/component/icon-webc.spec.js
@@ -81,3 +81,14 @@ test('large should have the default classes applied', async ({ page }) => {
     const icon = page.locator(icons.selectors.alcoholFilledLarge.dataTestId);
     await expect(icon).toHaveClass('c-pieIcon c-pieIcon--alcoholFilledLarge');
 });
+
+test('when extra classes are provided, the icon should render the expected classes', async ({ page }) => {
+    // Arrange
+    const regularIconPage = new BasePage(page, 'icons--alcohol-filled-icon-with-class');
+    await regularIconPage.load();
+    await page.waitForSelector(icons.selectors.alcoholFilled.dataTestId);
+
+    // Assert
+    const icon = page.locator(icons.selectors.alcoholFilled.dataTestId);
+    await expect(icon).toHaveClass('c-pieIcon c-pieIcon--alcoholFilled custom-class');
+});


### PR DESCRIPTION
- **fix(pie-icons-webc): DSW-3175 ensure base classes are never removed**
- **fix(pie-storybook): DSW-3175 add testing story**
- **fix(pie-icons-webc): DSW-3175 add browser test**
- **fix(pie-icons-webc): DSW-3175 fix size prop for large icons**
- **fix(pie-monorepo): DSW-3175 changeset**

Please click the `Preview` tab and select a different PR template if your change isn't for an                                            existing web component.

[PIE Docs Template](?expand=1&template=docs_template.md)
[New Web Component Template](?expand=1&template=new_component_template.md)

═══════════════════════════════════════════════════════════

## Describe your changes (can list changeset entries if preferable)


## Author Checklist (complete before requesting a review, do not delete any)
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [ ] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.
