### PR TITLE
chore(pie-monorepo-utils): DSW-3604 move utility functions

### DIFF
--- a/packages/tools/pie-icons/bin/update-icons.mjs
+++ b/packages/tools/pie-icons/bin/update-icons.mjs
@@ -1,11 +1,12 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/extensions */
 import path from 'path';
-import { execFileSync, execSync } from 'child_process';
+import { execSync } from 'child_process';
 import {
     emptyDirSync, removeSync, readJSONSync, writeJsonSync,
 } from 'fs-extra/esm';
 import slugify from 'slugify';
+import { appendToGithubEnv, configureGitUser } from '@justeattakeaway/pie-monorepo-utils/utils/github-utils.js';
 
 import { getConfig } from './config.mjs';
 import { syncIcons } from './sync-icons.mjs';
@@ -209,15 +210,8 @@ async function updateIcons () {
         const pieDocsChangesetFilePath = await createPieDocsChangeset(pieDocsTestsPath);
         const changesetFilePath = await createIconsChangeset(changedFilesGroups);
 
-        // check if is running on GHA and setup the git user
-        if (process.env.GITHUB_ACTIONS) {
-            // configure git and push
-            const gitUserName = process.env.GIT_USER_NAME || 'github-actions[bot]';
-            const gitUserEmail = process.env.GIT_USER_EMAIL || '41898282+github-actions[bot]@users.noreply.github.com';
-
-            execFileSync('git', ['config', '--global', 'user.name', gitUserName]);
-            execFileSync('git', ['config', '--global', 'user.email', gitUserEmail]);
-        }
+        // setup the git user for CI environment
+        configureGitUser();
 
         const gitUpdatedPaths = [changesetFilePath, iconsDataFilePath, pieDocsTestsPath, pieDocsChangesetFilePath]
             .filter(Boolean).join(' ');
@@ -228,8 +222,8 @@ async function updateIcons () {
         // push if is running on GHA
         if (process.env.GITHUB_ACTIONS) {
             execSync(`git push --set-upstream origin ${branchName} --no-verify`);
-            execSync(`echo "BRANCH_NAME=${branchName}" >> $GITHUB_ENV`);
-            execSync(`echo "CHANGESET_FILE_PATH=${changesetFilePath}" >> $GITHUB_ENV`);
+            appendToGithubEnv('BRANCH_NAME', branchName);
+            appendToGithubEnv('CHANGESET_FILE_PATH', changesetFilePath);
         }
     }
 

--- a/packages/tools/pie-icons/package.json
+++ b/packages/tools/pie-icons/package.json
@@ -32,6 +32,7 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
+    "@justeattakeaway/pie-monorepo-utils": "0.9.0",
     "cheerio": "1.0.0-rc.12",
     "classnames": "2.5.1",
     "html-minifier-terser": "7.2.0",

--- a/packages/tools/pie-monorepo-utils/eslint-plugin-update/detect-changes.js
+++ b/packages/tools/pie-monorepo-utils/eslint-plugin-update/detect-changes.js
@@ -1,11 +1,13 @@
 const path = require('path');
 const fs = require('fs');
-const { execFileSync, execSync } = require('child_process');
+const { execSync } = require('child_process');
 
 const { extractComponentData } = require('@justeattakeaway/eslint-plugin-snacks-pie-migration/extract-component-data');
 const findMonorepoRoot = require('../utils/find-monorepo-root');
 const { BRANCH_PREFIX, diffComponentData } = require('./shared');
-const { appendToGithubOutput, appendToGithubEnv, appendJsonToGithubEnv } = require('../utils/github-utils');
+const {
+    appendToGithubOutput, appendToGithubEnv, appendJsonToGithubEnv, configureGitUser,
+} = require('../utils/github-utils');
 
 const ESLINT_PLUGIN_PACKAGE = '@justeattakeaway/eslint-plugin-snacks-pie-migration';
 
@@ -14,15 +16,6 @@ function hasDiff (diff) {
         diff.removed.length > 0 ||
         diff.statusChanged.length > 0 ||
         diff.snacksChanged.length > 0;
-}
-
-function configureGitUser () {
-    if (!process.env.GITHUB_ENV) return;
-
-    const gitUserName = process.env.GIT_USER_NAME || 'github-actions[bot]';
-    const gitUserEmail = process.env.GIT_USER_EMAIL || '41898282+github-actions[bot]@users.noreply.github.com';
-    execFileSync('git', ['config', '--global', 'user.name', gitUserName]);
-    execFileSync('git', ['config', '--global', 'user.email', gitUserEmail]);
 }
 
 /**

--- a/packages/tools/pie-monorepo-utils/eslint-plugin-update/detect-changes.js
+++ b/packages/tools/pie-monorepo-utils/eslint-plugin-update/detect-changes.js
@@ -5,6 +5,7 @@ const { execFileSync, execSync } = require('child_process');
 const { extractComponentData } = require('@justeattakeaway/eslint-plugin-snacks-pie-migration/extract-component-data');
 const findMonorepoRoot = require('../utils/find-monorepo-root');
 const { BRANCH_PREFIX, diffComponentData } = require('./shared');
+const { appendToGithubOutput, appendToGithubEnv, appendJsonToGithubEnv } = require('../utils/github-utils');
 
 const ESLINT_PLUGIN_PACKAGE = '@justeattakeaway/eslint-plugin-snacks-pie-migration';
 
@@ -13,21 +14,6 @@ function hasDiff (diff) {
         diff.removed.length > 0 ||
         diff.statusChanged.length > 0 ||
         diff.snacksChanged.length > 0;
-}
-
-function appendToGithubOutput (key, value) {
-    if (!process.env.GITHUB_OUTPUT) return;
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
-}
-
-function appendToGithubEnv (key, value) {
-    if (!process.env.GITHUB_ENV) return;
-    fs.appendFileSync(process.env.GITHUB_ENV, `${key}=${value}\n`);
-}
-
-function appendJsonToGithubEnv (key, value) {
-    if (!process.env.GITHUB_ENV) return;
-    fs.appendFileSync(process.env.GITHUB_ENV, `${key}<<EOF\n${JSON.stringify(value)}\nEOF\n`);
 }
 
 function configureGitUser () {

--- a/packages/tools/pie-monorepo-utils/utils/github-utils.js
+++ b/packages/tools/pie-monorepo-utils/utils/github-utils.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+function appendToGithubOutput (key, value) {
+    if (!process.env.GITHUB_OUTPUT) return;
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+}
+
+function appendToGithubEnv (key, value) {
+    if (!process.env.GITHUB_ENV) return;
+    fs.appendFileSync(process.env.GITHUB_ENV, `${key}=${value}\n`);
+}
+
+function appendJsonToGithubEnv (key, value) {
+    if (!process.env.GITHUB_ENV) return;
+    fs.appendFileSync(process.env.GITHUB_ENV, `${key}<<EOF\n${JSON.stringify(value)}\nEOF\n`);
+}
+
+function configureGitUser () {
+    if (!process.env.GITHUB_ENV) return;
+
+    const gitUserName = process.env.GIT_USER_NAME || 'github-actions[bot]';
+    const gitUserEmail = process.env.GIT_USER_EMAIL || '41898282+github-actions[bot]@users.noreply.github.com';
+    execFileSync('git', ['config', '--global', 'user.name', gitUserName]);
+    execFileSync('git', ['config', '--global', 'user.email', gitUserEmail]);
+}
+
+module.exports = {
+    appendToGithubOutput, appendToGithubEnv, appendJsonToGithubEnv, configureGitUser,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3811,6 +3811,7 @@ __metadata:
   dependencies:
     "@babel/node": 7.29.0
     "@changesets/write": 0.4.0
+    "@justeattakeaway/pie-monorepo-utils": 0.9.0
     babel-loader: 8.3.0
     cheerio: 1.0.0-rc.12
     classnames: 2.5.1


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

Clean-up PR create after https://github.com/justeattakeaway/pie/pull/2842 to extract common GitHub Actions helper functions into a shared utility module in `@justeattakeaway/pie-monorepo-utils` and update existing automation scripts to consume that shared implementation.

- Extracts duplicated GitHub Actions utility functions (`appendToGithubOutput`, `appendToGithubEnv`, `appendJsonToGithubEnv`, `configureGitUser`) into a new shared module at `packages/tools/pie-monorepo-utils/utils/github-utils.js`
- Removes the duplicate implementations from `eslint-plugin-update/detect-changes.js` and `pie-icons/bin/update-icons.mjs`, replacing them with imports from the shared module

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have reviewed visual test updates properly before approving.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have verified that all acceptance criteria for this ticket have been completed.

### Reviewer 2
- [x] I have verified that all acceptance criteria for this ticket have been completed.
