### PR TITLE
fix(pie-storybook): DSW-3824 make assistive text render in storybook

### DIFF
--- a/.changeset/vast-pans-enter.md
+++ b/.changeset/vast-pans-enter.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": patch
+---
+
+[Fixed] - Ensure assistive text renders in checkbox stories

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -136,7 +136,7 @@ const Template = ({
             ?indeterminate="${indeterminate}"
             ?required="${required}"
             @change="${onChange}"
-            ?assistiveText="${ifDefined(assistiveText)}"
+            assistiveText="${ifDefined(assistiveText)}"
             status=${ifDefined(status)}>
             ${sanitizeAndRenderHTML(slot)}
         </pie-checkbox>

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -201,3 +201,24 @@ const ExampleFormTemplate: TemplateFunction<CheckboxProps> = ({
 
 export const Default = createStory<CheckboxProps>(Template, defaultArgs)();
 export const ExampleForm = createStory<CheckboxProps>(ExampleFormTemplate, defaultArgs)();
+
+const richLabelSlot = `<div style="
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: var(--dt-spacing-a);
+">
+    <span class="u-font-body-l">A yummy dish</span>
+    <span class="u-font-body-l">£2.50</span>
+    <span class="u-font-caption" style="
+        width: 100%;
+        color: var(--dt-color-content-subdued);
+    ">
+        Some description as a part of the label
+    </span>
+</div>`;
+
+export const RichLabel = createStory<CheckboxProps>(Template, {
+    ...defaultArgs,
+    slot: richLabelSlot,
+})();

--- a/packages/components/pie-checkbox/README.md
+++ b/packages/components/pie-checkbox/README.md
@@ -49,7 +49,7 @@ Ideally, you should install the component using the **`@justeattakeaway/pie-webc
 
 | Slot     | Description                                                  |
 |----------|--------------------------------------------------------------|
-| `default`| The default, unnamed slot is used to pass label content to the component. This can be plain text or rich HTML for more complex labels (e.g., multi-line layouts with a title, price and description). When using rich HTML, use PIE design tokens for styling and typography utility classes from `@justeattakeaway/pie-css` for font styles. It is the consumer's responsibility to test screen reader narration when using complex slotted content. |
+| `default`| The default, unnamed slot is used to pass label content to the component. This can be plain text or rich HTML for more complex labels (e.g., multi-line layouts with a title, price and description). When using rich HTML, use PIE design tokens for styling and typography utility classes from `@justeattakeaway/pie-css` for font styles. It is the consumer's responsibility to test screen reader narration when using complex slotted content. Test that the label reads in a logical order and conveys the intended meaning. |
 
 ### CSS Variables
 This component does not expose any CSS variables for style overrides.

--- a/packages/components/pie-checkbox/README.md
+++ b/packages/components/pie-checkbox/README.md
@@ -49,7 +49,7 @@ Ideally, you should install the component using the **`@justeattakeaway/pie-webc
 
 | Slot     | Description                                                  |
 |----------|--------------------------------------------------------------|
-| `default`| The default, unnamed slot is used to pass in text to the component. |
+| `default`| The default, unnamed slot is used to pass label content to the component. This can be plain text or rich HTML for more complex labels (e.g., multi-line layouts with a title, price and description). When using rich HTML, use PIE design tokens for styling and typography utility classes from `@justeattakeaway/pie-css` for font styles. It is the consumer's responsibility to test screen reader narration when using complex slotted content. |
 
 ### CSS Variables
 This component does not expose any CSS variables for style overrides.
@@ -131,6 +131,58 @@ import { PieCheckbox } from '@justeattakeaway/pie-webc/react/checkbox.js';
 
 // Always use aria-label if you are not passing a label
 <PieCheckbox name="mycheckbox" aria-label="Label"></PieCheckbox>
+```
+
+### Rich Label Slot Content
+
+The default slot accepts HTML, so you can build more complex label layouts such as a product row with a title, price and description. Use PIE design tokens for spacing and `pie-css` typography utility classes for font styles.
+
+> **Accessibility note:** When using rich slotted content, it is the consumer's responsibility to verify screen reader narration is acceptable. Test that the label reads in a logical order and conveys the intended meaning.
+
+**HTML example:**
+
+```html
+<pie-checkbox name="carrots" value="carrots">
+    <div style="
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: var(--dt-spacing-a);
+    ">
+        <span class="u-font-body-l">A nasty bag of carrots</span>
+        <span class="u-font-body-l">£2.50</span>
+        <span class="u-font-caption" style="
+            width: 100%;
+            color: var(--dt-color-content-subdued);
+        ">
+            Some description as a part of the label
+        </span>
+    </div>
+</pie-checkbox>
+```
+
+**React example:**
+
+```jsx
+import { PieCheckbox } from '@justeattakeaway/pie-webc/react/checkbox.js';
+
+<PieCheckbox name="carrots" value="carrots">
+    <div style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
+        gap: 'var(--dt-spacing-a)',
+    }}>
+        <span className="u-font-body-l">A nasty bag of carrots</span>
+        <span className="u-font-body-l">£2.50</span>
+        <span className="u-font-caption" style={{
+            width: '100%',
+            color: 'var(--dt-color-content-subdued)',
+        }}>
+            Some description as a part of the label
+        </span>
+    </div>
+</PieCheckbox>
 ```
 
 ## Questions and Support


### PR DESCRIPTION
- Fix the assistive text not rendering in checkbox stories
- Add a new story showcasing more complex label slots
- Document the label slot usage with guidance on creating more complex markup
<img width="535" height="121" alt="Screenshot 2026-04-22 at 10 43 47" src="https://github.com/user-attachments/assets/010a6e0a-339f-400e-b08f-99f1f6eec8e5" />
