### PR TITLE
feat(pie-checkbox): DSW-3919 label fit and position properties

### DIFF
--- a/.changeset/orange-apes-relax.md
+++ b/.changeset/orange-apes-relax.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-checkbox": minor
+"@justeattakeaway/pie-storybook": minor
+---
+
+[Added] - LabelFit and LabelPosition properties for Checkbox label styling

--- a/apps/pie-storybook/stories/pie-checkbox.stories.ts
+++ b/apps/pie-storybook/stories/pie-checkbox.stories.ts
@@ -3,7 +3,9 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { type Meta } from '@storybook/web-components';
 
 import '@justeattakeaway/pie-webc/components/checkbox';
-import { type CheckboxProps as CheckboxBaseProps, defaultProps, statusTypes } from '@justeattakeaway/pie-webc/components/checkbox';
+import {
+    type CheckboxProps as CheckboxBaseProps, defaultProps, statusTypes, labelPositions, labelFits,
+} from '@justeattakeaway/pie-webc/components/checkbox';
 
 import { action } from 'storybook/actions';
 import { type SlottedComponentProps } from '../types';
@@ -96,6 +98,24 @@ const checkboxStoryMeta: CheckboxStoryMeta = {
                 summary: defaultProps.status,
             },
         },
+
+        labelPosition: {
+            description: 'The position of the label relative to the checkbox input.',
+            control: 'select',
+            options: labelPositions,
+            defaultValue: {
+                summary: defaultProps.labelPosition,
+            },
+        },
+
+        labelFit: {
+            description: 'Controls how the label container is sized. `hug` wraps the content, `fill` stretches to fill available width.',
+            control: 'select',
+            options: labelFits,
+            defaultValue: {
+                summary: defaultProps.labelFit,
+            },
+        },
     },
     args: defaultArgs,
     parameters: {
@@ -118,6 +138,8 @@ const Template = ({
     required,
     assistiveText,
     status,
+    labelPosition,
+    labelFit,
     slot,
 }: CheckboxProps) => {
     function onChange (event: CustomEvent) {
@@ -137,7 +159,9 @@ const Template = ({
             ?required="${required}"
             @change="${onChange}"
             assistiveText="${ifDefined(assistiveText)}"
-            status=${ifDefined(status)}>
+            status=${ifDefined(status)}
+            labelPosition=${ifDefined(labelPosition)}
+            labelFit=${ifDefined(labelFit)}>
             ${sanitizeAndRenderHTML(slot)}
         </pie-checkbox>
     `;
@@ -222,3 +246,94 @@ export const RichLabel = createStory<CheckboxProps>(Template, {
     ...defaultArgs,
     slot: richLabelSlot,
 })();
+
+export const LabelTrailing = createStory<CheckboxProps>(Template, {
+    ...defaultArgs,
+    labelPosition: 'trailing',
+})();
+
+export const LabelLeading = createStory<CheckboxProps>(Template, {
+    ...defaultArgs,
+    labelPosition: 'leading',
+})();
+
+export const RichLabelLeading = createStory<CheckboxProps>(Template, {
+    ...defaultArgs,
+    slot: richLabelSlot,
+    labelPosition: 'leading',
+})();
+
+export const RichLabelTrailing = createStory<CheckboxProps>(Template, {
+    ...defaultArgs,
+    slot: richLabelSlot,
+    labelPosition: 'trailing',
+})();
+
+const LabelFitComparisonTemplate = ({
+    value,
+    name,
+    checked,
+    defaultChecked,
+    disabled,
+    indeterminate,
+    required,
+    assistiveText,
+    status,
+    slot,
+}: CheckboxProps) => html`
+    <style>
+        .label-fit-demo pie-checkbox {
+            background: rgba(0, 123, 255, 0.06);
+            outline: 1px dashed rgba(0, 123, 255, 0.3);
+        }
+    </style>
+    <div class="label-fit-demo" style="display: flex; flex-direction: column; gap: 16px; width: 400px; border: 1px dashed var(--dt-color-border-default); padding: 16px;">
+        <p style="margin: 0; font-family: var(--dt-font-body-l-family); font-size: 14px; color: var(--dt-color-content-subdued);">labelPosition="trailing" labelFit="hug" (default)</p>
+        <pie-checkbox
+            .value="${value}"
+            name="${ifDefined(name)}"
+            ?checked="${checked}"
+            ?defaultChecked="${defaultChecked}"
+            ?disabled="${disabled}"
+            ?indeterminate="${indeterminate}"
+            ?required="${required}"
+            assistiveText="${ifDefined(assistiveText)}"
+            status=${ifDefined(status)}
+            labelFit="hug">
+            ${sanitizeAndRenderHTML(slot)}
+        </pie-checkbox>
+        <p style="margin: 0; font-family: var(--dt-font-body-l-family); font-size: 14px; color: var(--dt-color-content-subdued);">labelPosition="leading" labelFit="hug"</p>
+        <pie-checkbox
+            .value="${value}"
+            name="${ifDefined(name)}"
+            ?checked="${checked}"
+            ?defaultChecked="${defaultChecked}"
+            ?disabled="${disabled}"
+            ?indeterminate="${indeterminate}"
+            ?required="${required}"
+            assistiveText="${ifDefined(assistiveText)}"
+            status=${ifDefined(status)}
+            labelPosition="leading"
+            labelFit="hug">
+            ${sanitizeAndRenderHTML(slot)}
+        </pie-checkbox>
+        <p style="margin: 0; font-family: var(--dt-font-body-l-family); font-size: 14px; color: var(--dt-color-content-subdued);">labelPosition="leading" labelFit="fill" — checkbox pushed to far right</p>
+        <pie-checkbox
+            .value="${value}"
+            name="${ifDefined(name)}"
+            ?checked="${checked}"
+            ?defaultChecked="${defaultChecked}"
+            ?disabled="${disabled}"
+            ?indeterminate="${indeterminate}"
+            ?required="${required}"
+            assistiveText="${ifDefined(assistiveText)}"
+            status=${ifDefined(status)}
+            labelPosition="leading"
+            labelFit="fill">
+            ${sanitizeAndRenderHTML(slot)}
+        </pie-checkbox>
+    </div>
+`;
+
+export const LabelFitComparison = createStory<CheckboxProps>(LabelFitComparisonTemplate, defaultArgs)();
+

--- a/apps/pie-storybook/stories/testing/pie-checkbox.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-checkbox.test.stories.ts
@@ -3,7 +3,9 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { type Meta } from '@storybook/web-components';
 
 import '@justeattakeaway/pie-webc/components/checkbox';
-import { type CheckboxProps as CheckboxBaseProps, defaultProps, statusTypes } from '@justeattakeaway/pie-webc/components/checkbox';
+import {
+    type CheckboxProps as CheckboxBaseProps, defaultProps, statusTypes, labelPositions, labelFits,
+} from '@justeattakeaway/pie-webc/components/checkbox';
 
 import { type SlottedComponentProps } from '../../types';
 import {
@@ -113,6 +115,8 @@ const Template = ({
     required,
     assistiveText,
     status,
+    labelPosition,
+    labelFit,
     slot,
 }: CheckboxProps) => {
     function onChange (event: CustomEvent) {
@@ -130,7 +134,9 @@ const Template = ({
             ?required="${required}"
             @change="${onChange}"
             assistiveText="${ifDefined(assistiveText)}"
-            status=${ifDefined(status)}>
+            status=${ifDefined(status)}
+            labelPosition=${ifDefined(labelPosition)}
+            labelFit=${ifDefined(labelFit)}>
             ${sanitizeAndRenderHTML(slot)}
         </pie-checkbox>
     `;
@@ -271,3 +277,36 @@ const checkedTruePropsMatrix: Partial<Record<keyof CheckboxProps, unknown[]>> = 
 
 export const CheckedFalseVariations = createVariantStory<CheckboxProps>(Template, checkedFalsePropsMatrix);
 export const CheckedTrueVariations = createVariantStory<CheckboxProps>(Template, checkedTruePropsMatrix);
+
+const labelPositionPropsMatrix: Partial<Record<keyof CheckboxProps, unknown[]>> = {
+    slot: ['Label'],
+    labelPosition: [...labelPositions],
+    labelFit: [...labelFits],
+    checked: [true, false],
+};
+
+export const LabelPositionVariations = createVariantStory<CheckboxProps>(Template, labelPositionPropsMatrix);
+
+const richLabelSlot = `<div style="
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: var(--dt-spacing-a);
+">
+    <span class="u-font-body-l">A yummy dish</span>
+    <span class="u-font-body-l">£2.50</span>
+    <span class="u-font-caption" style="
+        width: 100%;
+        color: var(--dt-color-content-subdued);
+    ">
+        Some description as a part of the label
+    </span>
+</div>`;
+
+const richLabelPropsMatrix: Partial<Record<keyof CheckboxProps, unknown[]>> = {
+    slot: [richLabelSlot],
+    labelPosition: [...labelPositions],
+    checked: [true, false],
+};
+
+export const RichLabelVariations = createVariantStory<CheckboxProps>(Template, richLabelPropsMatrix);

--- a/packages/components/pie-checkbox/README.md
+++ b/packages/components/pie-checkbox/README.md
@@ -44,6 +44,8 @@ Ideally, you should install the component using the **`@justeattakeaway/pie-webc
 | `indeterminate`  | `-`                                    | Indicates whether the checkbox visually shows a horizontal line in the box instead of a check/tick. It has no impact on whether the checkbox's value is used in a form submission. That is decided by the checked state, regardless of the indeterminate state.                                                                          | `false`     |
 | `assistiveText`  | `-`                                    | Allows assistive text to be displayed below the checkbox element.                                                                                                                                                                                                                                                                                                                | `-`         |
 | `status`         | `"default"`, `"error"`, `"success"`    | The status of the checkbox component / assistive text. If you use `status` you must provide an `assistiveText` prop value for accessibility purposes.                                                                                                                                                                                                                            | `"default"` |
+| `labelPosition`  | `"trailing"`, `"leading"`              | The position of the label relative to the checkbox input. `trailing` places the label after the checkbox, `leading` places it before.                                                                                                                                                                                                                                           | `"trailing"` |
+| `labelFit`       | `"hug"`, `"fill"`                      | Controls how the label container is sized. `hug` wraps the content, `fill` stretches to fill the available width.                                                                                                                                                                                                                                                               | `"hug"`     |
 
 ### Slots
 
@@ -122,6 +124,19 @@ import '@justeattakeaway/pie-webc/components/checkbox.js';
 <pie-checkbox name="mycheckbox" aria-label="Label"></pie-checkbox>
 ```
 
+**Label positioning and fit:**
+
+```html
+<!-- Leading label (label appears before the checkbox) -->
+<pie-checkbox name="mycheckbox" labelPosition="leading">Label</pie-checkbox>
+
+<!-- Fill label (label container stretches to fill available width) -->
+<pie-checkbox name="mycheckbox" labelFit="fill">Label</pie-checkbox>
+
+<!-- Combined leading + fill -->
+<pie-checkbox name="mycheckbox" labelPosition="leading" labelFit="fill">Label</pie-checkbox>
+```
+
 **For React Applications:**
 
 ```jsx
@@ -131,6 +146,12 @@ import { PieCheckbox } from '@justeattakeaway/pie-webc/react/checkbox.js';
 
 // Always use aria-label if you are not passing a label
 <PieCheckbox name="mycheckbox" aria-label="Label"></PieCheckbox>
+
+// Leading label
+<PieCheckbox name="mycheckbox" labelPosition="leading">Label</PieCheckbox>
+
+// Fill label
+<PieCheckbox name="mycheckbox" labelFit="fill">Label</PieCheckbox>
 ```
 
 ### Rich Label Slot Content

--- a/packages/components/pie-checkbox/src/checkbox.scss
+++ b/packages/components/pie-checkbox/src/checkbox.scss
@@ -4,6 +4,7 @@
     display: block;
 }
 
+
 @keyframes checkboxCheck {
     0% {
         width: 0;
@@ -222,6 +223,7 @@
 
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
 
     input {
         display: block;
@@ -239,6 +241,29 @@
         max-width: 100%;
         white-space: nowrap;
         cursor: pointer;
+    }
+
+    &.c-checkbox--leading {
+        label {
+            flex-direction: row-reverse;
+        }
+
+        .c-checkbox-text {
+            margin-inline-start: 0;
+            margin-inline-end: var(--checkbox-gap);
+        }
+    }
+
+    &.c-checkbox--fill {
+        align-items: stretch;
+
+        label {
+            justify-content: space-between;
+        }
+
+        .c-checkbox-text {
+            flex: 0 1 auto;
+        }
     }
 
     &:hover {

--- a/packages/components/pie-checkbox/src/defs.ts
+++ b/packages/components/pie-checkbox/src/defs.ts
@@ -1,6 +1,9 @@
 import { type ComponentDefaultProps } from '@justeattakeaway/pie-webc-core';
 
 export const statusTypes = ['default', 'success', 'error'] as const;
+export const labelPositions = ['leading', 'trailing'] as const;
+export const labelFits = ['hug', 'fill'] as const;
+
 export interface CheckboxProps {
     /**
      * The value of the checkbox (used as a key/value pair in HTML forms with `name`).
@@ -47,6 +50,16 @@ export interface CheckboxProps {
      * The status of the checkbox component / assistive text. Can be default, success or error.
      */
     status?: typeof statusTypes[number];
+
+    /**
+     * The position of the label relative to the checkbox input.
+     */
+    labelPosition?: typeof labelPositions[number];
+
+    /**
+     * Controls how the label container is sized. `hug` wraps the content, `fill` stretches to fill available width.
+     */
+    labelFit?: typeof labelFits[number];
 }
 
 export type DefaultProps = ComponentDefaultProps<CheckboxProps, keyof Omit<CheckboxProps, 'name' | 'assistiveText'>>;
@@ -61,4 +74,6 @@ export const defaultProps: DefaultProps = {
     indeterminate: false,
     required: false,
     status: 'default',
+    labelPosition: 'trailing',
+    labelFit: 'hug',
 };

--- a/packages/components/pie-checkbox/src/index.ts
+++ b/packages/components/pie-checkbox/src/index.ts
@@ -15,7 +15,9 @@ import {
 import '@justeattakeaway/pie-assistive-text';
 
 import styles from './checkbox.scss?inline';
-import { type CheckboxProps, defaultProps, statusTypes } from './defs';
+import {
+    type CheckboxProps, defaultProps, statusTypes, labelPositions, labelFits,
+} from './defs';
 
 // Valid values available to consumers
 export * from './defs';
@@ -69,6 +71,14 @@ export class PieCheckbox extends DelegatesFocusMixin(FormControlMixin(PieElement
     @property({ type: String })
     @validPropertyValues(componentSelector, statusTypes, defaultProps.status)
     public status = defaultProps.status;
+
+    @property({ type: String, reflect: true })
+    @validPropertyValues(componentSelector, labelPositions, defaultProps.labelPosition)
+    public labelPosition = defaultProps.labelPosition;
+
+    @property({ type: String, reflect: true })
+    @validPropertyValues(componentSelector, labelFits, defaultProps.labelFit)
+    public labelFit = defaultProps.labelFit;
 
     private _abortController!: AbortController;
 
@@ -168,6 +178,8 @@ export class PieCheckbox extends DelegatesFocusMixin(FormControlMixin(PieElement
             indeterminate,
             assistiveText,
             status,
+            labelPosition,
+            labelFit,
         } = this;
 
         const componentDisabled = disabled || _disabledByParent;
@@ -178,6 +190,8 @@ export class PieCheckbox extends DelegatesFocusMixin(FormControlMixin(PieElement
             'is-disabled': componentDisabled,
             'is-checked': checked,
             'is-indeterminate': indeterminate && !checked,
+            'c-checkbox--leading': labelPosition === 'leading',
+            'c-checkbox--fill': labelFit === 'fill',
         };
 
         const labelClasses = {

--- a/packages/components/pie-checkbox/test/visual/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/visual/pie-checkbox.spec.ts
@@ -13,3 +13,23 @@ checkedStates.forEach((state) => test(`should render all prop variations for the
     // Assert
     await percySnapshot(page, `PIE Checkbox - Checked State: ${state}`, percyWidths);
 }));
+
+test('should render all label position and fit variations', async ({ page }) => {
+    // Arrange
+    const labelPositionPage = new BasePage(page, 'checkbox--label-position-variations');
+    labelPositionPage.waitUntilStrategy = 'networkidle';
+    await labelPositionPage.load();
+
+    // Assert
+    await percySnapshot(page, 'PIE Checkbox - Label Position Variations', percyWidths);
+});
+
+test('should render all rich label variations', async ({ page }) => {
+    // Arrange
+    const richLabelPage = new BasePage(page, 'checkbox--rich-label-variations');
+    richLabelPage.waitUntilStrategy = 'networkidle';
+    await richLabelPage.load();
+
+    // Assert
+    await percySnapshot(page, 'PIE Checkbox - Rich Label Variations', percyWidths);
+});


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Adds two new properties to checkbox: `labelFit` and `labelPosition` - they allow labels to be set leading/trailing and hug/fill the container the checkbox sits in

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

https://github.com/justeattakeaway/pie-aperture/pull/474

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
