### PR TITLE
refactor(pie-monorepo): DSW-3079 split dangerjs checks to separate files

### DIFF
--- a/.changeset/busy-garlics-mate.md
+++ b/.changeset/busy-garlics-mate.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-monorepo-utils": minor
+"pie-monorepo": minor
+---
+
+[Changed] - split dangerjs into seperate files

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,159 +1,21 @@
 import { danger, fail } from 'danger';
-const { execSync } = require('child_process');
-const { validatePrTitle } = require('./packages/tools/pie-monorepo-utils/git-hooks/git-hooks-utils.js');
+import { checks } from '@justeattakeaway/pie-monorepo-utils/dangerjs-checks/index.js';
 
 const { pr } = danger.github;
-const validChangesetCategories = ['Added', 'Changed', 'Removed', 'Fixed'];
-
-const isDependabotPR = pr.user.login === 'dependabot[bot]';
-const isAutomationPR = pr.user.type === 'Bot';
-
-// PR Title validation (only for non-bot PRs)
-if (!isAutomationPR) {
-    const title = pr.title;
-    
-    if (!validatePrTitle(title)) {
-        fail(`❌ **PR Title Validation Failed**\n\nThe PR title should follow the same convention used for commits, e.g.:\n\`type(scope): TICKET-123 title\` where \`TICKET-123\` is a valid ticket ID.\n\n**Note:** Ticket IDs cannot be all zeros (e.g. DSW-000 is not allowed).\n\n**Current title:** \`${title}\``);
-    }
-}
-
-// PIE Webc major versioning check (only for non-bot PRs)
-if (!isAutomationPR) {
-    try {
-        execSync('npx detect-webc-major-version', { stdio: 'pipe' });
-    } catch (err) {
-        const errorOutput = err.stderr ? err.stderr.toString() : '';
-        fail(`${errorOutput}`);
-    }
-}
-
-// Check for correct Changeset formatting
-danger.git.created_files
-    .filter((filepath) => filepath.includes('.changeset/') && !filepath.includes('.changeset/pre.json'))
-    .forEach((filepath) => {
-        const changesetDiff = danger.git.diffForFile(filepath);
-        changesetDiff.then((result) => {
-            const diffString = result.diff;
-            const changesetCategoryRegex = /(?<=\[).+?(?=\])/g;
-            const changesetCategories = diffString.match(changesetCategoryRegex);
-            const numberOfCategories = changesetCategories ? changesetCategories.length : 0;
-
-            if (isDependabotPR) {
-                // Check if at least one of the valid changeset categories is present
-                if (numberOfCategories === 0) {
-                    fail(`:memo: Your changeset doesn't include a category. Please add one of: \`${validChangesetCategories.join(', ')}\`. Filepath: \`${filepath}`);
-                } else if (!validChangesetCategories.some((cat) => changesetCategories.includes(cat))) {
-                    fail(`:memo: Your changeset includes an invalid category. Please use one of: \`${validChangesetCategories.join(', ')}\`. Filepath: \`${filepath}`);
-                }
-
-                // Check that categories are followed are in the following format `[Category] - {Description}`
-                const changesetLineFormatRegex = /\[\w+\] - [\S].+/g;
-                const validChangesetEntries = diffString.match(changesetLineFormatRegex);
-                const numberOfValidChangesetEntries = validChangesetEntries ? validChangesetEntries.length : 0;
-                if (numberOfCategories !== numberOfValidChangesetEntries) {
-                    fail(`:memo: Your changeset entries should be in the format: \`[Category] - {Description}\`. One or more of your entries does not follow this format. Filepath: \`${filepath}`);
-                }
-            }
-        }, (err) => {
-            console.error(err);
-        });
-    });
-
-// Allow unchecked checkboxes only in "Not-applicable Checklist items"
-if (!isDependabotPR) {
-    const { body } = pr;
-
-    const uncheckedCheckboxRegex = /- \[ \]/g;
-
-    // Split the body into sections
-    const sections = body.split(/## /);
-    const notApplicableSection = sections.find((section) => section.startsWith('Not-applicable Checklist items'));
-
-    // Check for unchecked checkboxes outside the "Not-applicable Checklist items" section
-    const uncheckedOutsideNotApplicableSection = sections.some((section) => {
-        if (section !== notApplicableSection) {
-            return uncheckedCheckboxRegex.test(section);
-        }
-        return false;
-    });
-
-    if (uncheckedOutsideNotApplicableSection) {
-        fail('You have unchecked checklist items outside the "Not-applicable Checklist items" section.\n\nPlease ensure all unchecked checkboxes are moved to the appropriate section.');
-    }
-
-    // Match sections for Reviewer 1 and Reviewer 2
-    const reviewer1Section = body.match(/### Reviewer 1.*?(?=###|$)/s);
-    const reviewer2Section = body.match(/### Reviewer 2.*?(?=###|$)/s);
-
-    // Helper function to check a reviewer's section
-    const checkReviewerSection = (section, reviewerName) => {
-        if (section) {
-            const uncheckedReviewerCheckboxes = section.match(uncheckedCheckboxRegex);
-            if (uncheckedReviewerCheckboxes) {
-                fail(`You have unchecked checklist items in ${reviewerName}'s section.\n\nPlease ensure all items are addressed before approval.`);
-            }
-        }
-    };
-
-    // Check Reviewer 1
-    checkReviewerSection(reviewer1Section ? reviewer1Section[0] : null, 'Reviewer 1');
-
-    // Check Reviewer 2
-    checkReviewerSection(reviewer2Section ? reviewer2Section[0] : null, 'Reviewer 2');
-}
-
-// README checks for Web Components (excluding core/testing projects)
-const readmeFiles = [...danger.git.created_files, ...danger.git.modified_files]
-    .filter((file) => /^packages\/components\/(?!pie-webc(?:-core|-testing)?\/)[^/]+\/README\.md$/.test(file));
-
-const checkReadmeStructure = async (filepath) => {
-    const diff = await danger.git.diffForFile(filepath);
-    const fileContent = diff.after;
-
-    const errors = [];
-
-    if (!/https:\/\/img\.shields\.io\/npm\/v\/@justeattakeaway\//.test(fileContent)) {
-        errors.push('Missing npm badge (https://img.shields.io/npm/v/@justeattakeaway/...).');
-    }
-
-    if (!/## Table of Contents/.test(fileContent)) {
-        errors.push('Missing "## Table of Contents" section.');
-    }
-
-    if (!/## Documentation/.test(fileContent)) {
-        errors.push('Missing "## Documentation" section.');
-    }
-
-    if (!/### Properties/.test(fileContent)) {
-        errors.push('Missing "### Properties" sub-section under Documentation.');
-    }
-    if (!/### Slots/.test(fileContent)) {
-        errors.push('Missing "### Slots" sub-section under Documentation.');
-    }
-    if (!/### Events/.test(fileContent)) {
-        errors.push('Missing "### Events" sub-section under Documentation.');
-    }
-    if (!/### CSS Variables/.test(fileContent)) {
-        errors.push('Missing "### CSS Variables" sub-section under Documentation.');
-    }
-
-    if (!/## Usage Examples/.test(fileContent)) {
-        errors.push('Missing "## Usage Examples" section.');
-    }
-
-    if (!/## Questions and Support/.test(fileContent)) {
-        errors.push('Missing "## Questions and Support" section.');
-    }
-
-    if (!/## Contributing/.test(fileContent)) {
-        errors.push('Missing "## Contributing" section.');
-    }
-
-    if (errors.length > 0) {
-        fail(`📘 \`${filepath}\` is missing required README sections:\n- ${errors.join('\n- ')}`);
-    }
+const flags = {
+    isAutomationPR: pr.user.type === 'Bot',
+    isDependabotPR: pr.user.login === 'dependabot[bot]',
 };
 
-readmeFiles.forEach((file) => {
-    checkReadmeStructure(file);
-});
+(async () => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const check of checks) {
+        // eslint-disable-next-line no-await-in-loop
+        await check({
+            danger,
+            fail,
+            pr,
+            flags,
+        });
+    }
+})();

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/changeset-format.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/changeset-format.test.js
@@ -3,9 +3,10 @@ import {
 } from 'vitest';
 import changesetFormat from '../../dangerjs-checks/changeset-format.js';
 
-function makeDanger({ createdFiles = [], diffs = {} } = {}) {
+function makeDanger ({ createdFiles = [], diffs = {} } = {}) {
     return {
         git: {
+            // eslint-disable-next-line camelcase
             created_files: createdFiles,
             diffForFile: vi.fn((path) => Promise.resolve({ diff: diffs[path] ?? '' })),
         },

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/changeset-format.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/changeset-format.test.js
@@ -1,0 +1,117 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import changesetFormat from '../../dangerjs-checks/changeset-format.js';
+
+function makeDanger({ createdFiles = [], diffs = {} } = {}) {
+    return {
+        git: {
+            created_files: createdFiles,
+            diffForFile: vi.fn((path) => Promise.resolve({ diff: diffs[path] ?? '' })),
+        },
+    };
+}
+
+describe('changeset-format check', () => {
+    let fail;
+
+    beforeEach(() => {
+        fail = vi.fn();
+    });
+
+    it('ignores non-changeset files', async () => {
+        const danger = makeDanger({ createdFiles: ['src/foo.js'] });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: true },
+        });
+        expect(danger.git.diffForFile).not.toHaveBeenCalled();
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('ignores .changeset/pre.json', async () => {
+        const danger = makeDanger({ createdFiles: ['.changeset/pre.json'] });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: true },
+        });
+        expect(danger.git.diffForFile).not.toHaveBeenCalled();
+    });
+
+    it('only validates for dependabot PRs', async () => {
+        const danger = makeDanger({
+            createdFiles: ['.changeset/abc.md'],
+            diffs: { '.changeset/abc.md': '+ no categories here' },
+        });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('fails when dependabot changeset has no category', async () => {
+        const danger = makeDanger({
+            createdFiles: ['.changeset/abc.md'],
+            diffs: { '.changeset/abc.md': '+ Some line with no brackets' },
+        });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: true },
+        });
+        expect(fail).toHaveBeenCalledOnce();
+        expect(fail.mock.calls[0][0]).toContain("doesn't include a category");
+    });
+
+    it('fails when dependabot changeset category is invalid', async () => {
+        const danger = makeDanger({
+            createdFiles: ['.changeset/abc.md'],
+            diffs: { '.changeset/abc.md': '+ [Unknown] - Bumped thing' },
+        });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: true },
+        });
+        expect(fail).toHaveBeenCalled();
+        expect(fail.mock.calls[0][0]).toContain('invalid category');
+    });
+
+    it('passes for well-formed dependabot changeset', async () => {
+        const danger = makeDanger({
+            createdFiles: ['.changeset/abc.md'],
+            diffs: { '.changeset/abc.md': '+ [Changed] - Bumped dep to 1.2.3' },
+        });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: true },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('fails on malformed `[Category] - description` line', async () => {
+        const danger = makeDanger({
+            createdFiles: ['.changeset/abc.md'],
+            diffs: { '.changeset/abc.md': '+ [Changed]no dash no space' },
+        });
+        await changesetFormat({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: true },
+        });
+        expect(fail).toHaveBeenCalled();
+        expect(fail.mock.calls[0][0]).toContain('should be in the format');
+    });
+});

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-checkboxes.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-checkboxes.test.js
@@ -62,7 +62,7 @@ describe('pr-checkboxes check', () => {
             flags: { isAutomationPR: false, isDependabotPR: false },
         });
         expect(fail).toHaveBeenCalled();
-        expect(fail.mock.calls.some((c) => c[0].includes("Reviewer 1"))).toBe(true);
+        expect(fail.mock.calls.some((c) => c[0].includes('Reviewer 1'))).toBe(true);
     });
 
     it('fails on unchecked in Reviewer 2 section', async () => {
@@ -74,6 +74,6 @@ describe('pr-checkboxes check', () => {
             flags: { isAutomationPR: false, isDependabotPR: false },
         });
         expect(fail).toHaveBeenCalled();
-        expect(fail.mock.calls.some((c) => c[0].includes("Reviewer 2"))).toBe(true);
+        expect(fail.mock.calls.some((c) => c[0].includes('Reviewer 2'))).toBe(true);
     });
 });

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-checkboxes.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-checkboxes.test.js
@@ -1,0 +1,79 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import prCheckboxes from '../../dangerjs-checks/pr-checkboxes.js';
+
+describe('pr-checkboxes check', () => {
+    let fail;
+
+    beforeEach(() => {
+        fail = vi.fn();
+    });
+
+    it('skips dependabot PRs', async () => {
+        await prCheckboxes({
+            danger: {},
+            fail,
+            pr: { body: '## Something\n- [ ] unchecked' },
+            flags: { isAutomationPR: false, isDependabotPR: true },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('passes with no unchecked boxes', async () => {
+        await prCheckboxes({
+            danger: {},
+            fail,
+            pr: { body: '## Checklist\n- [x] done' },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('allows unchecked inside Not-applicable section', async () => {
+        const body = '## Checklist\n- [x] done\n## Not-applicable Checklist items\n- [ ] skip me';
+        await prCheckboxes({
+            danger: {},
+            fail,
+            pr: { body },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('fails on unchecked outside Not-applicable section', async () => {
+        const body = '## Checklist\n- [ ] missing\n## Not-applicable Checklist items\n- [x] ok';
+        await prCheckboxes({
+            danger: {},
+            fail,
+            pr: { body },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalled();
+        expect(fail.mock.calls[0][0]).toContain('unchecked checklist items outside');
+    });
+
+    it('fails on unchecked in Reviewer 1 section', async () => {
+        const body = '## Checklist\n- [x] done\n### Reviewer 1\n- [ ] review\n### Reviewer 2\n- [x] review';
+        await prCheckboxes({
+            danger: {},
+            fail,
+            pr: { body },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalled();
+        expect(fail.mock.calls.some((c) => c[0].includes("Reviewer 1"))).toBe(true);
+    });
+
+    it('fails on unchecked in Reviewer 2 section', async () => {
+        const body = '## Checklist\n- [x] done\n### Reviewer 1\n- [x] ok\n### Reviewer 2\n- [ ] review';
+        await prCheckboxes({
+            danger: {},
+            fail,
+            pr: { body },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalled();
+        expect(fail.mock.calls.some((c) => c[0].includes("Reviewer 2"))).toBe(true);
+    });
+});

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-title.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-title.test.js
@@ -2,12 +2,12 @@ import {
     describe, it, expect, vi, beforeEach,
 } from 'vitest';
 
+import { validatePrTitle } from '../../git-hooks/git-hooks-utils.js';
+import prTitle from '../../dangerjs-checks/pr-title.js';
+
 vi.mock('../../git-hooks/git-hooks-utils.js', () => ({
     validatePrTitle: vi.fn(),
 }));
-
-import { validatePrTitle } from '../../git-hooks/git-hooks-utils.js';
-import prTitle from '../../dangerjs-checks/pr-title.js';
 
 describe('pr-title check', () => {
     beforeEach(() => {

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-title.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/pr-title.test.js
@@ -1,0 +1,54 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+vi.mock('../../git-hooks/git-hooks-utils.js', () => ({
+    validatePrTitle: vi.fn(),
+}));
+
+import { validatePrTitle } from '../../git-hooks/git-hooks-utils.js';
+import prTitle from '../../dangerjs-checks/pr-title.js';
+
+describe('pr-title check', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('skips automation PRs', async () => {
+        const fail = vi.fn();
+        await prTitle({
+            danger: {},
+            fail,
+            pr: { title: 'anything' },
+            flags: { isAutomationPR: true, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+        expect(validatePrTitle).not.toHaveBeenCalled();
+    });
+
+    it('passes on valid title', async () => {
+        validatePrTitle.mockReturnValue(true);
+        const fail = vi.fn();
+        await prTitle({
+            danger: {},
+            fail,
+            pr: { title: 'feat(pie-button): DSW-1234 add thing' },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('fails on invalid title', async () => {
+        validatePrTitle.mockReturnValue(false);
+        const fail = vi.fn();
+        await prTitle({
+            danger: {},
+            fail,
+            pr: { title: 'bad title' },
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalledOnce();
+        expect(fail.mock.calls[0][0]).toContain('PR Title Validation Failed');
+        expect(fail.mock.calls[0][0]).toContain('bad title');
+    });
+});

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/readme-structure.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/readme-structure.test.js
@@ -16,10 +16,12 @@ const validReadme = [
     '## Contributing',
 ].join('\n');
 
-function makeDanger({ created = [], modified = [], diffs = {} }) {
+function makeDanger ({ created = [], modified = [], diffs = {} }) {
     return {
         git: {
+            // eslint-disable-next-line camelcase
             created_files: created,
+            // eslint-disable-next-line camelcase
             modified_files: modified,
             diffForFile: vi.fn((path) => Promise.resolve({ after: diffs[path] ?? '' })),
         },
@@ -94,7 +96,7 @@ describe('readme-structure check', () => {
             flags: { isAutomationPR: false, isDependabotPR: false },
         });
         expect(fail).toHaveBeenCalledOnce();
-        const msg = fail.mock.calls[0][0];
+        const [[msg]] = fail.mock.calls;
         expect(msg).toContain('Missing npm badge');
         expect(msg).toContain('## Table of Contents');
         expect(msg).toContain('## Documentation');

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/readme-structure.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/readme-structure.test.js
@@ -1,0 +1,109 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import readmeStructure from '../../dangerjs-checks/readme-structure.js';
+
+const validReadme = [
+    'https://img.shields.io/npm/v/@justeattakeaway/pie-button',
+    '## Table of Contents',
+    '## Documentation',
+    '### Properties',
+    '### Slots',
+    '### Events',
+    '### CSS Variables',
+    '## Usage Examples',
+    '## Questions and Support',
+    '## Contributing',
+].join('\n');
+
+function makeDanger({ created = [], modified = [], diffs = {} }) {
+    return {
+        git: {
+            created_files: created,
+            modified_files: modified,
+            diffForFile: vi.fn((path) => Promise.resolve({ after: diffs[path] ?? '' })),
+        },
+    };
+}
+
+describe('readme-structure check', () => {
+    let fail;
+
+    beforeEach(() => {
+        fail = vi.fn();
+    });
+
+    it('ignores non-component files', async () => {
+        const danger = makeDanger({ created: ['src/foo.js'] });
+        await readmeStructure({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(danger.git.diffForFile).not.toHaveBeenCalled();
+    });
+
+    it('excludes pie-webc README', async () => {
+        const danger = makeDanger({ created: ['packages/components/pie-webc/README.md'] });
+        await readmeStructure({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(danger.git.diffForFile).not.toHaveBeenCalled();
+    });
+
+    it('excludes pie-webc-core README', async () => {
+        const danger = makeDanger({ created: ['packages/components/pie-webc-core/README.md'] });
+        await readmeStructure({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(danger.git.diffForFile).not.toHaveBeenCalled();
+    });
+
+    it('passes on a complete README', async () => {
+        const path = 'packages/components/pie-button/README.md';
+        const danger = makeDanger({
+            created: [path],
+            diffs: { [path]: validReadme },
+        });
+        await readmeStructure({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('reports each missing section', async () => {
+        const path = 'packages/components/pie-button/README.md';
+        const danger = makeDanger({
+            modified: [path],
+            diffs: { [path]: '# README with nothing' },
+        });
+        await readmeStructure({
+            danger,
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalledOnce();
+        const msg = fail.mock.calls[0][0];
+        expect(msg).toContain('Missing npm badge');
+        expect(msg).toContain('## Table of Contents');
+        expect(msg).toContain('## Documentation');
+        expect(msg).toContain('### Properties');
+        expect(msg).toContain('### Slots');
+        expect(msg).toContain('### Events');
+        expect(msg).toContain('### CSS Variables');
+        expect(msg).toContain('## Usage Examples');
+        expect(msg).toContain('## Questions and Support');
+        expect(msg).toContain('## Contributing');
+    });
+});

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/webc-major-version.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/webc-major-version.test.js
@@ -2,14 +2,14 @@ import {
     describe, it, expect, vi, beforeEach,
 } from 'vitest';
 
+import { execSync } from 'child_process';
+import webcMajorVersion from '../../dangerjs-checks/webc-major-version.js';
+
 const { mockExecSync } = vi.hoisted(() => ({ mockExecSync: vi.fn() }));
 vi.mock('child_process', () => ({
     default: { execSync: mockExecSync },
     execSync: mockExecSync,
 }));
-
-import { execSync } from 'child_process';
-import webcMajorVersion from '../../dangerjs-checks/webc-major-version.js';
 
 describe('webc-major-version check', () => {
     beforeEach(() => {

--- a/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/webc-major-version.test.js
+++ b/packages/tools/pie-monorepo-utils/__tests__/dangerjs-checks/webc-major-version.test.js
@@ -1,0 +1,70 @@
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+const { mockExecSync } = vi.hoisted(() => ({ mockExecSync: vi.fn() }));
+vi.mock('child_process', () => ({
+    default: { execSync: mockExecSync },
+    execSync: mockExecSync,
+}));
+
+import { execSync } from 'child_process';
+import webcMajorVersion from '../../dangerjs-checks/webc-major-version.js';
+
+describe('webc-major-version check', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('skips automation PRs', async () => {
+        const fail = vi.fn();
+        await webcMajorVersion({
+            danger: {},
+            fail,
+            pr: {},
+            flags: { isAutomationPR: true, isDependabotPR: false },
+        });
+        expect(fail).not.toHaveBeenCalled();
+        expect(execSync).not.toHaveBeenCalled();
+    });
+
+    it('passes when execSync succeeds', async () => {
+        execSync.mockReturnValue(Buffer.from(''));
+        const fail = vi.fn();
+        await webcMajorVersion({
+            danger: {},
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(execSync).toHaveBeenCalledWith('npx detect-webc-major-version', { stdio: 'pipe' });
+        expect(fail).not.toHaveBeenCalled();
+    });
+
+    it('fails with stderr when execSync throws', async () => {
+        const err = new Error('boom');
+        err.stderr = Buffer.from('major version bump missing');
+        execSync.mockImplementation(() => { throw err; });
+        const fail = vi.fn();
+        await webcMajorVersion({
+            danger: {},
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalledOnce();
+        expect(fail.mock.calls[0][0]).toContain('major version bump missing');
+    });
+
+    it('fails with empty string when thrown error has no stderr', async () => {
+        execSync.mockImplementation(() => { throw new Error('boom'); });
+        const fail = vi.fn();
+        await webcMajorVersion({
+            danger: {},
+            fail,
+            pr: {},
+            flags: { isAutomationPR: false, isDependabotPR: false },
+        });
+        expect(fail).toHaveBeenCalledWith('');
+    });
+});

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/changeset-format.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/changeset-format.js
@@ -1,9 +1,7 @@
 const validChangesetCategories = ['Added', 'Changed', 'Removed', 'Fixed'];
 
-export default async function changesetFormat({ danger, fail, flags }) {
-    const changesetFiles = danger.git.created_files.filter(
-        (filepath) => filepath.includes('.changeset/') && !filepath.includes('.changeset/pre.json'),
-    );
+export default async function changesetFormat ({ danger, fail, flags }) {
+    const changesetFiles = danger.git.created_files.filter((filepath) => filepath.includes('.changeset/') && !filepath.includes('.changeset/pre.json'));
 
     await Promise.all(changesetFiles.map(async (filepath) => {
         const result = await danger.git.diffForFile(filepath);

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/changeset-format.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/changeset-format.js
@@ -1,0 +1,30 @@
+const validChangesetCategories = ['Added', 'Changed', 'Removed', 'Fixed'];
+
+export default async function changesetFormat({ danger, fail, flags }) {
+    const changesetFiles = danger.git.created_files.filter(
+        (filepath) => filepath.includes('.changeset/') && !filepath.includes('.changeset/pre.json'),
+    );
+
+    await Promise.all(changesetFiles.map(async (filepath) => {
+        const result = await danger.git.diffForFile(filepath);
+        const diffString = result.diff;
+        const changesetCategoryRegex = /(?<=\[).+?(?=\])/g;
+        const changesetCategories = diffString.match(changesetCategoryRegex);
+        const numberOfCategories = changesetCategories ? changesetCategories.length : 0;
+
+        if (!flags.isDependabotPR) return;
+
+        if (numberOfCategories === 0) {
+            fail(`:memo: Your changeset doesn't include a category. Please add one of: \`${validChangesetCategories.join(', ')}\`. Filepath: \`${filepath}`);
+        } else if (!validChangesetCategories.some((cat) => changesetCategories.includes(cat))) {
+            fail(`:memo: Your changeset includes an invalid category. Please use one of: \`${validChangesetCategories.join(', ')}\`. Filepath: \`${filepath}`);
+        }
+
+        const changesetLineFormatRegex = /\[\w+\] - [\S].+/g;
+        const validChangesetEntries = diffString.match(changesetLineFormatRegex);
+        const numberOfValidChangesetEntries = validChangesetEntries ? validChangesetEntries.length : 0;
+        if (numberOfCategories !== numberOfValidChangesetEntries) {
+            fail(`:memo: Your changeset entries should be in the format: \`[Category] - {Description}\`. One or more of your entries does not follow this format. Filepath: \`${filepath}`);
+        }
+    }));
+}

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/index.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/index.js
@@ -1,0 +1,13 @@
+import prTitle from './pr-title.js';
+import webcMajorVersion from './webc-major-version.js';
+import changesetFormat from './changeset-format.js';
+import prCheckboxes from './pr-checkboxes.js';
+import readmeStructure from './readme-structure.js';
+
+export const checks = [
+    prTitle,
+    webcMajorVersion,
+    changesetFormat,
+    prCheckboxes,
+    readmeStructure,
+];

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-checkboxes.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-checkboxes.js
@@ -1,0 +1,35 @@
+export default async function prCheckboxes({ fail, pr, flags }) {
+    if (flags.isDependabotPR) return;
+
+    const { body } = pr;
+    const uncheckedCheckboxRegex = /- \[ \]/g;
+
+    const sections = body.split(/## /);
+    const notApplicableSection = sections.find((section) => section.startsWith('Not-applicable Checklist items'));
+
+    const uncheckedOutsideNotApplicableSection = sections.some((section) => {
+        if (section !== notApplicableSection) {
+            return uncheckedCheckboxRegex.test(section);
+        }
+        return false;
+    });
+
+    if (uncheckedOutsideNotApplicableSection) {
+        fail('You have unchecked checklist items outside the "Not-applicable Checklist items" section.\n\nPlease ensure all unchecked checkboxes are moved to the appropriate section.');
+    }
+
+    const reviewer1Section = body.match(/### Reviewer 1.*?(?=###|$)/s);
+    const reviewer2Section = body.match(/### Reviewer 2.*?(?=###|$)/s);
+
+    const checkReviewerSection = (section, reviewerName) => {
+        if (section) {
+            const uncheckedReviewerCheckboxes = section.match(uncheckedCheckboxRegex);
+            if (uncheckedReviewerCheckboxes) {
+                fail(`You have unchecked checklist items in ${reviewerName}'s section.\n\nPlease ensure all items are addressed before approval.`);
+            }
+        }
+    };
+
+    checkReviewerSection(reviewer1Section ? reviewer1Section[0] : null, 'Reviewer 1');
+    checkReviewerSection(reviewer2Section ? reviewer2Section[0] : null, 'Reviewer 2');
+}

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-checkboxes.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-checkboxes.js
@@ -1,4 +1,4 @@
-export default async function prCheckboxes({ fail, pr, flags }) {
+export default async function prCheckboxes ({ fail, pr, flags }) {
     if (flags.isDependabotPR) return;
 
     const { body } = pr;

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-title.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-title.js
@@ -1,6 +1,6 @@
 import { validatePrTitle } from '../git-hooks/git-hooks-utils.js';
 
-export default async function prTitle({ fail, pr, flags }) {
+export default async function prTitle ({ fail, pr, flags }) {
     if (flags.isAutomationPR) return;
 
     const { title } = pr;

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-title.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/pr-title.js
@@ -1,0 +1,10 @@
+import { validatePrTitle } from '../git-hooks/git-hooks-utils.js';
+
+export default async function prTitle({ fail, pr, flags }) {
+    if (flags.isAutomationPR) return;
+
+    const { title } = pr;
+    if (!validatePrTitle(title)) {
+        fail(`❌ **PR Title Validation Failed**\n\nThe PR title should follow the same convention used for commits, e.g.:\n\`type(scope): TICKET-123 title\` where \`TICKET-123\` is a valid ticket ID.\n\n**Note:** Ticket IDs cannot be all zeros (e.g. DSW-000 is not allowed).\n\n**Current title:** \`${title}\``);
+    }
+}

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/readme-structure.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/readme-structure.js
@@ -1,6 +1,6 @@
 const readmePathRegex = /^packages\/components\/(?!pie-webc(?:-core|-testing)?\/)[^/]+\/README\.md$/;
 
-async function checkReadmeStructure(danger, fail, filepath) {
+async function checkReadmeStructure (danger, fail, filepath) {
     const diff = await danger.git.diffForFile(filepath);
     const fileContent = diff.after;
 
@@ -24,7 +24,7 @@ async function checkReadmeStructure(danger, fail, filepath) {
     }
 }
 
-export default async function readmeStructure({ danger, fail }) {
+export default async function readmeStructure ({ danger, fail }) {
     const readmeFiles = [...danger.git.created_files, ...danger.git.modified_files]
         .filter((file) => readmePathRegex.test(file));
 

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/readme-structure.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/readme-structure.js
@@ -1,0 +1,32 @@
+const readmePathRegex = /^packages\/components\/(?!pie-webc(?:-core|-testing)?\/)[^/]+\/README\.md$/;
+
+async function checkReadmeStructure(danger, fail, filepath) {
+    const diff = await danger.git.diffForFile(filepath);
+    const fileContent = diff.after;
+
+    const errors = [];
+
+    if (!/https:\/\/img\.shields\.io\/npm\/v\/@justeattakeaway\//.test(fileContent)) {
+        errors.push('Missing npm badge (https://img.shields.io/npm/v/@justeattakeaway/...).');
+    }
+    if (!/## Table of Contents/.test(fileContent)) errors.push('Missing "## Table of Contents" section.');
+    if (!/## Documentation/.test(fileContent)) errors.push('Missing "## Documentation" section.');
+    if (!/### Properties/.test(fileContent)) errors.push('Missing "### Properties" sub-section under Documentation.');
+    if (!/### Slots/.test(fileContent)) errors.push('Missing "### Slots" sub-section under Documentation.');
+    if (!/### Events/.test(fileContent)) errors.push('Missing "### Events" sub-section under Documentation.');
+    if (!/### CSS Variables/.test(fileContent)) errors.push('Missing "### CSS Variables" sub-section under Documentation.');
+    if (!/## Usage Examples/.test(fileContent)) errors.push('Missing "## Usage Examples" section.');
+    if (!/## Questions and Support/.test(fileContent)) errors.push('Missing "## Questions and Support" section.');
+    if (!/## Contributing/.test(fileContent)) errors.push('Missing "## Contributing" section.');
+
+    if (errors.length > 0) {
+        fail(`📘 \`${filepath}\` is missing required README sections:\n- ${errors.join('\n- ')}`);
+    }
+}
+
+export default async function readmeStructure({ danger, fail }) {
+    const readmeFiles = [...danger.git.created_files, ...danger.git.modified_files]
+        .filter((file) => readmePathRegex.test(file));
+
+    await Promise.all(readmeFiles.map((file) => checkReadmeStructure(danger, fail, file)));
+}

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/readme-structure.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/readme-structure.js
@@ -1,23 +1,25 @@
 const readmePathRegex = /^packages\/components\/(?!pie-webc(?:-core|-testing)?\/)[^/]+\/README\.md$/;
 
+const requiredReadmeSections = [
+    { regex: /https:\/\/img\.shields\.io\/npm\/v\/@justeattakeaway\//, error: 'Missing npm badge (https://img.shields.io/npm/v/@justeattakeaway/...).' },
+    { regex: /## Table of Contents/, error: 'Missing "## Table of Contents" section.' },
+    { regex: /## Documentation/, error: 'Missing "## Documentation" section.' },
+    { regex: /### Properties/, error: 'Missing "### Properties" sub-section under Documentation.' },
+    { regex: /### Slots/, error: 'Missing "### Slots" sub-section under Documentation.' },
+    { regex: /### Events/, error: 'Missing "### Events" sub-section under Documentation.' },
+    { regex: /### CSS Variables/, error: 'Missing "### CSS Variables" sub-section under Documentation.' },
+    { regex: /## Usage Examples/, error: 'Missing "## Usage Examples" section.' },
+    { regex: /## Questions and Support/, error: 'Missing "## Questions and Support" section.' },
+    { regex: /## Contributing/, error: 'Missing "## Contributing" section.' },
+];
+
 async function checkReadmeStructure (danger, fail, filepath) {
     const diff = await danger.git.diffForFile(filepath);
     const fileContent = diff.after;
 
-    const errors = [];
-
-    if (!/https:\/\/img\.shields\.io\/npm\/v\/@justeattakeaway\//.test(fileContent)) {
-        errors.push('Missing npm badge (https://img.shields.io/npm/v/@justeattakeaway/...).');
-    }
-    if (!/## Table of Contents/.test(fileContent)) errors.push('Missing "## Table of Contents" section.');
-    if (!/## Documentation/.test(fileContent)) errors.push('Missing "## Documentation" section.');
-    if (!/### Properties/.test(fileContent)) errors.push('Missing "### Properties" sub-section under Documentation.');
-    if (!/### Slots/.test(fileContent)) errors.push('Missing "### Slots" sub-section under Documentation.');
-    if (!/### Events/.test(fileContent)) errors.push('Missing "### Events" sub-section under Documentation.');
-    if (!/### CSS Variables/.test(fileContent)) errors.push('Missing "### CSS Variables" sub-section under Documentation.');
-    if (!/## Usage Examples/.test(fileContent)) errors.push('Missing "## Usage Examples" section.');
-    if (!/## Questions and Support/.test(fileContent)) errors.push('Missing "## Questions and Support" section.');
-    if (!/## Contributing/.test(fileContent)) errors.push('Missing "## Contributing" section.');
+    const errors = requiredReadmeSections
+        .filter(({ regex }) => !regex.test(fileContent))
+        .map(({ error }) => error);
 
     if (errors.length > 0) {
         fail(`📘 \`${filepath}\` is missing required README sections:\n- ${errors.join('\n- ')}`);

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/webc-major-version.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/webc-major-version.js
@@ -1,0 +1,12 @@
+import childProcess from 'child_process';
+
+export default async function webcMajorVersion({ fail, flags }) {
+    if (flags.isAutomationPR) return;
+
+    try {
+        childProcess.execSync('npx detect-webc-major-version', { stdio: 'pipe' });
+    } catch (err) {
+        const errorOutput = err.stderr ? err.stderr.toString() : '';
+        fail(`${errorOutput}`);
+    }
+}

--- a/packages/tools/pie-monorepo-utils/dangerjs-checks/webc-major-version.js
+++ b/packages/tools/pie-monorepo-utils/dangerjs-checks/webc-major-version.js
@@ -1,6 +1,6 @@
 import childProcess from 'child_process';
 
-export default async function webcMajorVersion({ fail, flags }) {
+export default async function webcMajorVersion ({ fail, flags }) {
     if (flags.isAutomationPR) return;
 
     try {

--- a/packages/tools/pie-monorepo-utils/index.js
+++ b/packages/tools/pie-monorepo-utils/index.js
@@ -1,3 +1,4 @@
 export * from './git-hooks/check-branch-name.js';
 export * from './git-hooks/git-hooks-utils.js';
 export * from './commitlint-plugin/index.js';
+export * from './dangerjs-checks/index.js';


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
  - Split root dangerfile.js into per-check modules `pie-monorepo-utils/dangerjs-checks`                                  
  - Added vitest unit tests per check                                                                

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
