### PR TITLE
test(pie-toast-provider): DSW-1234 improve test flakiness

### DIFF
--- a/.changeset/eight-lemons-attack.md
+++ b/.changeset/eight-lemons-attack.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-toast-provider": patch
+---
+
+[Changed] - tests approach to ensure results consistency

--- a/.changeset/nine-lemons-attack.md
+++ b/.changeset/nine-lemons-attack.md
@@ -1,0 +1,5 @@
+---
+"pie-monorepo": minor
+---
+
+[Added] - leaf AGENTS.md for components with test patterns and guidance

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -13,23 +13,59 @@ Browser tests run in a separate Node.js process (the test runner) that communica
 
 Asserting on any state populated by a console listener (or any CDP-sourced event) immediately after `page.evaluate()` is a race condition. It may pass locally and fail in CI.
 
-### Required pattern: listen → act → await → assert
+### Preferred pattern: browser-side accumulation + `page.waitForFunction`
 
-Always register the wait **before** the action that triggers it, then `await` it before asserting.
+The strongest synchronisation strategy keeps as much as possible inside the browser process. Install a listener that accumulates state into a `window` variable, then use `page.waitForFunction` to poll that variable. The polling condition runs in the browser — no CDP round-trip on every check.
+
+```ts
+// 1. Install a browser-side listener once after the component attaches.
+await page.evaluate(() => {
+    window.__snapshots = [];
+    document.querySelector('my-component').addEventListener('my-event', (e) => {
+        window.__snapshots.push(structuredClone(e.detail));
+    });
+});
+
+// 2. Read the current count BEFORE the action so the event can never be missed.
+const countBefore = await page.evaluate(() => window.__snapshots?.length ?? 0);
+
+// 3. Trigger the action.
+await page.evaluate(() => { component.doSomething(); });
+
+// 4. Wait in-browser until the count increases.
+await page.waitForFunction(
+    (count) => (window.__snapshots?.length ?? 0) > count,
+    countBefore,
+);
+
+// 5. Read the result — guaranteed to have arrived.
+const snapshots = await page.evaluate(() => window.__snapshots ?? []);
+```
+
+Benefits over console-based approaches:
+- Listens to the component's own public API, not a story side-effect. Refactoring the story cannot silently break the test.
+- `structuredClone` per snapshot means each captured state is independent. Later mutations cannot corrupt earlier captures.
+- Accumulating every snapshot lets you assert on intermediate states, not just the final one.
+
+### CDP `waitForEvent` — acceptable for browser → Node.js messages
+
+When you genuinely need to wait for a specific message to arrive in the test process (e.g. a `console.info` from a click handler), `page.waitForEvent` is the right tool. Set it up **before** the action so it cannot miss the event.
 
 ```ts
 // CORRECT — listener is active before the action fires
-const queueUpdated = page.waitForEvent(
+const received = page.waitForEvent(
     'console',
-    (msg) => msg.text().includes('my marker'),
+    (msg) => msg.type() === 'info' && msg.text() === 'expected message',
 );
-await page.evaluate(() => { /* triggers console.info */ });
-const result = await queueUpdated; // only now is the data guaranteed to have arrived
+await button.click();
+await received; // only now is the message guaranteed to have arrived
 
-// INCORRECT — race condition; the event may arrive before this line is reached
-await page.evaluate(() => { /* triggers console.info */ });
-const queueUpdated = page.waitForEvent('console', ...); // may already be missed
+// INCORRECT — race condition; the event may have fired before this line
+await button.click();
+const received = page.waitForEvent('console', ...); // may already be missed
 ```
+
+Prefer the browser-side polling pattern (above) over `waitForEvent('console', ...)` for observing component state. Reserve `waitForEvent` for interactions that genuinely produce a user-visible console output, such as button click handlers in stories.
 
 ### Lit update batching
 
@@ -43,58 +79,50 @@ await page.evaluate(() => {
 });
 ```
 
-Lit fires **one** `updated()` with the **final** state (`_items = []`). This means:
-
-- One CDP console event arrives, carrying `[]`.
-- An assertion that the queue was populated before being cleared is **impossible** to make with a single evaluate.
-- The test may pass trivially (asserting `length === 0` on a queue that never visibly had items).
+Lit fires **one** `updated()` with the **final** state (`_items = []`). This means an assertion that the queue was populated before being cleared is **impossible** to make from a single evaluate — you will only ever see the final empty state.
 
 **Split evaluate calls when testing distinct state transitions:**
 
 ```ts
-// Verify items were actually enqueued
-const populated = page.waitForEvent('console', (m) => m.text().includes('marker'));
+// Step 1 — create items, wait for the populated snapshot
+const countBefore = await page.evaluate(() => window.__snapshots?.length ?? 0);
 await page.evaluate(() => { component.createItem('a'); component.createItem('b'); });
-await populated;
+await page.waitForFunction((c) => (window.__snapshots?.length ?? 0) > c, countBefore);
 
-// Verify clear actually clears
-const cleared = page.waitForEvent('console', (m) => m.text().includes('marker'));
+// Step 2 — clear, wait for the empty snapshot
+const countBeforeClear = await page.evaluate(() => window.__snapshots?.length ?? 0);
 await page.evaluate(() => { component.clear(); });
-const result = await cleared;
-expect(result).toHaveLength(0);
+await page.waitForFunction((c) => (window.__snapshots?.length ?? 0) > c, countBeforeClear);
+
+const snapshots = await page.evaluate(() => window.__snapshots ?? []);
+expect(snapshots[snapshots.length - 1]).toHaveLength(0);
 ```
 
-### Reset shared state in `beforeEach`
+### Avoid shared `let` variables for captured state
 
-Variables declared at `test.describe` scope are shared across all tests in that suite and across `--repeat-each` repetitions. Never rely on their initial value inside a test — reset them at the top of `beforeEach`.
+Variables declared at `test.describe` scope and populated by async listeners are the most common source of flakiness in this test suite. There are two ways to deal with them, in order of preference:
+
+**Preferred — eliminate the shared variable entirely.** Return data directly from the synchronisation helper so each test owns its result as a local constant:
 
 ```ts
-let queue: Item[] = [];
+// Each test gets its own result — no shared state, no reset needed
+const snapshot = await afterNextSnapshot(page, () => page.evaluate(() => { ... }));
+expect(snapshot).toHaveLength(2);
+```
+
+**Acceptable — reset in `beforeEach` if a shared variable is unavoidable.** If you must keep a describe-scope variable (e.g. for a listener that accumulates across multiple steps), always reset it at the top of `beforeEach`:
+
+```ts
+let captured: Item[] = [];
 
 test.beforeEach(() => {
-    queue = []; // without this, stale data from the previous test bleeds in
+    captured = []; // without this, stale data from the previous test bleeds in
 });
-```
-
-### Capturing the event payload directly
-
-Prefer returning the value directly from the `waitForEvent` promise rather than relying on a side-effectful listener to update a shared variable. The listener fires asynchronously — by the time your assertion runs, it may not have completed its own `await` yet.
-
-```ts
-// PREFERRED — data flows explicitly from the wait to the assertion
-const msg = await page.waitForEvent('console', (m) => m.text().includes('queue:'));
-const queue = await msg.args()[1].jsonValue();
-expect(queue).toHaveLength(2);
-
-// FRAGILE — the listener's internal await may not have resolved yet
-page.on('console', async (msg) => { sharedQueue = await msg.args()[1].jsonValue(); });
-await someAction();
-expect(sharedQueue).toHaveLength(2); // sharedQueue may still be stale
 ```
 
 ### Waiting for post-click console messages
 
-`sectionButton.click()` resolves after the browser processes the click, but `console.info(...)` in the click handler still travels asynchronously over CDP. Always set up the wait before clicking.
+`element.click()` resolves after the browser processes the click, but `console.info(...)` in the click handler still travels asynchronously over CDP. Always set up the wait before clicking.
 
 ```ts
 const received = page.waitForEvent(
@@ -109,8 +137,10 @@ await received; // guarantees the message arrived before asserting
 
 | Pattern | Why it fails under CI load | Fix |
 |---|---|---|
-| `await page.evaluate(...)` then immediately read a listener-populated variable | CDP event arrives after assertion | Set up `waitForEvent` before evaluate, await after |
-| Shared `let` variable never reset in `beforeEach` | Previous test's data bleeds in | Reset at top of `beforeEach` |
+| Assert on a listener-populated variable immediately after `page.evaluate()` | CDP event arrives after assertion | Browser-side listener + `page.waitForFunction` |
+| Using `page.waitForEvent('console', ...)` to observe component state | Couples tests to a story `console.info` side-effect; still relies on CDP timing | Install a browser-side CustomEvent listener; poll with `page.waitForFunction` |
+| Shared `let` variable never reset in `beforeEach` | Previous test's data bleeds in | Eliminate shared state, or reset at top of `beforeEach` |
 | All mutations in one `evaluate()`, then assert intermediate state | Lit batches them; only final state is observable | Split into separate `evaluate()` calls |
 | `await element.click()` then immediately assert on a console-driven value | Same CDP delay applies | `waitForEvent` before click, await after |
-| `forEach` on a listener-populated array that may still be `[]` | Loop body never executes; assertions silently pass | Ensure data has arrived (await) before iterating |
+| `forEach` on a listener-populated array that may still be `[]` | Loop body never executes; assertions silently pass | Assert `length > 0` before iterating, or use the browser-side accumulation pattern |
+| Reading `boundingBox` immediately after `toBeVisible()` on an animated element | `toBeVisible` returns `true` mid-animation; position is transient | Wait for `getAnimations().map(a => a.finished)` before measuring |

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md - packages/components
+
+Supplements the root `AGENTS.md`. Read that file first; this one adds guidance specific to writing browser tests for Lit web components.
+
+## Playwright browser tests
+
+### The async event chain
+
+Browser tests run in a separate Node.js process (the test runner) that communicates with the browser via the Chrome DevTools Protocol (CDP) over a WebSocket. This means:
+
+- `page.evaluate()` returns to Node.js **after the synchronous browser JS completes**, but **before** any async browser work (Lit update cycles, CustomEvent dispatch, `console.info(...)`) has been transmitted back.
+- `page.on('console', ...)` listeners are called **asynchronously** — the CDP message may arrive milliseconds after `page.evaluate()` resolves, especially under CI load.
+
+Asserting on any state populated by a console listener (or any CDP-sourced event) immediately after `page.evaluate()` is a race condition. It may pass locally and fail in CI.
+
+### Required pattern: listen → act → await → assert
+
+Always register the wait **before** the action that triggers it, then `await` it before asserting.
+
+```ts
+// CORRECT — listener is active before the action fires
+const queueUpdated = page.waitForEvent(
+    'console',
+    (msg) => msg.text().includes('my marker'),
+);
+await page.evaluate(() => { /* triggers console.info */ });
+const result = await queueUpdated; // only now is the data guaranteed to have arrived
+
+// INCORRECT — race condition; the event may arrive before this line is reached
+await page.evaluate(() => { /* triggers console.info */ });
+const queueUpdated = page.waitForEvent('console', ...); // may already be missed
+```
+
+### Lit update batching
+
+Lit batches all synchronous property changes made within the same JS call stack into a single `updated()` lifecycle call (scheduled as a microtask). If a single `page.evaluate()` call makes several state mutations:
+
+```ts
+await page.evaluate(() => {
+    component.createItem('a'); // sets _items = ['a']
+    component.createItem('b'); // sets _items = ['a', 'b']
+    component.clear();         // sets _items = []
+});
+```
+
+Lit fires **one** `updated()` with the **final** state (`_items = []`). This means:
+
+- One CDP console event arrives, carrying `[]`.
+- An assertion that the queue was populated before being cleared is **impossible** to make with a single evaluate.
+- The test may pass trivially (asserting `length === 0` on a queue that never visibly had items).
+
+**Split evaluate calls when testing distinct state transitions:**
+
+```ts
+// Verify items were actually enqueued
+const populated = page.waitForEvent('console', (m) => m.text().includes('marker'));
+await page.evaluate(() => { component.createItem('a'); component.createItem('b'); });
+await populated;
+
+// Verify clear actually clears
+const cleared = page.waitForEvent('console', (m) => m.text().includes('marker'));
+await page.evaluate(() => { component.clear(); });
+const result = await cleared;
+expect(result).toHaveLength(0);
+```
+
+### Reset shared state in `beforeEach`
+
+Variables declared at `test.describe` scope are shared across all tests in that suite and across `--repeat-each` repetitions. Never rely on their initial value inside a test — reset them at the top of `beforeEach`.
+
+```ts
+let queue: Item[] = [];
+
+test.beforeEach(() => {
+    queue = []; // without this, stale data from the previous test bleeds in
+});
+```
+
+### Capturing the event payload directly
+
+Prefer returning the value directly from the `waitForEvent` promise rather than relying on a side-effectful listener to update a shared variable. The listener fires asynchronously — by the time your assertion runs, it may not have completed its own `await` yet.
+
+```ts
+// PREFERRED — data flows explicitly from the wait to the assertion
+const msg = await page.waitForEvent('console', (m) => m.text().includes('queue:'));
+const queue = await msg.args()[1].jsonValue();
+expect(queue).toHaveLength(2);
+
+// FRAGILE — the listener's internal await may not have resolved yet
+page.on('console', async (msg) => { sharedQueue = await msg.args()[1].jsonValue(); });
+await someAction();
+expect(sharedQueue).toHaveLength(2); // sharedQueue may still be stale
+```
+
+### Waiting for post-click console messages
+
+`sectionButton.click()` resolves after the browser processes the click, but `console.info(...)` in the click handler still travels asynchronously over CDP. Always set up the wait before clicking.
+
+```ts
+const received = page.waitForEvent(
+    'console',
+    (msg) => msg.type() === 'info' && msg.text() === 'expected message',
+);
+await button.click();
+await received; // guarantees the message arrived before asserting
+```
+
+## Common flakiness patterns to avoid
+
+| Pattern | Why it fails under CI load | Fix |
+|---|---|---|
+| `await page.evaluate(...)` then immediately read a listener-populated variable | CDP event arrives after assertion | Set up `waitForEvent` before evaluate, await after |
+| Shared `let` variable never reset in `beforeEach` | Previous test's data bleeds in | Reset at top of `beforeEach` |
+| All mutations in one `evaluate()`, then assert intermediate state | Lit batches them; only final state is observable | Split into separate `evaluate()` calls |
+| `await element.click()` then immediately assert on a console-driven value | Same CDP delay applies | `waitForEvent` before click, await after |
+| `forEach` on a listener-populated array that may still be `[]` | Loop body never executes; assertions silently pass | Ensure data has arrived (await) before iterating |

--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -11,29 +11,75 @@ import {
 
 import { toastProvider } from '../helpers/page-object/selectors.ts';
 
-const QUEUE_UPDATE_LOG = 'toast provider queue:';
+declare global {
+    interface Window {
+        __queueSnapshots?: ExtendedToastProps[][];
+    }
+}
 
 /**
- * Waits for the next `pie-toast-provider-queue-update` console log emitted by the story
- * and returns the queue payload. Must be called BEFORE the action that triggers the update
- * so the event is never missed.
+ * Installs a browser-side listener on the component's public
+ * `pie-toast-provider-queue-update` CustomEvent. Every emitted detail is
+ * structuredClone'd and appended to `window.__queueSnapshots`, giving tests
+ * access to every queue state the provider passed through — not just the last.
+ *
+ * Must be called after the component is attached to the DOM.
  */
-const waitForQueueUpdate = async (page: Page): Promise<ExtendedToastProps[]> => {
-    const msg = await page.waitForEvent(
-        'console',
-        (m) => m.text().includes(QUEUE_UPDATE_LOG),
+async function installQueueListener (page: Page): Promise<void> {
+    await page.evaluate(() => {
+        window.__queueSnapshots = [];
+        const provider = document.querySelector('pie-toast-provider');
+        if (!provider) throw new Error('pie-toast-provider not found in DOM');
+        provider.addEventListener(
+            'pie-toast-provider-queue-update',
+            (event) => {
+                const { detail } = event as CustomEvent<ExtendedToastProps[]>;
+                (window.__queueSnapshots ??= []).push(structuredClone(detail));
+            },
+        );
+    });
+}
+
+/**
+ * Reads the snapshot count before running `action`, then waits — via
+ * `page.waitForFunction` so polling stays in-browser — until at least one new
+ * snapshot has appeared. Returns the latest snapshot.
+ *
+ * Capturing the count *before* the action means the event can never be missed,
+ * even if it fires before `waitForFunction` is reached.
+ */
+async function afterNextSnapshot (
+    page: Page,
+    action: () => Promise<void>,
+): Promise<ExtendedToastProps[]> {
+    const countBefore = await page.evaluate(() => window.__queueSnapshots?.length ?? 0);
+    await action();
+    await page.waitForFunction(
+        (count: number) => (window.__queueSnapshots?.length ?? 0) > count,
+        countBefore,
     );
-    return msg.args()[1].jsonValue() as Promise<ExtendedToastProps[]>;
-};
+    const snapshots = await page.evaluate(() => window.__queueSnapshots ?? []);
+    return snapshots[snapshots.length - 1];
+}
+
+/** Returns every snapshot accumulated since `installQueueListener` was called. */
+async function getQueueSnapshots (page: Page): Promise<ExtendedToastProps[][]> {
+    return page.evaluate(() => window.__queueSnapshots ?? []);
+}
+
+/**
+ * Finds the first toast whose `message` matches across all captured snapshots.
+ * Searching by identity rather than queue position makes assertions resilient
+ * to priority-driven reordering.
+ */
+async function findToastByMessage (page: Page, message: string): Promise<ExtendedToastProps | undefined> {
+    return page.evaluate(
+        (msg) => (window.__queueSnapshots ?? []).flat().find((t) => t.message === msg),
+        message,
+    );
+}
 
 test.describe('PieToastProvider - Component tests', () => {
-    let toastsQueue: ExtendedToastProps[] = [];
-
-    test.beforeEach(() => {
-        // Reset between tests so stale data from a previous run never bleeds into assertions.
-        toastsQueue = [];
-    });
-
     test('should render successfully', async ({ page }) => {
         // Arrange
         const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
@@ -52,44 +98,33 @@ test.describe('PieToastProvider - Component tests', () => {
             const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
             await pieToastProviderPage.load();
             await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+            await installQueueListener(page);
 
-            // Act — register the listener BEFORE triggering the action to avoid a race condition
-            // between the Lit update cycle dispatching the event and the assertion reading toastsQueue.
-            const queueUpdated = waitForQueueUpdate(page);
-            await page.evaluate(() => {
-                const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
+            // Act — all four creates run synchronously so Lit batches them into one
+            // updated() cycle, producing a single snapshot. afterNextSnapshot captures
+            // the count before the action and waits in-browser, so the event can never
+            // be missed regardless of CDP timing.
+            await afterNextSnapshot(page, () => page.evaluate(() => {
+                const tp = document.querySelector('pie-toast-provider') as PieToastProvider;
+                tp.createToast({ message: 'Neutral toast (Priority 10)', variant: 'neutral' });
+                tp.createToast({ message: 'Success toast with action (Priority 4)', variant: 'success', leadingAction: { text: 'Action' } });
+                tp.createToast({ message: 'Info toast with action (Priority 5)', variant: 'info', leadingAction: { text: 'Action' } });
+                tp.createToast({ message: 'Error toast (Priority 2)', variant: 'error' });
+            }));
 
-                toastProvider.createToast({
-                    message: 'Neutral toast (Priority 10)',
-                    variant: 'neutral',
-                });
+            // Assert — verify every snapshot the provider ever emitted was sorted by
+            // priority, not just the final state.
+            const snapshots = await getQueueSnapshots(page);
+            const priorityOf = (toast: ExtendedToastProps): number => {
+                const key: Priority = `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`;
+                return PRIORITY_ORDER[key];
+            };
 
-                toastProvider.createToast({
-                    message: 'Success toast with action (Priority 4)',
-                    variant: 'success',
-                    leadingAction: { text: 'Action' },
-                });
-
-                toastProvider.createToast({
-                    message: 'Info toast with action (Priority 5)',
-                    variant: 'info',
-                    leadingAction: { text: 'Action' },
-                });
-
-                toastProvider.createToast({
-                    message: 'Error toast (Priority 2)',
-                    variant: 'error',
+            snapshots.forEach((snapshot) => {
+                snapshot.slice(1).forEach((toast, index) => {
+                    expect(priorityOf(toast)).toBeGreaterThanOrEqual(priorityOf(snapshot[index])); // Ensure the current has a higher priority
                 });
             });
-            toastsQueue = await queueUpdated;
-
-            // Assert
-            const queueVariants: Priority[] = toastsQueue.map((toast: ExtendedToastProps): Priority => `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`);
-            for (let i = 1; i < queueVariants.length; i++) {
-                const prevPriority = PRIORITY_ORDER[queueVariants[i - 1]];
-                const currPriority = PRIORITY_ORDER[queueVariants[i]];
-                expect(currPriority).toBeGreaterThanOrEqual(prevPriority); // Ensure the current has a higher priority
-            }
         });
 
         test('should clear all toasts when clearToasts is called', async ({ page }) => {
@@ -97,25 +132,25 @@ test.describe('PieToastProvider - Component tests', () => {
             const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
             await pieToastProviderPage.load();
             await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+            await installQueueListener(page);
 
-            // Act — split into two evaluate calls so each step produces its own queue update
-            // event, making the "before clear" and "after clear" states independently verifiable.
-            const queuePopulated = waitForQueueUpdate(page);
-            await page.evaluate(() => {
-                const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
-                toastProvider.createToast({ message: 'Toast 1', variant: 'neutral' });
-                toastProvider.createToast({ message: 'Toast 2', variant: 'success' });
-            });
-            await queuePopulated;
+            // Act — two separate evaluate calls so Lit produces two distinct updated()
+            // cycles. The first snapshot verifies toasts were actually enqueued; the
+            // second verifies clearToasts emptied the queue. A single evaluate would
+            // batch all mutations into one cycle and only the final empty state would
+            // be observable, making the populated intermediate state unverifiable.
+            await afterNextSnapshot(page, () => page.evaluate(() => {
+                const tp = document.querySelector('pie-toast-provider') as PieToastProvider;
+                tp.createToast({ message: 'Toast 1', variant: 'neutral' });
+                tp.createToast({ message: 'Toast 2', variant: 'success' });
+            }));
 
-            const queueCleared = waitForQueueUpdate(page);
-            await page.evaluate(() => {
+            const clearedQueue = await afterNextSnapshot(page, () => page.evaluate(() => {
                 (document.querySelector('pie-toast-provider') as PieToastProvider).clearToasts();
-            });
-            toastsQueue = await queueCleared;
+            }));
 
             // Assert
-            expect(toastsQueue.length).toBe(0);
+            expect(clearedQueue.length).toBe(0);
         });
     });
 
@@ -131,25 +166,28 @@ test.describe('PieToastProvider - Component tests', () => {
                     },
                 });
                 await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+                await installQueueListener(page);
 
                 // Act
-                const queueUpdated = waitForQueueUpdate(page);
-                await page.evaluate(() => {
-                    const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
-                    toastProvider.createToast({ message: 'Toast 1' });
-                    toastProvider.createToast({ message: 'Toast 2' });
-                });
-                toastsQueue = await queueUpdated;
+                await afterNextSnapshot(page, () => page.evaluate(() => {
+                    const tp = document.querySelector('pie-toast-provider') as PieToastProvider;
+                    tp.createToast({ message: 'Toast 1' });
+                    tp.createToast({ message: 'Toast 2' });
+                }));
 
-                // Assert — note: the first toast is immediately moved to _currentToast by the
-                // component, so toastsQueue only contains queued (not yet displayed) toasts.
-                toastsQueue.forEach((toast) => {
+                // Assert — iterate every toast that passed through the queue.
+                // Note: the first toast is immediately moved to _currentToast by the component
+                // and does not appear in the queue snapshots.
+                const seenToasts = (await getQueueSnapshots(page)).flat();
+                expect(seenToasts.length).toBeGreaterThan(0);
+                seenToasts.forEach((toast) => {
                     expect(toast.isDismissible).toBeTruthy();
                     expect(toast.variant).toBe('neutral');
                 });
             });
 
             test('should respect individual toast overrides when provided', async ({ page }) => {
+                // Arrange
                 const pieToastProviderPage = new BasePage(page, 'toast-provider--default');
                 await pieToastProviderPage.load({
                     options: {
@@ -158,20 +196,23 @@ test.describe('PieToastProvider - Component tests', () => {
                     },
                 });
                 await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
+                await installQueueListener(page);
 
                 // Act
-                const queueUpdated = waitForQueueUpdate(page);
-                await page.evaluate(() => {
-                    const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
-                    toastProvider.createToast({ message: 'Toast 1' });
-                    toastProvider.createToast({ message: 'Toast 2' });
-                    toastProvider.createToast({ message: 'Toast 3', isDismissible: false });
-                });
-                toastsQueue = await queueUpdated;
+                await afterNextSnapshot(page, () => page.evaluate(() => {
+                    const tp = document.querySelector('pie-toast-provider') as PieToastProvider;
+                    tp.createToast({ message: 'Toast 1' });
+                    tp.createToast({ message: 'Toast 2' });
+                    tp.createToast({ message: 'Toast 3', isDismissible: false });
+                }));
 
-                // Assert — Toast 1 is displayed (_currentToast), Toasts 2 & 3 are in the queue.
-                expect(toastsQueue[0].isDismissible).toBeTruthy(); // Global option should apply
-                expect(toastsQueue[1].isDismissible).toBeFalsy(); // Override should take precedence
+                // Assert by toast identity, not by queue index, to stay resilient to
+                // priority-driven reordering.
+                const toast2 = await findToastByMessage(page, 'Toast 2');
+                const toast3 = await findToastByMessage(page, 'Toast 3');
+
+                expect(toast2?.isDismissible).toBeTruthy(); // Global option should apply
+                expect(toast3?.isDismissible).toBeFalsy(); // Override should take precedence
             });
         });
     });
@@ -186,7 +227,7 @@ test.describe('PieToastProvider - Component tests', () => {
 
             const consoleMessages: string[] = [];
             page.on('console', (message) => {
-                if (message.type() === 'info' && !message.text().includes(QUEUE_UPDATE_LOG)) {
+                if (message.type() === 'info' && message.text() === expectedEventMessage) {
                     consoleMessages.push(message.text());
                 }
             });
@@ -194,12 +235,11 @@ test.describe('PieToastProvider - Component tests', () => {
             const toastElement = page.locator('pie-toast');
             await expect(toastElement).toBeVisible();
 
-            // Act
+            // Act — register the waitForEvent BEFORE clicking to avoid a race condition
+            // between the click handler firing console.info and the CDP message arriving.
             const sectionButton = page.locator('pie-button').filter({ hasText: 'Interactive element' });
             await expect(sectionButton).toBeVisible();
 
-            // Register the listener BEFORE clicking to avoid a race condition between the click
-            // handler firing console.info and the CDP message arriving in the test process.
             const consoleMessageReceived = page.waitForEvent(
                 'console',
                 (msg) => msg.type() === 'info' && msg.text() === expectedEventMessage,
@@ -221,12 +261,18 @@ test.describe('PieToastProvider - Component tests', () => {
             const toastElement = page.locator('pie-toast');
             await expect(toastElement).toBeVisible();
 
+            // Wait for the slide-in CSS animation to settle before sampling the initial
+            // position — toBeVisible returns true mid-animation so boundingBox would
+            // otherwise capture a transient value.
+            await toastElement.evaluate((el) => Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)));
+
             const initialPosition = await toastElement.boundingBox();
 
-            // Act
-            await page.evaluate(() => {
+            // Act — scroll, then wait two rAF frames for layout to commit before measuring.
+            await page.evaluate(() => new Promise<void>((resolve) => {
                 window.scrollTo(0, document.body.scrollHeight);
-            });
+                requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }));
 
             // Assert
             const finalPosition = await toastElement.boundingBox();

--- a/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 
 import type { PieToastProvider } from 'src/index.ts';
@@ -11,16 +11,27 @@ import {
 
 import { toastProvider } from '../helpers/page-object/selectors.ts';
 
+const QUEUE_UPDATE_LOG = 'toast provider queue:';
+
+/**
+ * Waits for the next `pie-toast-provider-queue-update` console log emitted by the story
+ * and returns the queue payload. Must be called BEFORE the action that triggers the update
+ * so the event is never missed.
+ */
+const waitForQueueUpdate = async (page: Page): Promise<ExtendedToastProps[]> => {
+    const msg = await page.waitForEvent(
+        'console',
+        (m) => m.text().includes(QUEUE_UPDATE_LOG),
+    );
+    return msg.args()[1].jsonValue() as Promise<ExtendedToastProps[]>;
+};
+
 test.describe('PieToastProvider - Component tests', () => {
     let toastsQueue: ExtendedToastProps[] = [];
 
-    test.beforeEach(({ page }) => {
-        // Set up a listener for the queue update log
-        page.on('console', async (message) => {
-            if (message.text().includes('toast provider queue:')) {
-                toastsQueue = await message.args()[1].jsonValue();
-            }
-        });
+    test.beforeEach(() => {
+        // Reset between tests so stale data from a previous run never bleeds into assertions.
+        toastsQueue = [];
     });
 
     test('should render successfully', async ({ page }) => {
@@ -42,7 +53,9 @@ test.describe('PieToastProvider - Component tests', () => {
             await pieToastProviderPage.load();
             await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
 
-            // Act
+            // Act — register the listener BEFORE triggering the action to avoid a race condition
+            // between the Lit update cycle dispatching the event and the assertion reading toastsQueue.
+            const queueUpdated = waitForQueueUpdate(page);
             await page.evaluate(() => {
                 const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
 
@@ -68,6 +81,7 @@ test.describe('PieToastProvider - Component tests', () => {
                     variant: 'error',
                 });
             });
+            toastsQueue = await queueUpdated;
 
             // Assert
             const queueVariants: Priority[] = toastsQueue.map((toast: ExtendedToastProps): Priority => `${toast.variant || toastDefaultProps.variant}${toast.leadingAction ? '-actionable' : ''}`);
@@ -84,18 +98,24 @@ test.describe('PieToastProvider - Component tests', () => {
             await pieToastProviderPage.load();
             await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
 
-            // Act
+            // Act — split into two evaluate calls so each step produces its own queue update
+            // event, making the "before clear" and "after clear" states independently verifiable.
+            const queuePopulated = waitForQueueUpdate(page);
             await page.evaluate(() => {
                 const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
-
                 toastProvider.createToast({ message: 'Toast 1', variant: 'neutral' });
                 toastProvider.createToast({ message: 'Toast 2', variant: 'success' });
-
-                toastProvider.clearToasts();
             });
+            await queuePopulated;
+
+            const queueCleared = waitForQueueUpdate(page);
+            await page.evaluate(() => {
+                (document.querySelector('pie-toast-provider') as PieToastProvider).clearToasts();
+            });
+            toastsQueue = await queueCleared;
 
             // Assert
-            await expect(toastsQueue.length).toBe(0);
+            expect(toastsQueue.length).toBe(0);
         });
     });
 
@@ -113,13 +133,16 @@ test.describe('PieToastProvider - Component tests', () => {
                 await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
 
                 // Act
+                const queueUpdated = waitForQueueUpdate(page);
                 await page.evaluate(() => {
                     const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
                     toastProvider.createToast({ message: 'Toast 1' });
                     toastProvider.createToast({ message: 'Toast 2' });
                 });
+                toastsQueue = await queueUpdated;
 
-                // Assert
+                // Assert — note: the first toast is immediately moved to _currentToast by the
+                // component, so toastsQueue only contains queued (not yet displayed) toasts.
                 toastsQueue.forEach((toast) => {
                     expect(toast.isDismissible).toBeTruthy();
                     expect(toast.variant).toBe('neutral');
@@ -137,14 +160,16 @@ test.describe('PieToastProvider - Component tests', () => {
                 await page.locator('pie-toast-provider').waitFor({ state: 'attached' });
 
                 // Act
+                const queueUpdated = waitForQueueUpdate(page);
                 await page.evaluate(() => {
                     const toastProvider = document.querySelector('pie-toast-provider') as PieToastProvider;
                     toastProvider.createToast({ message: 'Toast 1' });
                     toastProvider.createToast({ message: 'Toast 2' });
                     toastProvider.createToast({ message: 'Toast 3', isDismissible: false });
                 });
+                toastsQueue = await queueUpdated;
 
-                // Assert
+                // Assert — Toast 1 is displayed (_currentToast), Toasts 2 & 3 are in the queue.
                 expect(toastsQueue[0].isDismissible).toBeTruthy(); // Global option should apply
                 expect(toastsQueue[1].isDismissible).toBeFalsy(); // Override should take precedence
             });
@@ -161,7 +186,7 @@ test.describe('PieToastProvider - Component tests', () => {
 
             const consoleMessages: string[] = [];
             page.on('console', (message) => {
-                if (message.type() === 'info' && !message.text().includes('toast provider queue:')) {
+                if (message.type() === 'info' && !message.text().includes(QUEUE_UPDATE_LOG)) {
                     consoleMessages.push(message.text());
                 }
             });
@@ -172,7 +197,15 @@ test.describe('PieToastProvider - Component tests', () => {
             // Act
             const sectionButton = page.locator('pie-button').filter({ hasText: 'Interactive element' });
             await expect(sectionButton).toBeVisible();
+
+            // Register the listener BEFORE clicking to avoid a race condition between the click
+            // handler firing console.info and the CDP message arriving in the test process.
+            const consoleMessageReceived = page.waitForEvent(
+                'console',
+                (msg) => msg.type() === 'info' && msg.text() === expectedEventMessage,
+            );
             await sectionButton.click();
+            await consoleMessageReceived;
 
             // Assert
             expect(consoleMessages).toEqual([expectedEventMessage]);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### Problem

The `pie-toast-provider` component tests were intermittently failing in CI, also when run in local dev environment with `--repeat-each`. Failures were non-deterministic and difficult to reproduce locally under normal conditions.

All failures shared the same root cause: tests asserted against state that was not yet available, because the mechanism used to capture queue data was inherently asynchronous but the tests treated it as synchronous.

Tests relied on a `page.on('console', ...)` listener in `beforeEach` to populate a shared `toastsQueue` variable, which was then asserted against immediately after `page.evaluate()`.

The full chain between triggering an action and `toastsQueue` being updated spans multiple async hops:

`page.evaluate()` [synchronous browser JS]
→ Lit batches state changes (`_toasts = [...]`)
→ Lit `updated()` lifecycle fires (async microtask)
→ `_dispatchQueueUpdateEvent()` dispatches `CustomEvent`
→ Story's `onQueueUpdate` fires `console.info(...)`
→ Playwright sends console message to Node.js over CDP (IPC)
→ `beforeEach` listener sets `toastsQueue = [...]`

`page.evaluate()` returns to the test **after the synchronous JS executes - before any of those async steps complete**. Under local conditions the IPC round-trip is fast enough to pass most of the time. Under CI load the delay is enough to consistently expose the race.

Beyond the timing issue, the approach had several additional problems:

> `toastsQueue` never reset in `beforeEach`
Stale data from a previous test bled into the next test's assertions

> No synchronisation point after `page.evaluate()`
Assertions ran against stale or empty data

> Queue observer coupled to a story `console.info()` call
Any refactor of the story template silently breaks all queue-dependent tests

> `clearToasts` test: create and clear in one `page.evaluate()`
Lit batches all synchronous mutations into one `updated()` cycle, emitting only the final empty-queue event. The test passed trivially without ever observing the populated intermediate state

> Overrides test asserted by queue index
Priority-driven reordering could produce wrong index mappings

> Global options forEach ran on potentially empty array
If no snapshot had arrived yet the loop body never executed, silently passing without asserting anything

> Scrolling test sampled boundingBox mid-animation
`toBeVisible()` returns true during the slide-in animation, capturing a transient position rather than the settled one


### Solution

#### `installQueueListener` - listen to the component's public API directly

Instead of intercepting `console.info()` from the story, a browser-side listener is installed on the component's own `pie-toast-provider-queue-update` `CustomEvent`. Every emitted queue detail is `structuredClone`'d and appended to `window.__queueSnapshots`.

This removes the coupling to the Storybook story implementation entirely. Refactoring or removing the story's `console.info()` call no longer affects the tests.

```
async function installQueueListener(page: Page): Promise<void> {
    await page.evaluate(() => {
        window.__queueSnapshots = [];
        const provider = document.querySelector('pie-toast-provider');
        provider.addEventListener('pie-toast-provider-queue-update', (event) => {
            const { detail } = event as CustomEvent<ExtendedToastProps[]>;
            (window.__queueSnapshots ??= []).push(structuredClone(detail));
        });
    });
}
```

#### `afterNextSnapshot` - explicit, race-free synchronisation

Replaces the passive `page.on('console', ...)` pattern. It reads the current snapshot count before the action, then uses `page.waitForFunction` to poll in-browser until the count increases.
The event can never be missed because the reference point is established before anything fires.

```
async function afterNextSnapshot(page, action): Promise<ExtendedToastProps[]> {
    const countBefore = await page.evaluate(() => window.__queueSnapshots?.length ?? 0);
    await action();
    await page.waitForFunction(
        (count) => (window.__queueSnapshots?.length ?? 0) > count,
        countBefore,
    );
    const snapshots = await page.evaluate(() => window.__queueSnapshots ?? []);
    return snapshots[snapshots.length - 1];
}
```

Using `page.waitForFunction` (polling in the browser process) rather than `page.waitForEvent` (waiting on a CDP IPC message) keeps the synchronisation mechanism entirely browser-side, avoiding the same class of IPC race condition that caused the original failures.

#### Split `evaluate()` calls in the `clearToasts` test

All three operations (create × 2 + clear) previously ran inside a single `page.evaluate()`. Because they are synchronous, Lit batches them into one `updated()` cycle, emitting only the final empty-queue snapshot. The test passed trivially without ever proving the queue was populated in the first place.

Splitting into two separate `page.evaluate()` calls forces two distinct Lit update cycles and two distinct snapshots, making both the populated and cleared states independently observable and verified:

```
// First evaluate: proves toasts were enqueued
await afterNextSnapshot(page, () => page.evaluate(() => {
    tp.createToast({ message: 'Toast 1', variant: 'neutral' });
    tp.createToast({ message: 'Toast 2', variant: 'success' });
}));

// Second evaluate: proves clearToasts emptied the queue
const clearedQueue = await afterNextSnapshot(page, () => page.evaluate(() => {
    tp.clearToasts();
}));

expect(clearedQueue.length).toBe(0);
```

#### Identity-based toast lookup

The overrides test previously asserted by array index (`toastsQueue[0]`, `toastsQueue[1]`), which is fragile against priority-driven reordering. The replacement uses `findToastByMessage` to locate toasts by their unique message, making the assertion independent of queue ordering.

#### All-snapshots priority verification

The priority test now iterates every snapshot the provider emitted - not just the final queue state. This provides stronger coverage: if the component's sorting logic was ever correct at rest but briefly wrong during intermediate insertions, the test would now catch it.

#### Scrolling test: wait for animation and layout to settle

`toBeVisible()` returns true during the slide-in CSS animation, so sampling `boundingBox` immediately after could capture a transient mid-animation position. The fix waits for all animations on the toast element (and its subtree) to complete before reading the initial position, and waits two `requestAnimationFrame` cycles after `window.scrollTo` for layout to commit before taking the final measurement.

#### Elimination of shared mutable state

The `toastsQueue` describe-scope variable is removed entirely. Every test now receives queue data directly as a return value from `afterNextSnapshot` or `getQueueSnapshots`, making data flow explicit and eliminating the stale-state bleed problem at the root rather than papering over it with a `beforeEach` reset.

---
Files changed

- `packages/components/pie-toast-provider/test/component/pie-toast-provider.spec.ts` - rewrites the queue observation and synchronisation strategy; fixes all seven issues listed above
- `packages/components/AGENTS.md` - new leaf file documenting the async event chain, the correct listen → act → await → assert pattern, Lit update batching behaviour, and a reference table of common flakiness patterns to avoid in future tests

### Results

Running tests locally with `--repeat-each 20` now consistently passes without failures, whereas before it would often fail at least once.

```
yarn test:browsers --filter=@justeattakeaway/pie-toast-provider -- --repeat-each=20
```

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have filled out the DS Review Tracker checklist (Moving PR to "Ready to Review")

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Testing
[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)

| Task                   | Link                             |
|------------------------|----------------------------------|
| Aperture PR            | [🔗](#) |
| NextJS 15 deployment   | [🔗](#) |
| NextJS 14 deployment   | [🔗](#) |
| Nuxt 3 deployment      | [🔗](#) |
| Vanilla deployment     | [🔗](#) |

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have verified that all acceptance criteria for this ticket have been completed.

### Reviewer 2
- [x] I have verified that all acceptance criteria for this ticket have been completed.
