### PR TITLE
ci(pie-monorepo-utils): DSW-3811 fix changeset peerdep upgrades

### DIFF
--- a/.changeset/clear-mammals-wonder.md
+++ b/.changeset/clear-mammals-wonder.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-webc-core": patch
+"@justeattakeaway/stylelint-config-pie": patch
+---
+
+[Changed] - updated pie-css peerDep to non-pinned version

--- a/.changeset/light-garlics-help.md
+++ b/.changeset/light-garlics-help.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-monorepo-utils": minor
+---
+
+[Added] - preserve-peer-dep-ranges which makes changeset preserve fuzzy peerDep ranges when upgrading

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ custom-elements.json
 # Yalc
 .yalc
 yalc.lock
+
+# Changeset peer dep range snapshot (temp file)
+.changeset/.peer-dep-ranges-snapshot.json

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "changeset": "changeset && npx detect-webc-major-version",
     "changeset:publish": "changeset publish",
     "changeset:snapshot": "changeset version --snapshot snapshot-release",
-    "changeset:version": "changeset version && yarn --mode update-lockfile",
+    "changeset:version": "./packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/changeset-version.sh",
     "chromatic": "chromatic --exit-zero-on-changes",
     "clean": "turbo run clean --filter=!pie-monorepo",
     "cz": "./packages/tools/pie-monorepo-utils/git-hooks/check-branch-name.js $(git symbolic-ref --short HEAD) && ./node_modules/cz-customizable/standalone.js",

--- a/packages/components/pie-webc-core/package.json
+++ b/packages/components/pie-webc-core/package.json
@@ -28,7 +28,7 @@
     "lit": "3.2.0"
   },
   "peerDependencies": {
-    "@justeattakeaway/pie-css": "1.1.0"
+    "@justeattakeaway/pie-css": "1.x"
   },
   "devDependencies": {
     "@justeattakeaway/pie-components-config": "0.21.0"

--- a/packages/tools/pie-monorepo-utils/__tests__/preserve-peer-dep-ranges/preserve-peer-dep-ranges.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/preserve-peer-dep-ranges/preserve-peer-dep-ranges.test.js
@@ -1,0 +1,352 @@
+import {
+    describe, it, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import {
+    isRange,
+    isInternalDep,
+    buildSnapshot,
+    saveSnapshot,
+    restoreFromSnapshot,
+} from '../../preserve-peer-dep-ranges/preserve-peer-dep-ranges';
+
+/**
+ * Creates a temporary workspace directory structure for testing.
+ * Returns { root, cleanup } where root is the temp dir path.
+ */
+function createTempWorkspace (packages = []) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'peer-dep-test-'));
+
+    // Root package.json with workspaces config
+    fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify({
+            name: 'test-monorepo',
+            workspaces: { packages: ['packages/*'] },
+        }, null, 2),
+    );
+
+    // Create yarn.lock so findMonorepoRoot can locate the root
+    fs.writeFileSync(path.join(root, 'yarn.lock'), '');
+
+    // Create each package
+    fs.mkdirSync(path.join(root, 'packages'), { recursive: true });
+    for (const pkg of packages) {
+        const pkgDir = path.join(root, 'packages', pkg.dirName);
+        fs.mkdirSync(pkgDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(pkgDir, 'package.json'),
+            JSON.stringify(pkg.packageJson, null, 2),
+        );
+    }
+
+    const cleanup = () => fs.rmSync(root, { recursive: true, force: true });
+
+    return { root, cleanup };
+}
+
+describe('preserve-peer-dep-ranges', () => {
+    describe('isRange', () => {
+        it('should return true for wildcard *', () => {
+            expect(isRange('*')).toBe(true);
+        });
+
+        it('should return true for .x ranges', () => {
+            expect(isRange('1.x')).toBe(true);
+            expect(isRange('2.x')).toBe(true);
+            expect(isRange('16.x')).toBe(true);
+            expect(isRange('1.0.x')).toBe(true);
+        });
+
+        it('should return true for caret ranges', () => {
+            expect(isRange('^1.0.0')).toBe(true);
+            expect(isRange('^2.3.4')).toBe(true);
+        });
+
+        it('should return true for tilde ranges', () => {
+            expect(isRange('~1.0.0')).toBe(true);
+            expect(isRange('~2.3.4')).toBe(true);
+        });
+
+        it('should return true for comparator ranges', () => {
+            expect(isRange('>=1.0.0')).toBe(true);
+            expect(isRange('>1')).toBe(true);
+            expect(isRange('<2.0.0')).toBe(true);
+            expect(isRange('<=3.0.0')).toBe(true);
+        });
+
+        it('should return true for union ranges', () => {
+            expect(isRange('^1.0.0 || ^2.0.0')).toBe(true);
+        });
+
+        it('should return false for exact versions', () => {
+            expect(isRange('1.0.0')).toBe(false);
+            expect(isRange('0.26.21')).toBe(false);
+            expect(isRange('14.0.0')).toBe(false);
+            expect(isRange('1.1.0')).toBe(false);
+        });
+    });
+
+    describe('isInternalDep', () => {
+        it('should return true for @justeattakeaway/ scoped packages', () => {
+            expect(isInternalDep('@justeattakeaway/pie-css')).toBe(true);
+            expect(isInternalDep('@justeattakeaway/pie-webc-core')).toBe(true);
+        });
+
+        it('should return true for @justeat/ scoped packages', () => {
+            expect(isInternalDep('@justeat/pie-design-tokens')).toBe(true);
+        });
+
+        it('should return false for external packages', () => {
+            expect(isInternalDep('stylelint')).toBe(false);
+            expect(isInternalDep('@playwright/test')).toBe(false);
+            expect(isInternalDep('lit')).toBe(false);
+        });
+    });
+
+    describe('buildSnapshot', () => {
+        let workspace;
+
+        afterEach(() => {
+            if (workspace) workspace.cleanup();
+        });
+
+        it('should detect internal peer deps with range formats', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            '@justeattakeaway/pie-css': '1.x',
+                        },
+                    },
+                },
+            ]);
+
+            const snapshot = buildSnapshot(workspace.root);
+            const entries = Object.values(snapshot);
+
+            expect(entries).toHaveLength(1);
+            expect(entries[0].name).toBe('@justeattakeaway/pkg-a');
+            expect(entries[0].ranges).toEqual({
+                '@justeattakeaway/pie-css': '1.x',
+            });
+        });
+
+        it('should ignore internal peer deps with exact versions', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            '@justeattakeaway/pie-css': '1.1.0',
+                        },
+                    },
+                },
+            ]);
+
+            const snapshot = buildSnapshot(workspace.root);
+            expect(Object.keys(snapshot)).toHaveLength(0);
+        });
+
+        it('should ignore external peer deps even if they use ranges', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            stylelint: '16.x',
+                            '@playwright/test': '^1.0.0',
+                        },
+                    },
+                },
+            ]);
+
+            const snapshot = buildSnapshot(workspace.root);
+            expect(Object.keys(snapshot)).toHaveLength(0);
+        });
+
+        it('should handle packages with no peerDependencies', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        dependencies: { lit: '3.2.0' },
+                    },
+                },
+            ]);
+
+            const snapshot = buildSnapshot(workspace.root);
+            expect(Object.keys(snapshot)).toHaveLength(0);
+        });
+
+        it('should snapshot multiple packages', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            '@justeattakeaway/pie-css': '1.x',
+                        },
+                    },
+                },
+                {
+                    dirName: 'pkg-b',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-b',
+                        peerDependencies: {
+                            '@justeat/pie-design-tokens': '*',
+                            '@justeattakeaway/pie-css': '^1.0.0',
+                        },
+                    },
+                },
+            ]);
+
+            const snapshot = buildSnapshot(workspace.root);
+            const entries = Object.values(snapshot);
+
+            expect(entries).toHaveLength(2);
+
+            const pkgB = entries.find((e) => e.name === '@justeattakeaway/pkg-b');
+            expect(pkgB.ranges).toEqual({
+                '@justeat/pie-design-tokens': '*',
+                '@justeattakeaway/pie-css': '^1.0.0',
+            });
+        });
+    });
+
+    describe('saveSnapshot + restoreFromSnapshot', () => {
+        let workspace;
+        let snapshotPath;
+
+        afterEach(() => {
+            if (workspace) workspace.cleanup();
+        });
+
+        it('should restore clobbered ranges to their original values', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            '@justeattakeaway/pie-css': '1.x',
+                        },
+                    },
+                },
+            ]);
+
+            snapshotPath = path.join(workspace.root, '.snapshot.json');
+
+            // 1. Build and save snapshot
+            const snapshot = buildSnapshot(workspace.root);
+            saveSnapshot(snapshotPath, snapshot);
+
+            // 2. Simulate changeset clobbering the range
+            const pkgPath = Object.keys(snapshot)[0];
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            pkg.peerDependencies['@justeattakeaway/pie-css'] = '1.1.0';
+            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+            // 3. Restore
+            const { found, restorations } = restoreFromSnapshot(snapshotPath);
+
+            expect(found).toBe(true);
+            expect(restorations).toHaveLength(1);
+            expect(restorations[0]).toEqual({
+                package: '@justeattakeaway/pkg-a',
+                dep: '@justeattakeaway/pie-css',
+                from: '1.1.0',
+                to: '1.x',
+            });
+
+            // 4. Verify the file on disk was updated
+            const restored = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            expect(restored.peerDependencies['@justeattakeaway/pie-css']).toBe('1.x');
+
+            // 5. Verify snapshot file was deleted
+            expect(fs.existsSync(snapshotPath)).toBe(false);
+        });
+
+        it('should return found=true with empty restorations when nothing was clobbered', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            '@justeattakeaway/pie-css': '1.x',
+                        },
+                    },
+                },
+            ]);
+
+            snapshotPath = path.join(workspace.root, '.snapshot.json');
+            const snapshot = buildSnapshot(workspace.root);
+            saveSnapshot(snapshotPath, snapshot);
+
+            // Do NOT clobber anything — restore immediately
+            const { found, restorations } = restoreFromSnapshot(snapshotPath);
+
+            expect(found).toBe(true);
+            expect(restorations).toHaveLength(0);
+            expect(fs.existsSync(snapshotPath)).toBe(false);
+        });
+
+        it('should return found=false when no snapshot file exists', () => {
+            const { found, restorations } = restoreFromSnapshot('/tmp/nonexistent-snapshot.json');
+
+            expect(found).toBe(false);
+            expect(restorations).toHaveLength(0);
+        });
+
+        it('should handle multiple packages with mixed clobbered and unclobbered ranges', () => {
+            workspace = createTempWorkspace([
+                {
+                    dirName: 'pkg-a',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-a',
+                        peerDependencies: {
+                            '@justeattakeaway/pie-css': '1.x',
+                        },
+                    },
+                },
+                {
+                    dirName: 'pkg-b',
+                    packageJson: {
+                        name: '@justeattakeaway/pkg-b',
+                        peerDependencies: {
+                            '@justeat/pie-design-tokens': '*',
+                        },
+                    },
+                },
+            ]);
+
+            snapshotPath = path.join(workspace.root, '.snapshot.json');
+            const snapshot = buildSnapshot(workspace.root);
+            saveSnapshot(snapshotPath, snapshot);
+
+            // Only clobber pkg-a
+            const pkgAPath = Object.keys(snapshot).find((p) => p.includes('pkg-a'));
+            const pkgA = JSON.parse(fs.readFileSync(pkgAPath, 'utf8'));
+            pkgA.peerDependencies['@justeattakeaway/pie-css'] = '1.2.0';
+            fs.writeFileSync(pkgAPath, JSON.stringify(pkgA, null, 2));
+
+            const { found, restorations } = restoreFromSnapshot(snapshotPath);
+
+            expect(found).toBe(true);
+            expect(restorations).toHaveLength(1);
+            expect(restorations[0].package).toBe('@justeattakeaway/pkg-a');
+            expect(restorations[0].from).toBe('1.2.0');
+            expect(restorations[0].to).toBe('1.x');
+        });
+    });
+});

--- a/packages/tools/pie-monorepo-utils/__tests__/preserve-peer-dep-ranges/preserve-peer-dep-ranges.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/preserve-peer-dep-ranges/preserve-peer-dep-ranges.test.js
@@ -1,5 +1,5 @@
 import {
-    describe, it, expect, beforeEach, afterEach,
+    describe, it, expect, afterEach,
 } from 'vitest';
 import fs from 'fs';
 import path from 'path';
@@ -34,14 +34,14 @@ function createTempWorkspace (packages = []) {
 
     // Create each package
     fs.mkdirSync(path.join(root, 'packages'), { recursive: true });
-    for (const pkg of packages) {
+    packages.forEach((pkg) => {
         const pkgDir = path.join(root, 'packages', pkg.dirName);
         fs.mkdirSync(pkgDir, { recursive: true });
         fs.writeFileSync(
             path.join(pkgDir, 'package.json'),
             JSON.stringify(pkg.packageJson, null, 2),
         );
-    }
+    });
 
     const cleanup = () => fs.rmSync(root, { recursive: true, force: true });
 
@@ -251,7 +251,7 @@ describe('preserve-peer-dep-ranges', () => {
             saveSnapshot(snapshotPath, snapshot);
 
             // 2. Simulate changeset clobbering the range
-            const pkgPath = Object.keys(snapshot)[0];
+            const [pkgPath] = Object.keys(snapshot);
             const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
             pkg.peerDependencies['@justeattakeaway/pie-css'] = '1.1.0';
             fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));

--- a/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/changeset-version.sh
+++ b/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/changeset-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# changeset-version.sh
+#
+# Wrapper around `changeset version` that preserves fuzzy peerDependency
+# ranges on internal packages (e.g. "1.x", "^1.0.0", "*").
+#
+# Problem:
+#   `changeset version` rewrites internal peerDependency ranges to exact
+#   versions (e.g. "1.x" → "1.1.0"). This is undesirable because we
+#   intentionally use ranges so consumers aren't forced to pin.
+#
+# Solution:
+#   1. Snapshot all internal peer dep ranges before versioning.
+#   2. Run `changeset version` (which may clobber them).
+#   3. Restore any clobbered ranges from the snapshot.
+#   4. Update the yarn lockfile to reflect the final state.
+#
+# The restore step runs even if `changeset version` fails, via a trap,
+# so the snapshot file is always cleaned up.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cleanup() {
+    node "$SCRIPT_DIR/cli.js" restore
+}
+
+# Step 1: Snapshot current peer dep ranges
+node "$SCRIPT_DIR/cli.js" snapshot
+
+# Ensure restore always runs, even on failure
+trap cleanup EXIT
+
+# Step 2: Run changeset version
+changeset version
+
+# Step 3: restore runs automatically via the EXIT trap
+
+# Step 4: Update the lockfile (runs after trap, only if changeset succeeded)
+trap - EXIT
+cleanup
+yarn --mode update-lockfile

--- a/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/cli.js
+++ b/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/cli.js
@@ -17,13 +17,13 @@ const { runSnapshot, runRestore } = require('./preserve-peer-dep-ranges');
 
 const root = findMonorepoRoot();
 const SNAPSHOT_PATH = path.join(root, '.changeset', '.peer-dep-ranges-snapshot.json');
-const command = process.argv[2];
+const [,, command] = process.argv;
 
 if (command === 'snapshot') {
     runSnapshot(SNAPSHOT_PATH);
 } else if (command === 'restore') {
     runRestore(SNAPSHOT_PATH);
 } else {
-    console.error('Usage: preserve-peer-dep-ranges <snapshot|restore>');
+    console.error('Usage: preserve-peer-dep-ranges <snapshot|restore>'); // eslint-disable-line no-console
     process.exit(1);
 }

--- a/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/cli.js
+++ b/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+/**
+ * CLI for preserve-peer-dep-ranges.
+ *
+ * Prevents `changeset version` from clobbering fuzzy peerDependency ranges
+ * on internal packages (e.g. "1.x" → "1.1.0").
+ *
+ * Usage (wired into the changeset:version script in root package.json):
+ *   preserve-peer-dep-ranges snapshot
+ *   preserve-peer-dep-ranges restore
+ */
+
+const path = require('path');
+const findMonorepoRoot = require('../utils/find-monorepo-root');
+const { runSnapshot, runRestore } = require('./preserve-peer-dep-ranges');
+
+const root = findMonorepoRoot();
+const SNAPSHOT_PATH = path.join(root, '.changeset', '.peer-dep-ranges-snapshot.json');
+const command = process.argv[2];
+
+if (command === 'snapshot') {
+    runSnapshot(SNAPSHOT_PATH);
+} else if (command === 'restore') {
+    runRestore(SNAPSHOT_PATH);
+} else {
+    console.error('Usage: preserve-peer-dep-ranges <snapshot|restore>');
+    process.exit(1);
+}

--- a/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/preserve-peer-dep-ranges.js
+++ b/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/preserve-peer-dep-ranges.js
@@ -1,0 +1,197 @@
+const fs = require('fs');
+const path = require('path');
+const findMonorepoRoot = require('../utils/find-monorepo-root');
+
+const INTERNAL_SCOPE_PREFIXES = ['@justeattakeaway/', '@justeat/'];
+
+/**
+ * Returns true if a version string is a range (not an exact version).
+ *
+ * Exact versions match: 1.0.0, 0.26.21, 14.0.0
+ * Ranges match: *, 1.x, ^1.0.0, ~2.3.0, >=1.0.0, >1, 1.x || 2.x, etc.
+ */
+function isRange (version) {
+    if (version === '*') return true;
+    if (/[~^><=|]/.test(version)) return true;
+    if (/\.x(?:\.|$)/i.test(version)) return true;
+    return false;
+}
+
+/**
+ * Returns true if a dependency name belongs to an internal scope.
+ */
+function isInternalDep (depName) {
+    return INTERNAL_SCOPE_PREFIXES.some((prefix) => depName.startsWith(prefix));
+}
+
+/**
+ * Discovers all workspace package.json paths by reading the root package.json
+ * workspaces config and globbing for package.json files.
+ */
+function getWorkspacePackageJsonPaths (root) {
+    const rootPkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+    const workspaceGlobs = rootPkg.workspaces?.packages || rootPkg.workspaces || [];
+
+    const paths = [];
+
+    for (const pattern of workspaceGlobs) {
+        if (pattern === './') continue;
+        const globPattern = path.join(root, pattern, 'package.json');
+        const matched = fs.globSync(globPattern);
+        paths.push(...matched);
+    }
+
+    return paths;
+}
+
+/**
+ * Scans all workspace package.json files and returns a snapshot object
+ * mapping file paths to their internal peer dep ranges.
+ */
+function buildSnapshot (root) {
+    const pkgPaths = getWorkspacePackageJsonPaths(root);
+    const snapshot = {};
+
+    for (const pkgPath of pkgPaths) {
+        try {
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            const peerDeps = pkg.peerDependencies;
+
+            if (!peerDeps) continue;
+
+            const rangesToPreserve = {};
+
+            for (const [depName, depVersion] of Object.entries(peerDeps)) {
+                if (isInternalDep(depName) && isRange(depVersion)) {
+                    rangesToPreserve[depName] = depVersion;
+                }
+            }
+
+            if (Object.keys(rangesToPreserve).length > 0) {
+                snapshot[pkgPath] = {
+                    name: pkg.name,
+                    ranges: rangesToPreserve,
+                };
+            }
+        } catch (err) {
+            console.warn(`[preserve-peer-dep-ranges] Skipping ${pkgPath}: ${err.message}`);
+        }
+    }
+
+    return snapshot;
+}
+
+/**
+ * Writes a snapshot to the given file path.
+ */
+function saveSnapshot (snapshotPath, snapshot) {
+    fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2));
+}
+
+/**
+ * Reads a snapshot from the given file path, restores clobbered ranges
+ * in their package.json files, and deletes the snapshot file.
+ *
+ * Returns { found, restorations } where `found` indicates the snapshot existed,
+ * and `restorations` is an array of { package, dep, from, to } for each restored range.
+ */
+function restoreFromSnapshot (snapshotPath) {
+    if (!fs.existsSync(snapshotPath)) {
+        return { found: false, restorations: [] };
+    }
+
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    const restorations = [];
+
+    for (const [pkgPath, entry] of Object.entries(snapshot)) {
+        try {
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+            if (!pkg.peerDependencies) continue;
+
+            let changed = false;
+
+            for (const [dep, originalRange] of Object.entries(entry.ranges)) {
+                const currentValue = pkg.peerDependencies[dep];
+
+                if (currentValue !== undefined && currentValue !== originalRange) {
+                    pkg.peerDependencies[dep] = originalRange;
+                    changed = true;
+                    restorations.push({
+                        package: entry.name,
+                        dep,
+                        from: currentValue,
+                        to: originalRange,
+                    });
+                }
+            }
+
+            if (changed) {
+                fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+            }
+        } catch (err) {
+            console.error(`[preserve-peer-dep-ranges] Failed to restore ${pkgPath}: ${err.message}`);
+        }
+    }
+
+    fs.unlinkSync(snapshotPath);
+
+    return { found: true, restorations };
+}
+
+/**
+ * CLI handler: snapshot mode.
+ * Scans workspaces and saves internal peer dep ranges to a temp file.
+ */
+function runSnapshot (snapshotPath) {
+    const root = findMonorepoRoot();
+    const snapshot = buildSnapshot(root);
+
+    if (Object.keys(snapshot).length === 0) {
+        console.log('[preserve-peer-dep-ranges] No internal peer dep ranges found to preserve.');
+        return;
+    }
+
+    saveSnapshot(snapshotPath, snapshot);
+
+    for (const [, entry] of Object.entries(snapshot)) {
+        for (const [dep, range] of Object.entries(entry.ranges)) {
+            console.log(`[preserve-peer-dep-ranges] Snapshotted ${entry.name} → ${dep}: "${range}"`);
+        }
+    }
+}
+
+/**
+ * CLI handler: restore mode.
+ * Reads the snapshot and overwrites clobbered ranges back to originals.
+ */
+function runRestore (snapshotPath) {
+    const { found, restorations } = restoreFromSnapshot(snapshotPath);
+
+    if (!found) {
+        console.log('[preserve-peer-dep-ranges] No snapshot found — nothing to restore.');
+        return;
+    }
+
+    if (restorations.length === 0) {
+        console.log('[preserve-peer-dep-ranges] No peer dep ranges were clobbered — nothing to restore.');
+        console.log('[preserve-peer-dep-ranges] Snapshot cleaned up.');
+        return;
+    }
+
+    for (const r of restorations) {
+        console.log(`[preserve-peer-dep-ranges] Restored ${r.package} → ${r.dep}: "${r.from}" → "${r.to}"`);
+    }
+
+    console.log('[preserve-peer-dep-ranges] Snapshot cleaned up.');
+}
+
+module.exports = {
+    isRange,
+    isInternalDep,
+    buildSnapshot,
+    saveSnapshot,
+    restoreFromSnapshot,
+    runSnapshot,
+    runRestore,
+};

--- a/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/preserve-peer-dep-ranges.js
+++ b/packages/tools/pie-monorepo-utils/preserve-peer-dep-ranges/preserve-peer-dep-ranges.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
 const findMonorepoRoot = require('../utils/find-monorepo-root');
@@ -32,16 +33,9 @@ function getWorkspacePackageJsonPaths (root) {
     const rootPkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
     const workspaceGlobs = rootPkg.workspaces?.packages || rootPkg.workspaces || [];
 
-    const paths = [];
-
-    for (const pattern of workspaceGlobs) {
-        if (pattern === './') continue;
-        const globPattern = path.join(root, pattern, 'package.json');
-        const matched = fs.globSync(globPattern);
-        paths.push(...matched);
-    }
-
-    return paths;
+    return workspaceGlobs
+        .filter((pattern) => pattern !== './')
+        .flatMap((pattern) => fs.globSync(path.join(root, pattern, 'package.json')));
 }
 
 /**
@@ -52,20 +46,20 @@ function buildSnapshot (root) {
     const pkgPaths = getWorkspacePackageJsonPaths(root);
     const snapshot = {};
 
-    for (const pkgPath of pkgPaths) {
+    pkgPaths.forEach((pkgPath) => {
         try {
             const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
             const peerDeps = pkg.peerDependencies;
 
-            if (!peerDeps) continue;
+            if (!peerDeps) return;
 
             const rangesToPreserve = {};
 
-            for (const [depName, depVersion] of Object.entries(peerDeps)) {
+            Object.entries(peerDeps).forEach(([depName, depVersion]) => {
                 if (isInternalDep(depName) && isRange(depVersion)) {
                     rangesToPreserve[depName] = depVersion;
                 }
-            }
+            });
 
             if (Object.keys(rangesToPreserve).length > 0) {
                 snapshot[pkgPath] = {
@@ -76,7 +70,7 @@ function buildSnapshot (root) {
         } catch (err) {
             console.warn(`[preserve-peer-dep-ranges] Skipping ${pkgPath}: ${err.message}`);
         }
-    }
+    });
 
     return snapshot;
 }
@@ -103,15 +97,15 @@ function restoreFromSnapshot (snapshotPath) {
     const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
     const restorations = [];
 
-    for (const [pkgPath, entry] of Object.entries(snapshot)) {
+    Object.entries(snapshot).forEach(([pkgPath, entry]) => {
         try {
             const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 
-            if (!pkg.peerDependencies) continue;
+            if (!pkg.peerDependencies) return;
 
             let changed = false;
 
-            for (const [dep, originalRange] of Object.entries(entry.ranges)) {
+            Object.entries(entry.ranges).forEach(([dep, originalRange]) => {
                 const currentValue = pkg.peerDependencies[dep];
 
                 if (currentValue !== undefined && currentValue !== originalRange) {
@@ -124,7 +118,7 @@ function restoreFromSnapshot (snapshotPath) {
                         to: originalRange,
                     });
                 }
-            }
+            });
 
             if (changed) {
                 fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
@@ -132,7 +126,7 @@ function restoreFromSnapshot (snapshotPath) {
         } catch (err) {
             console.error(`[preserve-peer-dep-ranges] Failed to restore ${pkgPath}: ${err.message}`);
         }
-    }
+    });
 
     fs.unlinkSync(snapshotPath);
 
@@ -154,11 +148,11 @@ function runSnapshot (snapshotPath) {
 
     saveSnapshot(snapshotPath, snapshot);
 
-    for (const [, entry] of Object.entries(snapshot)) {
-        for (const [dep, range] of Object.entries(entry.ranges)) {
+    Object.values(snapshot).forEach((entry) => {
+        Object.entries(entry.ranges).forEach(([dep, range]) => {
             console.log(`[preserve-peer-dep-ranges] Snapshotted ${entry.name} → ${dep}: "${range}"`);
-        }
-    }
+        });
+    });
 }
 
 /**
@@ -179,9 +173,9 @@ function runRestore (snapshotPath) {
         return;
     }
 
-    for (const r of restorations) {
+    restorations.forEach((r) => {
         console.log(`[preserve-peer-dep-ranges] Restored ${r.package} → ${r.dep}: "${r.from}" → "${r.to}"`);
-    }
+    });
 
     console.log('[preserve-peer-dep-ranges] Snapshot cleaned up.');
 }

--- a/packages/tools/stylelint-config-pie/package.json
+++ b/packages/tools/stylelint-config-pie/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@justeat/pie-design-tokens": "*",
-    "@justeattakeaway/pie-css": "1.1.0",
+    "@justeattakeaway/pie-css": "1.x",
     "stylelint": "16.x",
     "stylelint-config-standard-scss": "13.x",
     "stylelint-order": "6.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,7 +4267,7 @@ __metadata:
     "@justeattakeaway/pie-components-config": 0.21.0
     lit: 3.2.0
   peerDependencies:
-    "@justeattakeaway/pie-css": 1.1.0
+    "@justeattakeaway/pie-css": 1.x
   languageName: unknown
   linkType: soft
 
@@ -4343,7 +4343,7 @@ __metadata:
     "@justeattakeaway/stylelint-no-logical-props-shorthands": 0.3.0
   peerDependencies:
     "@justeat/pie-design-tokens": "*"
-    "@justeattakeaway/pie-css": 1.1.0
+    "@justeattakeaway/pie-css": 1.x
     stylelint: 16.x
     stylelint-config-standard-scss: 13.x
     stylelint-order: 6.x


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### `@justeattakeaway/pie-webc-core`, `@justeattakeaway/stylelint-config-pie`
[Changed] - updated pie-css peerDep to non-pinned version

### `@justeattakeaway/pie-monorepo-utils`
[Added] - preserve-peer-dep-ranges which makes changeset preserve fuzzy peerDep ranges when upgrading

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 15 deployment   | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

