### PR TITLE
chore(pie-monorepo): DSW-1234 remove pie-aperture deployments table from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,17 +22,6 @@ Please move any Author checklist items that do not apply to this pull request he
 
 ---
 
-## Testing
-[How do I test my changes?](https://github.com/justeattakeaway/pie/wiki/PIE-Aperture)
-
-| Task                   | Link                             |
-|------------------------|----------------------------------|
-| Aperture PR            | [🔗](#) |
-| NextJS 15 deployment   | [🔗](#) |
-| NextJS 14 deployment   | [🔗](#) |
-| Nuxt 3 deployment      | [🔗](#) |
-| Vanilla deployment     | [🔗](#) |
-
 ## Reviewer checklists (complete before approving)
 Mark items as `[-] N/A` if not applicable.
 


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
Given PIE Aperture deployments are now shown directly in PIE, we no longer need to render this table within our PR descriptions.