### PR TITLE
fix(pie-notification): DSW-3824 remove nested landmarks in template

### DIFF
--- a/.changeset/small-actors-admire.md
+++ b/.changeset/small-actors-admire.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": minor
+---
+
+[Added] - Notification story with no actions

--- a/.changeset/thin-dancers-watch.md
+++ b/.changeset/thin-dancers-watch.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-notification": minor
+---
+
+[Changed] - Tidy up markup in Notification template to remove nested landmarks

--- a/apps/pie-storybook/stories/pie-notification.stories.ts
+++ b/apps/pie-storybook/stories/pie-notification.stories.ts
@@ -214,6 +214,10 @@ export const Success = createNotificationStory({ variant: 'success' });
 export const Error = createNotificationStory({ variant: 'error' });
 export const Warning = createNotificationStory({ variant: 'warning' });
 export const Translucent = createNotificationStory({ variant: 'translucent' });
+export const NoActions = createNotificationStory({
+    leadingAction: undefined,
+    supportingAction: undefined,
+});
 export const WithLinkActions = createNotificationStory({
     variant: 'info',
     heading: 'Update Available',

--- a/packages/components/pie-notification/src/index.ts
+++ b/packages/components/pie-notification/src/index.ts
@@ -156,14 +156,14 @@ export class PieNotification extends PieElement implements NotificationProps {
             [`${componentClass}-footer--stacked`]: hasStackedActions && !isCompact,
         };
         return html`
-            <footer
+            <div
                 class="${classMap(classes)}"
                 data-test-id="${componentSelector}-footer">
                     ${this.renderSupportingAction()}
                     <slot name="supportingAction"></slot>
                     ${this.renderLeadingAction()}
                     <slot name="leadingAction"></slot>
-            </footer>
+            </div>
         `;
     }
 
@@ -347,13 +347,13 @@ export class PieNotification extends PieElement implements NotificationProps {
                 aria-label="${!heading && ifDefined(aria?.label)}">
                 ${showCloseButton ? this.renderCloseButton() : nothing}
 
-                <section class="${classMap(contentSectionClasses)}">
+                <div class="${classMap(contentSectionClasses)}">
                     ${!hideIcon ? this.renderIcon() : nothing}
-                    <article>
+                    <div>
                         ${heading ? this.renderNotificationHeading() : nothing}
                         <slot></slot>
-                    </article>
-                </section>
+                    </div>
+                </div>
 
                 ${this.renderFooter()}
             </div>`;


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Tidies up the Notification markup - was using sections, articles and footers which was causing a "Contentinfo landmark must not be contained in another landmark" error in some a11y tests

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
