### PR TITLE
ci(pie-monorepo): DSW-3344 fix typo that causes Percy errors in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         uses: ./.github/actions/run-script
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         with:
-          script-name: "test:visual:ci --filter='{./packages/components/*}...[HEAD^1] --filter='{./packages/tools/*}...[HEAD^1]'"
+          script-name: "test:visual:ci --filter='{./packages/components/*}...[HEAD^1]' --filter='{./packages/tools/*}...[HEAD^1]'"
           concurrency: 1
       - name: Run Visual Tests for changed packages and dependents since origin/main
         uses: ./.github/actions/run-script


### PR DESCRIPTION
Fixes typo that was causing Percy tests to fail in `main`.