### PR TITLE
fix(pie-checkbox): DSW-3824 remove excess whitespace from host element

### DIFF
--- a/.changeset/empty-loops-remain.md
+++ b/.changeset/empty-loops-remain.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-checkbox": minor
+---
+
+[Fixed] - Do not allow checkbox to fill entire container width with whitespace touch target unless labelFit="fill"

--- a/packages/components/pie-checkbox/src/checkbox.scss
+++ b/packages/components/pie-checkbox/src/checkbox.scss
@@ -2,8 +2,7 @@
 
 :host {
     display: block;
-    width: max-content;
-    max-width: 100%;
+    width: fit-content;
 }
 
 :host([labelFit='fill']) {

--- a/packages/components/pie-checkbox/src/checkbox.scss
+++ b/packages/components/pie-checkbox/src/checkbox.scss
@@ -243,7 +243,6 @@
     label {
         display: flex;
         width: 100%;
-        max-width: 100%;
         white-space: nowrap;
         cursor: pointer;
     }

--- a/packages/components/pie-checkbox/src/checkbox.scss
+++ b/packages/components/pie-checkbox/src/checkbox.scss
@@ -2,8 +2,13 @@
 
 :host {
     display: block;
+    width: max-content;
+    max-width: 100%;
 }
 
+:host([labelFit='fill']) {
+    width: 100%;
+}
 
 @keyframes checkboxCheck {
     0% {
@@ -114,7 +119,7 @@
         border-bottom: 2px solid transparent;
         transform: rotate(45deg);
         transform-origin: 0% 100%;
-    
+
         @media (prefers-reduced-motion: reduce) {
             animation-duration: 1ms !important;
             animation-delay: 0 !important;
@@ -125,7 +130,7 @@
             border-bottom-right-radius: 2px;
             transform: translate3d(0, -16px, 0) rotate(45deg);
         }
-    
+
         @media only percy {
             animation: none;
             width: 8px;
@@ -140,7 +145,7 @@
     &.is-checked.is-animated:before {
         animation: checkboxCheck var(--dt-motion-timing-150) var(--checkbox-motion-easing) forwards;
     }
-    
+
     &.is-checked:not(.is-animated):before {
         width: 8px;
         height: 16px;
@@ -238,6 +243,7 @@
 
     label {
         display: flex;
+        width: 100%;
         max-width: 100%;
         white-space: nowrap;
         cursor: pointer;


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Set the internal label to 100% width to allow for more flexible custom label text styles
- Set the width on default checkboxes to `max-content` to ensure that they do not fill the entire container width with an empty whitespace that triggers active and hover styles but not checkbox interactions (this was a bug we hadn't previously spotted)
- Ensure the max-width of the label does not exceed containers

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1 - @xander-marjoram 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2 - @siggerzz 
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [x] If there are visual test updates, I have reviewed them.
