### PR TITLE
fix(pie-modal): DSW-3317 properly pass aria to icon buttons

### DIFF
--- a/.changeset/khaki-windows-shout.md
+++ b/.changeset/khaki-windows-shout.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": patch
+---
+
+[Fixed] - Correctly provide aria labels to pie-icon-button instances inside the modal.

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -355,7 +355,7 @@ export class PieModal extends PieElement implements ModalProps {
                 @click="${() => { this.isOpen = false; }}"
                 variant="ghost-secondary"
                 class="c-modal-closeBtn"
-                aria-label="${this.aria?.close || nothing}"
+                .aria=${ifDefined(this.aria?.close) ? { label: this.aria?.close } : nothing}
                 data-test-id="modal-close-button">
                 <icon-close></icon-close>
             </pie-icon-button>`;
@@ -377,9 +377,9 @@ export class PieModal extends PieElement implements ModalProps {
                 @click="${() => { this._backButtonClicked = true; this.isOpen = false; }}"
                 variant="ghost-secondary"
                 class="c-modal-backBtn"
-                aria-label="${ifDefined(this.aria?.back)}"
+                .aria=${ifDefined(this.aria?.back) ? { label: this.aria?.back } : nothing}
                 data-test-id="modal-back-button">
-                    <icon-chevron-left class="c-modal-backBtn-icon"></icon-chevron-right>
+                    <icon-chevron-left class="c-modal-backBtn-icon"></icon-chevron-left>
             </pie-icon-button>
         `;
     }


### PR DESCRIPTION
- Correctly passes aria labels down to icon button for close and back buttons in the modal component