### PR TITLE
fix(pie-modal): DSW-3317 allow SRs to announce heading/aria label

### DIFF
--- a/.changeset/mean-wombats-laugh.md
+++ b/.changeset/mean-wombats-laugh.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-modal": minor
+---
+
+[Changed] - Ensure screenreaders announce modal labels and add aria-label property. Remove aria-busy=false when not isLoading

--- a/apps/pie-storybook/stories/pie-modal.stories.ts
+++ b/apps/pie-storybook/stories/pie-modal.stories.ts
@@ -40,6 +40,7 @@ const defaultArgs: ModalProps = {
         back: 'Back',
         close: 'Close',
         loading: 'Loading',
+        label: 'A custom modal label',
     },
 };
 

--- a/packages/components/pie-modal/src/defs.ts
+++ b/packages/components/pie-modal/src/defs.ts
@@ -10,6 +10,7 @@ type AriaProps = {
     close?: string;
     back?: string;
     loading?: string;
+    label?: string;
 };
 
 type ActionProps = {
@@ -151,7 +152,7 @@ export const ON_MODAL_SUPPORTING_ACTION_CLICK = 'pie-modal-supporting-action-cli
 
 export type ModalActionType = 'leading' | 'supporting';
 
-export type DefaultProps = ComponentDefaultProps<ModalProps, keyof Omit<ModalProps, 'aria' | 'heading' | 'leadingAction' | 'supportingAction' | 'returnFocusAfterCloseSelector'>>;
+export type DefaultProps = ComponentDefaultProps<ModalProps, keyof Omit<ModalProps, 'aria' | 'heading' | 'isLoading' | 'leadingAction' | 'supportingAction' | 'returnFocusAfterCloseSelector'>>;
 
 export const defaultProps: DefaultProps = {
     hasBackButton: false,
@@ -161,7 +162,6 @@ export const defaultProps: DefaultProps = {
     isDismissible: false,
     isFooterPinned: true,
     isFullWidthBelowMid: false,
-    isLoading: false,
     position: 'center',
     size: 'medium',
 };

--- a/packages/components/pie-modal/src/index.ts
+++ b/packages/components/pie-modal/src/index.ts
@@ -525,7 +525,7 @@ export class PieModal extends PieElement implements ModalProps {
             size,
         } = this;
 
-        const ariaLabel = (isLoading && aria?.loading) || undefined;
+        const ariaLabel = (isLoading && aria?.loading) || this.aria?.label || this.heading || undefined;
 
         const modalClasses = {
             'c-modal': true,
@@ -541,7 +541,7 @@ export class PieModal extends PieElement implements ModalProps {
         <dialog
             id="dialog"
             class="${classMap(modalClasses)}"
-            aria-busy="${isLoading ? 'true' : 'false'}"
+            aria-busy="${ifDefined(isLoading || undefined)}"
             aria-label="${ifDefined(ariaLabel)}"
             data-test-id="pie-modal">
             <header class="c-modal-header" data-test-id="modal-header">


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Allow an aria labe to be passed directly to the dialog element
- Falls back to heading text if none provided
- Remove `aria-busy="false"` if `isLoading` is false