### PR TITLE
ci(pie-monorepo): DSW-3816 tidyup app token generation

### DIFF
--- a/.github/actions/amplify-teardown/action.yml
+++ b/.github/actions/amplify-teardown/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
   - name: 🎟 Get GitHub App token
-    uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1 
+    uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
     id: get-token
     with:
       app-id: ${{ inputs.gh-app-id }}

--- a/.github/workflows/amplify-deploy.yml
+++ b/.github/workflows/amplify-deploy.yml
@@ -76,6 +76,13 @@ jobs:
           role-session-name: github-actions-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Generate GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       # Process package name to remove prefix
       - name: Remove scope from package name
         run: |
@@ -113,7 +120,7 @@ jobs:
         uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1 # v2.0.7
         id: deploy
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           environment: "${{ inputs.sub-domain-suffix }}-pr-${{ github.event.number }}"
       # Zip dist folder
       - name: Zip build output
@@ -236,7 +243,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && success() }}
         uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806 # v2.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           environment-url: https://${{ env.SUB_DOMAIN }}.pie.design/
           deployment-id: ${{ steps.deploy.outputs.deployment_id }}
           state: "success"
@@ -246,7 +253,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && failure() }}
         uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806 # v2.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           environment-url: https://${{ env.SUB_DOMAIN }}.pie.design/
           deployment-id: ${{ steps.deploy.outputs.deployment_id }}
           state: "failure"

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -62,7 +62,7 @@ jobs:
         os: ${{ inputs.os }}
     - name: Generate GitHub App token
       id: get-token
-      uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
         app-id: ${{ vars.GH_APP_ID }}
         private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/changeset-snapshot.yml
+++ b/.github/workflows/changeset-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: get-token
-        uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/closed.yml
+++ b/.github/workflows/closed.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: get-token
-        uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/dangerjs-checks.yml
+++ b/.github/workflows/dangerjs-checks.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - name: Generate GitHub App token
         id: get-token
-        uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/labeler-set-labels.yml
+++ b/.github/workflows/labeler-set-labels.yml
@@ -16,10 +16,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Generate GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Download artifact and set labels
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const script = require('./packages/tools/pie-monorepo-utils/pr-labeler/set-labels.js');
             await script({ github, context });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,10 +10,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - name: Generate GitHub App token
+      id: get-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      with:
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
     - name: Labeler
       uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
       with:
         configuration-path: '.github/project-labeler.yml'
-        repo-token: '${{ secrets.GITHUB_TOKEN }}'
+        repo-token: '${{ steps.get-token.outputs.token }}'
         # Category labels will be removed if they no longer apply
         sync-labels: true

--- a/.github/workflows/test-aperture.yml
+++ b/.github/workflows/test-aperture.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: get-token
-        uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: get-token
-        uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681 # v1.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Tidy up task to use short-lived app tokens in our CI workflows. Also moves us onto using the official GH App token workflow rather than a community tool

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
