### PR TITLE
fix(pie-monorepo): DSW-3309 issue where pie-webc-core wasn't availabl…

### DIFF
--- a/.changeset/real-numbers-refuse.md
+++ b/.changeset/real-numbers-refuse.md
@@ -2,4 +2,4 @@
 "@justeattakeaway/generator-pie-component": patch
 ---
 
-[Fixed] - Issue where CI test jobs weren't building `pie-webc-core` as part of setup
+[Fixed] - Issue where CI test jobs weren't building dependencies as part of setup

--- a/.changeset/real-numbers-refuse.md
+++ b/.changeset/real-numbers-refuse.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/generator-pie-component": patch
+---
+
+[Fixed] - Issue where CI test jobs weren't building `pie-webc-core` as part of setup

--- a/configs/pie-components-config/index.js
+++ b/configs/pie-components-config/index.js
@@ -1,6 +1,6 @@
 // @playwright/test config
-export * from './playwright-native-config.js';
-export * from './playwright-native-visual-config.js';
+export * from './playwright-native-config.ts';
+export * from './playwright-native-visual-config.ts';
 
 export * from './vite.config.js';
 export * from './custom-elements-manifest.config.js';

--- a/configs/pie-components-config/package.json
+++ b/configs/pie-components-config/package.json
@@ -13,8 +13,8 @@
     "vite.config.js",
     "tsconfig.json",
     "playwright/**",
-    "playwright-lit-config.js",
-    "playwright-lit-visual-config.js"
+    "playwright-native-config.ts",
+    "playwright-native-visual-config.ts"
   ],
   "dependencies": {
     "deepmerge-ts": "5.1.0"

--- a/configs/pie-components-config/playwright-native-config.js
+++ b/configs/pie-components-config/playwright-native-config.js
@@ -46,11 +46,11 @@ export function getPlaywrightNativeConfig () {
                 testMatch: ['**/test/accessibility/*.spec.{js,ts}'],
             },
         ],
-        // webServer: !process.env.CI ? {
-        //     command: 'npx turbo dev:testing --filter=@justeattakeaway/pie-storybook',
-        //     url: 'http://localhost:6007',
-        //     timeout: 120 * 10000,
-        //     reuseExistingServer: !process.env.CI,
-        // } : undefined,
+        webServer: !process.env.CI ? {
+            command: 'npx turbo dev:testing --filter=@justeattakeaway/pie-storybook',
+            url: 'http://localhost:6007',
+            timeout: 120 * 10000,
+            reuseExistingServer: !process.env.CI,
+        } : undefined,
     };
 }

--- a/configs/pie-components-config/playwright-native-config.js
+++ b/configs/pie-components-config/playwright-native-config.js
@@ -46,11 +46,11 @@ export function getPlaywrightNativeConfig () {
                 testMatch: ['**/test/accessibility/*.spec.{js,ts}'],
             },
         ],
-        webServer: !process.env.CI ? {
-            command: 'npx turbo dev:testing --filter=@justeattakeaway/pie-storybook',
-            url: 'http://localhost:6007',
-            timeout: 120 * 10000,
-            reuseExistingServer: !process.env.CI,
-        } : undefined,
+        // webServer: !process.env.CI ? {
+        //     command: 'npx turbo dev:testing --filter=@justeattakeaway/pie-storybook',
+        //     url: 'http://localhost:6007',
+        //     timeout: 120 * 10000,
+        //     reuseExistingServer: !process.env.CI,
+        // } : undefined,
     };
 }

--- a/configs/pie-components-config/playwright-native-config.ts
+++ b/configs/pie-components-config/playwright-native-config.ts
@@ -3,7 +3,7 @@ import { devices } from '@playwright/test';
 /**
  * See https://playwright.dev/docs/test-configuration
  */
-export function getPlaywrightNativeConfig () {
+export function getPlaywrightNativeConfig() {
     return {
         /* The base directory, relative to the config file, for snapshot files created with toMatchSnapshot and toHaveScreenshot. */
         snapshotDir: './__snapshots__',

--- a/configs/pie-components-config/playwright-native-visual-config.ts
+++ b/configs/pie-components-config/playwright-native-visual-config.ts
@@ -3,7 +3,7 @@ import { devices } from '@playwright/test';
 /**
  * See https://playwright.dev/docs/test-configuration
  */
-export function getPlaywrightNativeVisualConfig () {
+export function getPlaywrightNativeVisualConfig() {
     return {
         /* Maximum time one test can run for. */
         timeout: 10 * 1000,

--- a/packages/components/pie-assistive-text/turbo.json
+++ b/packages/components/pie-assistive-text/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-assistive-text.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-assistive-text.test.stories.ts"

--- a/packages/components/pie-assistive-text/turbo.json
+++ b/packages/components/pie-assistive-text/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-assistive-text.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-assistive-text.test.stories.ts"

--- a/packages/components/pie-avatar/turbo.json
+++ b/packages/components/pie-avatar/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-avatar.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-avatar.test.stories.ts"

--- a/packages/components/pie-avatar/turbo.json
+++ b/packages/components/pie-avatar/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-avatar.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-avatar.test.stories.ts"

--- a/packages/components/pie-breadcrumb/turbo.json
+++ b/packages/components/pie-breadcrumb/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-breadcrumb.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-breadcrumb.test.stories.ts"

--- a/packages/components/pie-breadcrumb/turbo.json
+++ b/packages/components/pie-breadcrumb/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-breadcrumb.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-breadcrumb.test.stories.ts"

--- a/packages/components/pie-button/turbo.json
+++ b/packages/components/pie-button/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"

--- a/packages/components/pie-button/turbo.json
+++ b/packages/components/pie-button/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-button.test.stories.ts"

--- a/packages/components/pie-card/turbo.json
+++ b/packages/components/pie-card/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-card.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-card.test.stories.ts"

--- a/packages/components/pie-card/turbo.json
+++ b/packages/components/pie-card/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-card.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-card.test.stories.ts"

--- a/packages/components/pie-checkbox-group/turbo.json
+++ b/packages/components/pie-checkbox-group/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox-group.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox-group.test.stories.ts"

--- a/packages/components/pie-checkbox-group/turbo.json
+++ b/packages/components/pie-checkbox-group/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox-group.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox-group.test.stories.ts"

--- a/packages/components/pie-checkbox/turbo.json
+++ b/packages/components/pie-checkbox/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox.test.stories.ts"

--- a/packages/components/pie-checkbox/turbo.json
+++ b/packages/components/pie-checkbox/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-checkbox.test.stories.ts"

--- a/packages/components/pie-chip/turbo.json
+++ b/packages/components/pie-chip/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-chip.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-chip.test.stories.ts"

--- a/packages/components/pie-chip/turbo.json
+++ b/packages/components/pie-chip/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-chip.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-chip.test.stories.ts"

--- a/packages/components/pie-cookie-banner/turbo.json
+++ b/packages/components/pie-cookie-banner/turbo.json
@@ -25,7 +25,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-cookie-banner.test.stories.ts"
@@ -41,7 +41,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-cookie-banner.test.stories.ts"

--- a/packages/components/pie-cookie-banner/turbo.json
+++ b/packages/components/pie-cookie-banner/turbo.json
@@ -25,7 +25,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-cookie-banner.test.stories.ts"
@@ -41,7 +41,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-cookie-banner.test.stories.ts"

--- a/packages/components/pie-data-table/turbo.json
+++ b/packages/components/pie-data-table/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-data-table.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-data-table.test.stories.ts"

--- a/packages/components/pie-data-table/turbo.json
+++ b/packages/components/pie-data-table/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-data-table.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-data-table.test.stories.ts"

--- a/packages/components/pie-divider/turbo.json
+++ b/packages/components/pie-divider/turbo.json
@@ -14,7 +14,7 @@
       },
       "test:browsers:ci": {
         "cache": true,
-        "dependsOn": [],
+        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-divider.test.stories.ts"
@@ -30,7 +30,7 @@
       },
       "test:visual:ci": {
         "cache": false,
-        "dependsOn": [],
+        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-divider.test.stories.ts"

--- a/packages/components/pie-divider/turbo.json
+++ b/packages/components/pie-divider/turbo.json
@@ -14,7 +14,7 @@
       },
       "test:browsers:ci": {
         "cache": true,
-        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+        "dependsOn": ["^build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-divider.test.stories.ts"
@@ -30,7 +30,7 @@
       },
       "test:visual:ci": {
         "cache": false,
-        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+        "dependsOn": ["^build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-divider.test.stories.ts"

--- a/packages/components/pie-form-label/turbo.json
+++ b/packages/components/pie-form-label/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-form-label.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-form-label.test.stories.ts"

--- a/packages/components/pie-form-label/turbo.json
+++ b/packages/components/pie-form-label/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-form-label.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-form-label.test.stories.ts"

--- a/packages/components/pie-icon-button/turbo.json
+++ b/packages/components/pie-icon-button/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-icon-button.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-icon-button.test.stories.ts"

--- a/packages/components/pie-icon-button/turbo.json
+++ b/packages/components/pie-icon-button/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-icon-button.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-icon-button.test.stories.ts"

--- a/packages/components/pie-link/turbo.json
+++ b/packages/components/pie-link/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-link.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-link.test.stories.ts"

--- a/packages/components/pie-link/turbo.json
+++ b/packages/components/pie-link/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-link.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-link.test.stories.ts"

--- a/packages/components/pie-list/turbo.json
+++ b/packages/components/pie-list/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-list.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-list.test.stories.ts"

--- a/packages/components/pie-list/turbo.json
+++ b/packages/components/pie-list/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-list.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-list.test.stories.ts"

--- a/packages/components/pie-lottie-player/test/component/pie-lottie-player.spec.ts
+++ b/packages/components/pie-lottie-player/test/component/pie-lottie-player.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { LottiePlayerDefaultPage } from '../helpers/page-object/pie-lottie-player-default.page.ts';
-import { type LottiePlayerProps } from '../../src/index.ts';
+import { type LottiePlayerProps } from '../../src/defs.ts';
 
 test.describe('PieLottiePlayer - Component tests', () => {
     test('should render successfully', async ({ page }) => {
@@ -15,7 +15,7 @@ test.describe('PieLottiePlayer - Component tests', () => {
         await expect(lottiePlayerComponent).toBeVisible();
     });
 
-    test.describe('when props are not provided"', () => {
+    test.describe('when props are not provided', () => {
         test('should render the expected default props', async ({ page }) => {
             // Arrange
             const lottiePlayerPage = new LottiePlayerDefaultPage(page);

--- a/packages/components/pie-lottie-player/test/visual/pie-lottie-player.spec.ts
+++ b/packages/components/pie-lottie-player/test/visual/pie-lottie-player.spec.ts
@@ -1,9 +1,9 @@
 import { test } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
 import { LottiePlayerDefaultPage } from 'test/helpers/page-object/pie-lottie-player-default.page.ts';
-import { type LottiePlayerProps } from '../../src/index.ts';
+import { type LottiePlayerProps } from '../../src/defs.ts';
 
-test.describe('PieLottiePlayer - Visual tests`', () => {
+test.describe('PieLottiePlayer - Visual tests', () => {
     test('should display the PieLottiePlayer component successfully', async ({ page }) => {
         // Arrange
         const props: LottiePlayerProps = {

--- a/packages/components/pie-lottie-player/turbo.json
+++ b/packages/components/pie-lottie-player/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-lottie-player.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-lottie-player.test.stories.ts"

--- a/packages/components/pie-lottie-player/turbo.json
+++ b/packages/components/pie-lottie-player/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-lottie-player.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-lottie-player.test.stories.ts"

--- a/packages/components/pie-modal/turbo.json
+++ b/packages/components/pie-modal/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-modal.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-modal.test.stories.ts"

--- a/packages/components/pie-modal/turbo.json
+++ b/packages/components/pie-modal/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-modal.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-modal.test.stories.ts"

--- a/packages/components/pie-notification/turbo.json
+++ b/packages/components/pie-notification/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"

--- a/packages/components/pie-notification/turbo.json
+++ b/packages/components/pie-notification/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-notification.test.stories.ts"

--- a/packages/components/pie-radio-group/turbo.json
+++ b/packages/components/pie-radio-group/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts"

--- a/packages/components/pie-radio-group/turbo.json
+++ b/packages/components/pie-radio-group/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio-group.test.stories.ts"

--- a/packages/components/pie-radio/turbo.json
+++ b/packages/components/pie-radio/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio.test.stories.ts"

--- a/packages/components/pie-radio/turbo.json
+++ b/packages/components/pie-radio/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-radio.test.stories.ts"

--- a/packages/components/pie-select/turbo.json
+++ b/packages/components/pie-select/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-select.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-select.test.stories.ts"

--- a/packages/components/pie-select/turbo.json
+++ b/packages/components/pie-select/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-select.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-select.test.stories.ts"

--- a/packages/components/pie-spinner/turbo.json
+++ b/packages/components/pie-spinner/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-spinner.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-spinner.test.stories.ts"

--- a/packages/components/pie-spinner/turbo.json
+++ b/packages/components/pie-spinner/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-spinner.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-spinner.test.stories.ts"

--- a/packages/components/pie-switch/turbo.json
+++ b/packages/components/pie-switch/turbo.json
@@ -14,7 +14,7 @@
       },
       "test:browsers:ci": {
         "cache": true,
-        "dependsOn": [],
+        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-switch.test.stories.ts"
@@ -30,7 +30,7 @@
       },
       "test:visual:ci": {
         "cache": false,
-        "dependsOn": [],
+        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-switch.test.stories.ts"

--- a/packages/components/pie-switch/turbo.json
+++ b/packages/components/pie-switch/turbo.json
@@ -14,7 +14,7 @@
       },
       "test:browsers:ci": {
         "cache": true,
-        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+        "dependsOn": ["^build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-switch.test.stories.ts"
@@ -30,7 +30,7 @@
       },
       "test:visual:ci": {
         "cache": false,
-        "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+        "dependsOn": ["^build"],
         "inputs": [
           "$TURBO_DEFAULT$",
           "../../../apps/pie-storybook/stories/testing/pie-switch.test.stories.ts"

--- a/packages/components/pie-tag/turbo.json
+++ b/packages/components/pie-tag/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"

--- a/packages/components/pie-tag/turbo.json
+++ b/packages/components/pie-tag/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-tag.test.stories.ts"

--- a/packages/components/pie-text-input/turbo.json
+++ b/packages/components/pie-text-input/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-text-input.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-text-input.test.stories.ts"

--- a/packages/components/pie-text-input/turbo.json
+++ b/packages/components/pie-text-input/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-text-input.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-text-input.test.stories.ts"

--- a/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
@@ -6,7 +6,7 @@ import { textArea } from '../helpers/page-objects/selectors.ts';
 
 import { statusTypes } from '../../src/defs.ts';
 
-test.describe('PieTextarea - Component tests', () => {
+test.describe.skip('PieTextarea - Component tests', () => {
     test('should render successfully', async ({ page }) => {
         // Arrange
         const textAreaPage = new BasePage(page, 'textarea');

--- a/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/component/pie-textarea.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
-import { type PieTextarea, type TextareaProps } from '../../src/index.ts';
+import type { PieTextarea, TextareaProps } from '../../src/index.ts';
 
 import { textArea } from '../helpers/page-objects/selectors.ts';
 
 import { statusTypes } from '../../src/defs.ts';
 
-test.describe.skip('PieTextarea - Component tests', () => {
+test.describe('PieTextarea - Component tests', () => {
     test('should render successfully', async ({ page }) => {
         // Arrange
         const textAreaPage = new BasePage(page, 'textarea');

--- a/packages/components/pie-textarea/turbo.json
+++ b/packages/components/pie-textarea/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-textarea.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-textarea.test.stories.ts"

--- a/packages/components/pie-textarea/turbo.json
+++ b/packages/components/pie-textarea/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-textarea.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-textarea.test.stories.ts"

--- a/packages/components/pie-thumbnail/turbo.json
+++ b/packages/components/pie-thumbnail/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-thumbnail.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-thumbnail.test.stories.ts"

--- a/packages/components/pie-thumbnail/turbo.json
+++ b/packages/components/pie-thumbnail/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-thumbnail.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-thumbnail.test.stories.ts"

--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 
-import { type PieToastProvider } from 'src/index.ts';
+import type { PieToastProvider } from 'src/index.ts';
 import { defaultProps as toastDefaultProps } from '@justeattakeaway/pie-toast/src/defs.ts';
 import {
     PRIORITY_ORDER,
@@ -11,7 +11,7 @@ import {
 
 import { toastProvider } from '../helpers/page-object/selectors.ts';
 
-test.describe.skip('PieToastProvider - Component tests', () => {
+test.describe('PieToastProvider - Component tests', () => {
     let toastsQueue: ExtendedToastProps[] = [];
 
     test.beforeEach(({ page }) => {

--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -11,7 +11,7 @@ import {
 
 import { toastProvider } from '../helpers/page-object/selectors.ts';
 
-test.describe('PieToastProvider - Component tests', () => {
+test.describe.skip('PieToastProvider - Component tests', () => {
     let toastsQueue: ExtendedToastProps[] = [];
 
     test.beforeEach(({ page }) => {

--- a/packages/components/pie-toast-provider/turbo.json
+++ b/packages/components/pie-toast-provider/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts"

--- a/packages/components/pie-toast-provider/turbo.json
+++ b/packages/components/pie-toast-provider/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast-provider.test.stories.ts"

--- a/packages/components/pie-toast/turbo.json
+++ b/packages/components/pie-toast/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast.test.stories.ts"

--- a/packages/components/pie-toast/turbo.json
+++ b/packages/components/pie-toast/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-toast.test.stories.ts"

--- a/packages/components/pie-webc-core/turbo.json
+++ b/packages/components/pie-webc-core/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts"

--- a/packages/tools/generator-pie-component/src/app/templates/turbo.json
+++ b/packages/tools/generator-pie-component/src/app/templates/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-<%= fileName %>.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-<%= fileName %>.test.stories.ts"

--- a/packages/tools/generator-pie-component/src/app/templates/turbo.json
+++ b/packages/tools/generator-pie-component/src/app/templates/turbo.json
@@ -14,7 +14,7 @@
     },
     "test:browsers:ci": {
       "cache": true,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-<%= fileName %>.test.stories.ts"
@@ -30,7 +30,7 @@
     },
     "test:visual:ci": {
       "cache": false,
-      "dependsOn": [],
+      "dependsOn": ["@justeattakeaway/pie-webc-core#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../../apps/pie-storybook/stories/testing/pie-<%= fileName %>.test.stories.ts"


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
For some reason, CI has started failing test jobs with the following error:

`Error: Cannot find package '/home/runner/work/pie/pie/node_modules/@justeattakeaway/pie-toast/dist/index.js' imported from /home/runner/work/pie/pie/packages/components/pie-toast-provider/src/defs.ts`

The reason for this, is that a base type is imported into all component `def.ts` files:
```
// pie-button defs.ts
import { type ComponentDefaultProps } from '@justeattakeaway/pie-webc-core';
```

We often import these def files into the test specs to allow us to use them as a source-of-truth for which component prop variations we need to test.

**Reason for the error**
Currently in CI, when we run the `test:browsers:ci`, we don't run as dependant tasks (such as build etc). - The original intention for this, was because we run tests against the deployed Storybook instance, there's no need to build components etc. However, be didn't account for dependency `dists` being used within the spec file itself

>[!NOTE]
>I'm only adding this to the `test:browsers:ci` script as this issue won't happen locally. This is because when running locally, as part of the Playwright setup, we have this line to start Storybook which will run a `build` of all components as part of it's setup:

```
        webServer: !process.env.CI ? {
            command: 'npx turbo dev:testing --filter=@justeattakeaway/pie-storybook',
            url: 'http://localhost:6007',
            timeout: 120 * 10000,
            reuseExistingServer: !process.env.CI,
        } : undefined,
```

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [-] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [-] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 @raoufswe 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @JoshuaNg2332 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
