### PR TITLE
ci(pie-monorepo): DSW-1982 update token scopes to be compatible with new `/test-aperture` workflow

### DIFF
--- a/.changeset/hot-trees-enjoy.md
+++ b/.changeset/hot-trees-enjoy.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Updated] changeset snapshot / test-aperture token scopes so use new test-aperture workflow correctly

--- a/.github/workflows/changeset-snapshot.yml
+++ b/.github/workflows/changeset-snapshot.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: justeattakeaway
+          repositories: |
+            pie
+            pie-aperture
 
       - name: Add initial reaction
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0

--- a/.github/workflows/test-aperture.yml
+++ b/.github/workflows/test-aperture.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: justeattakeaway
+          repositories: |
+            pie
+            pie-aperture
 
       - name: Add initial reaction
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
This PR updates the token scopes used by Changesets `/snapit` / `/test-aperture` workflows so it's compatible with the new pie-trigger.yml workflow in PIE Aperture.

This was actually a bug as part of the update to our new Github app but surfaced as part of my changes

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

