### PR TITLE
chore(pie-monorepo): DSW-3390 tighten codeowners rules

### DIFF
--- a/.changeset/gorgeous-lies-mate.md
+++ b/.changeset/gorgeous-lies-mate.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Changed] - Remove all CODEOWNERS apart from the ui-reviewers-design-system-senior group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,2 @@
 # By default, the design system UI reviewers should be the default owners for everything
-* @justeattakeaway/ui-reviewers-design-system @justeattakeaway/ui-reviewers-design-system-senior
-
-# We would like the design system UI reviewers _and_ design system designers to review docs site and component changes
-/apps/pie-docs @justeattakeaway/ui-reviewers-design-system @justeattakeaway/ui-reviewers-design-system-designers
-
-/packages/components/* @justeattakeaway/ui-reviewers-design-system @justeattakeaway/ui-reviewers-design-system-designers
+* @justeattakeaway/ui-reviewers-design-system-senior


### PR DESCRIPTION
Tighten up the CODEOWNERS file so only the senior engineer group will be a required approver. This, in combination with a change in the repo settings means that going forward we will require *1* reviewer (one of the codeowners) to merge PRs. However we advise 2 reviews in most cases.

<img width="1365" height="365" alt="Screenshot 2025-10-02 at 17 00 05" src="https://github.com/user-attachments/assets/3bf24fa2-a394-439c-88a0-6df5ac609ff0" />
