### PR TITLE
test(pie-toast-provider): DSW-123 Attempt to fix test flakiness

### DIFF
--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -25,12 +25,15 @@ declare global {
  */
 async function installQueueListener (page: Page): Promise<void> {
     await page.evaluate(() => {
-        window.__queueSnapshots = [];
-        document.querySelector('pie-toast-provider')!.addEventListener(
+        const snapshots: ExtendedToastProps[][] = [];
+        window.__queueSnapshots = snapshots;
+        const provider = document.querySelector('pie-toast-provider');
+        if (!provider) throw new Error('pie-toast-provider not found in DOM');
+        provider.addEventListener(
             'pie-toast-provider-queue-update',
             (event) => {
-                const detail = (event as CustomEvent<ExtendedToastProps[]>).detail;
-                window.__queueSnapshots!.push(structuredClone(detail));
+                const { detail } = (event as CustomEvent<ExtendedToastProps[]>);
+                snapshots.push(structuredClone(detail));
             },
         );
     });
@@ -50,7 +53,6 @@ async function getQueueSnapshots (page: Page): Promise<ExtendedToastProps[][]> {
 }
 
 test.describe('PieToastProvider - Component tests', () => {
-
     test('should render successfully', async ({ page }) => {
         // Arrange
         const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
@@ -107,15 +109,15 @@ test.describe('PieToastProvider - Component tests', () => {
             // is non-decreasing in priority. This is independent of how many
             // toasts the provider keeps in the queue vs displays immediately.
             const snapshots = await getQueueSnapshots(page);
-            for (const snapshot of snapshots) {
-                const priorities: number[] = snapshot.map((toast) => {
-                    const key: Priority = `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`;
-                    return PRIORITY_ORDER[key];
+            const priorityOf = (toast: ExtendedToastProps): number => {
+                const key: Priority = `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`;
+                return PRIORITY_ORDER[key];
+            };
+            snapshots.forEach((snapshot) => {
+                snapshot.slice(1).forEach((toast, index) => {
+                    expect(priorityOf(toast)).toBeGreaterThanOrEqual(priorityOf(snapshot[index]));
                 });
-                for (let i = 1; i < priorities.length; i++) {
-                    expect(priorities[i]).toBeGreaterThanOrEqual(priorities[i - 1]);
-                }
-            }
+            });
         });
 
         test('should clear all toasts when clearToasts is called', async ({ page }) => {
@@ -204,8 +206,10 @@ test.describe('PieToastProvider - Component tests', () => {
                 await expect.poll(() => findToastByMessage(page, 'Toast 2')).toBeDefined();
                 await expect.poll(() => findToastByMessage(page, 'Toast 3')).toBeDefined();
 
-                expect((await findToastByMessage(page, 'Toast 2'))!.isDismissible).toBeTruthy(); // Global option applies
-                expect((await findToastByMessage(page, 'Toast 3'))!.isDismissible).toBeFalsy();  // Override wins
+                const toast2 = await findToastByMessage(page, 'Toast 2');
+                const toast3 = await findToastByMessage(page, 'Toast 3');
+                expect(toast2?.isDismissible).toBeTruthy(); // Global option applies
+                expect(toast3?.isDismissible).toBeFalsy(); // Override wins
             });
         });
     });
@@ -251,9 +255,7 @@ test.describe('PieToastProvider - Component tests', () => {
             // returns true mid-animation, so reading boundingBox now would
             // sample a transient position. Wait for all animations on the
             // toast (and its descendants) to settle before measuring.
-            await toastElement.evaluate((el) => Promise.all(
-                el.getAnimations({ subtree: true }).map((animation) => animation.finished),
-            ));
+            await toastElement.evaluate((el) => Promise.all(el.getAnimations({ subtree: true }).map((animation) => animation.finished)));
 
             const initialPosition = await toastElement.boundingBox();
 

--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 
 import type { PieToastProvider } from 'src/index.ts';
@@ -11,17 +11,45 @@ import {
 
 import { toastProvider } from '../helpers/page-object/selectors.ts';
 
-test.describe('PieToastProvider - Component tests', () => {
-    let toastsQueue: ExtendedToastProps[] = [];
+declare global {
+    interface Window {
+        __queueSnapshots?: ExtendedToastProps[][];
+    }
+}
 
-    test.beforeEach(({ page }) => {
-        // Set up a listener for the queue update log
-        page.on('console', async (message) => {
-            if (message.text().includes('toast provider queue:')) {
-                toastsQueue = await message.args()[1].jsonValue();
-            }
-        });
+/**
+ * Subscribe to the provider's public `pie-toast-provider-queue-update` event
+ * and stash every detail snapshot on `window.__queueSnapshots`. Snapshots are
+ * structuredClone'd so later mutations to the live queue can't poison earlier
+ * captures.
+ */
+async function installQueueListener (page: Page): Promise<void> {
+    await page.evaluate(() => {
+        window.__queueSnapshots = [];
+        document.querySelector('pie-toast-provider')!.addEventListener(
+            'pie-toast-provider-queue-update',
+            (event) => {
+                const detail = (event as CustomEvent<ExtendedToastProps[]>).detail;
+                window.__queueSnapshots!.push(structuredClone(detail));
+            },
+        );
     });
+}
+
+/** Find the first toast across all captured snapshots whose `message` matches. */
+async function findToastByMessage (page: Page, message: string): Promise<ExtendedToastProps | undefined> {
+    return page.evaluate(
+        (msg) => (window.__queueSnapshots ?? []).flat().find((toast) => toast.message === msg),
+        message,
+    );
+}
+
+/** Read every captured snapshot back into the test runner. */
+async function getQueueSnapshots (page: Page): Promise<ExtendedToastProps[][]> {
+    return page.evaluate(() => window.__queueSnapshots ?? []);
+}
+
+test.describe('PieToastProvider - Component tests', () => {
 
     test('should render successfully', async ({ page }) => {
         // Arrange
@@ -41,6 +69,7 @@ test.describe('PieToastProvider - Component tests', () => {
             const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
             await pieToastProviderPage.load();
             await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+            await installQueueListener(page);
 
             // Act
             await page.evaluate(() => {
@@ -69,12 +98,23 @@ test.describe('PieToastProvider - Component tests', () => {
                 });
             });
 
-            // Assert
-            const queueVariants: Priority[] = toastsQueue.map((toast: ExtendedToastProps): Priority => `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`);
-            for (let i = 1; i < queueVariants.length; i++) {
-                const prevPriority = PRIORITY_ORDER[queueVariants[i - 1]];
-                const currPriority = PRIORITY_ORDER[queueVariants[i]];
-                expect(currPriority).toBeGreaterThanOrEqual(prevPriority); // Ensure the current has a higher priority
+            // Wait for the lowest-priority toast (last created) to surface in
+            // some snapshot — guarantees all create events have been processed.
+            await expect.poll(() => findToastByMessage(page, 'Error toast (Priority 2)')).toBeDefined();
+
+            // Assert — the contract under test is "the queue is always sorted
+            // by priority". Walk every captured snapshot and verify each one
+            // is non-decreasing in priority. This is independent of how many
+            // toasts the provider keeps in the queue vs displays immediately.
+            const snapshots = await getQueueSnapshots(page);
+            for (const snapshot of snapshots) {
+                const priorities: number[] = snapshot.map((toast) => {
+                    const key: Priority = `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`;
+                    return PRIORITY_ORDER[key];
+                });
+                for (let i = 1; i < priorities.length; i++) {
+                    expect(priorities[i]).toBeGreaterThanOrEqual(priorities[i - 1]);
+                }
             }
         });
 
@@ -83,6 +123,7 @@ test.describe('PieToastProvider - Component tests', () => {
             const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
             await pieToastProviderPage.load();
             await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+            await installQueueListener(page);
 
             // Act
             await page.evaluate(() => {
@@ -94,8 +135,11 @@ test.describe('PieToastProvider - Component tests', () => {
                 toastProvider.clearToasts();
             });
 
-            // Assert
-            await expect(toastsQueue.length).toBe(0);
+            // Assert — after clearToasts, the last queue snapshot should be empty.
+            await expect.poll(async () => {
+                const snapshots = await getQueueSnapshots(page);
+                return snapshots[snapshots.length - 1]?.length;
+            }).toBe(0);
         });
     });
 
@@ -111,6 +155,7 @@ test.describe('PieToastProvider - Component tests', () => {
                     },
                 });
                 await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+                await installQueueListener(page);
 
                 // Act
                 await page.evaluate(() => {
@@ -119,8 +164,16 @@ test.describe('PieToastProvider - Component tests', () => {
                     toastProvider.createToast({ message: 'Toast 2' });
                 });
 
-                // Assert
-                toastsQueue.forEach((toast) => {
+                // Assert — every toast we observe should carry the global
+                // options. (We can only verify queued toasts, not the one
+                // popped immediately into `_currentToast`.) Wait for at least
+                // one toast of interest to surface, then iterate every snapshot.
+                await expect.poll(() => findToastByMessage(page, 'Toast 2')).toBeDefined();
+
+                const snapshots = await getQueueSnapshots(page);
+                const seenToasts = snapshots.flat();
+                expect(seenToasts.length).toBeGreaterThan(0);
+                seenToasts.forEach((toast) => {
                     expect(toast.isDismissible).toBeTruthy();
                     expect(toast.variant).toBe('neutral');
                 });
@@ -135,6 +188,7 @@ test.describe('PieToastProvider - Component tests', () => {
                     },
                 });
                 await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+                await installQueueListener(page);
 
                 // Act
                 await page.evaluate(() => {
@@ -144,9 +198,14 @@ test.describe('PieToastProvider - Component tests', () => {
                     toastProvider.createToast({ message: 'Toast 3', isDismissible: false });
                 });
 
-                // Assert
-                expect(toastsQueue[0].isDismissible).toBeTruthy(); // Global option should apply
-                expect(toastsQueue[1].isDismissible).toBeFalsy(); // Override should take precedence
+                // Assert against toast identity, not queue position. Wait until
+                // both toasts of interest have appeared in some snapshot, then
+                // assert their merged props.
+                await expect.poll(() => findToastByMessage(page, 'Toast 2')).toBeDefined();
+                await expect.poll(() => findToastByMessage(page, 'Toast 3')).toBeDefined();
+
+                expect((await findToastByMessage(page, 'Toast 2'))!.isDismissible).toBeTruthy(); // Global option applies
+                expect((await findToastByMessage(page, 'Toast 3'))!.isDismissible).toBeFalsy();  // Override wins
             });
         });
     });
@@ -188,14 +247,23 @@ test.describe('PieToastProvider - Component tests', () => {
             const toastElement = page.locator('pie-toast');
             await expect(toastElement).toBeVisible();
 
+            // The toast slides in via CSS transform on mount. `toBeVisible`
+            // returns true mid-animation, so reading boundingBox now would
+            // sample a transient position. Wait for all animations on the
+            // toast (and its descendants) to settle before measuring.
+            await toastElement.evaluate((el) => Promise.all(
+                el.getAnimations({ subtree: true }).map((animation) => animation.finished),
+            ));
+
             const initialPosition = await toastElement.boundingBox();
 
-            // Act
-            await page.evaluate(() => {
+            // Act — scroll, then wait two frames so layout commits before measuring.
+            await page.evaluate(() => new Promise<void>((resolve) => {
                 window.scrollTo(0, document.body.scrollHeight);
-            });
+                requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }));
 
-            // Assert
+            // Assert — viewport coords should be unchanged after scroll.
             const finalPosition = await toastElement.boundingBox();
 
             expect(finalPosition?.x).toBe(initialPosition?.x);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Fixes flaky `pie-toast-provider` tests that surfaced under high parallel-worker pressure.

### `pie-toast-provider` — replace console-scraping with public event subscription                                                                                                                                                                                               
                                                         
The component spec previously listened to a `console.info('toast provider queue:', …)` log emitted by the storybook story to read provider state. The handler ran async, so assertions raced against listener arrivals — `toastsQueue` was frequently `[]` or stale at assertion 
time.                                                    
                                                                                                                                                                                                                                                                                 
Replaced with:                                           

- A `window.__queueSnapshots` array populated directly from the public `pie-toast-provider-queue-update` CustomEvent inside the page                                                                                           
- `installQueueListener(page)` / `findToastByMessage(page, message)` / `getQueueSnapshots(page)` helpers shared across all four mutation tests.
- Assertions now look up toasts by `message` identity, not queue index — independent of how many toasts the provider keeps queued vs immediately pops into `_currentToast`.                                                                                                      
- `expect.poll(...)` waits on observable state instead of indexing into uninitialised arrays.                                                                                                                                                                                    

## Author Checklist (complete before requesting a review, do not delete any)
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [ ] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 15 deployment   | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.
