### PR TITLE
chore(pie-monorepo): DSW-123 fix changeset

### DIFF
--- a/.changeset/good-jobs-allow.md
+++ b/.changeset/good-jobs-allow.md
@@ -1,5 +1,36 @@
 ---
 "@justeattakeaway/pie-components-config": patch
+"@justeattakeaway/pie-assistive-text": patch
+"@justeattakeaway/pie-avatar": patch
+"@justeattakeaway/pie-breadcrumb": patch
+"@justeattakeaway/pie-button": patch
+"@justeattakeaway/pie-card": patch
+"@justeattakeaway/pie-checkbox": patch
+"@justeattakeaway/pie-checkbox-group": patch
+"@justeattakeaway/pie-chip": patch
+"@justeattakeaway/pie-cookie-banner": patch
+"@justeattakeaway/pie-data-table": patch
+"@justeattakeaway/pie-divider": patch
+"@justeattakeaway/pie-form-label": patch
+"@justeattakeaway/pie-icon-button": patch
+"@justeattakeaway/pie-link": patch
+"@justeattakeaway/pie-list": patch
+"@justeattakeaway/pie-lottie-player": patch
+"@justeattakeaway/pie-modal": patch
+"@justeattakeaway/pie-notification": patch
+"@justeattakeaway/pie-radio": patch
+"@justeattakeaway/pie-radio-group": patch
+"@justeattakeaway/pie-select": patch
+"@justeattakeaway/pie-spinner": patch
+"@justeattakeaway/pie-switch": patch
+"@justeattakeaway/pie-tabs": patch
+"@justeattakeaway/pie-tag": patch
+"@justeattakeaway/pie-text-input": patch
+"@justeattakeaway/pie-textarea": patch
+"@justeattakeaway/pie-thumbnail": patch
+"@justeattakeaway/pie-toast": patch
+"@justeattakeaway/pie-toast-provider": patch
+"@justeattakeaway/pie-webc": patch
 ---
 
 [Updated] - `@custom-elements-manifest/analyzer` to version that fixes issue with new version of TS - https://github.com/open-wc/custom-elements-manifest/blob/master/packages/analyzer/CHANGELOG.md#release-094


### PR DESCRIPTION
Fixes changeset to trigger a `patch` bump for PIE components. I thought `pie-components-config` alone would trigger this, but apparently not as it's a devDep - In this case we _do_ need to bump packages as `custom-elements.json` is published as part of the packages.