### PR TITLE
ci(pie-monorepo): DSW-123 improve amplify cleanup logic

### DIFF
--- a/.github/workflows/closed.yml
+++ b/.github/workflows/closed.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: List repo environments
+      - name: Check repo environments
         id: list-environments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -41,19 +41,21 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // List environments
-            const environments = await github.rest.repos.getAllEnvironments({
-              owner: owner,
-              repo: repo,
-              per_page: 100,
-            });
+            async function environmentExists(name) {
+              try {
+                await github.rest.repos.getEnvironment({ owner, repo, environment_name: name });
+                return true;
+              } catch (e) {
+                if (e.status === 404) return false;
+                throw e;
+              }
+            }
 
-            const envList = environments.data.environments.map(env => env.name);
-
-            // Check for existence of specific environments
-            const hasDocsEnv = envList.includes(`docs-pr-${pull_number}`);
-            const hasStorybookEnv = envList.includes(`storybook-pr-${pull_number}`);
-            const hasStorybookTestingEnv = envList.includes(`storybook-testing-pr-${pull_number}`);
+            const [hasDocsEnv, hasStorybookEnv, hasStorybookTestingEnv] = await Promise.all([
+              environmentExists(`docs-pr-${pull_number}`),
+              environmentExists(`storybook-pr-${pull_number}`),
+              environmentExists(`storybook-testing-pr-${pull_number}`),
+            ]);
 
             core.setOutput('hasDocsEnv', hasDocsEnv);
             core.setOutput('hasStorybookEnv', hasStorybookEnv);


### PR DESCRIPTION
Improves Amplify deployment clean-up, the previous logic fetched all environments, with the `per_page: 100` causing some envs to not return and be cleaned up.