### PR TITLE
fix(pie-card): DSW-123 ensure inner div matches host el height

### DIFF
--- a/.changeset/chatty-stamps-arrive.md
+++ b/.changeset/chatty-stamps-arrive.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-storybook": minor
+---
+
+[Added] - Demo story to pie-card showing how to create card grids where cards on each row match the height of the tallest card in that row

--- a/.changeset/flat-cycles-create.md
+++ b/.changeset/flat-cycles-create.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-card": minor
+---
+
+[Fixed] - Ensure inner div inside pie-card will occupy the full height of the host element

--- a/apps/pie-storybook/stories/pie-card.stories.ts
+++ b/apps/pie-storybook/stories/pie-card.stories.ts
@@ -151,6 +151,74 @@ export const Default = createCardStory();
 export const Outline = createCardStory({ variant: 'outline' });
 export const Inverse = createCardStory({ variant: 'inverse' }, { bgColor: 'dark (container-dark)' });
 export const OutlineInverse = createCardStory({ variant: 'outline-inverse' }, { bgColor: 'dark (container-dark)' });
+const EqualHeightCardsTemplate: TemplateFunction<CardProps> = ({
+    variant,
+    padding,
+    tag,
+    disabled,
+    isDraggable,
+}) => {
+    const cards = [
+        {
+            title: 'Short card',
+            content: 'Just a brief description.',
+        },
+        {
+            title: 'Medium card',
+            content: 'This card has a bit more content to show how the equal-height layout works when cards have varying amounts of text.',
+        },
+        {
+            title: 'Tall card',
+            content: 'This card has the most content of all. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat dolore dolorem maxime, quod, in minima esse fugit distinctio, officia et soluta dicta consequuntur commodi officiis tempora asperiores aspernatur atque quas. Reprehenderit, voluptatum.',
+        },
+        {
+            title: 'Another short one',
+            content: 'Minimal content here.',
+        },
+        {
+            title: 'With a list',
+            content: '<ul><li>Item one</li><li>Item two</li><li>Item three</li><li>Item four</li><li>Item five</li></ul>',
+        },
+        {
+            title: 'Image card',
+            content: '<p>A card with an image.</p><img src="https://picsum.photos/280/120?image=10" alt="Sample" style="width:100%; border-radius: 4px;" />',
+        },
+    ];
+
+    return html`
+        <div style="margin-bottom: 16px; padding: 12px; background-color: var(--dt-color-support-info-02); border-radius: var(--dt-radius-rounded-b); font-size: calc(var(--dt-font-body-s-size) * 1px); font-family: var(--dt-font-interactive-l-family);">
+            This story demonstrates equal-height cards in a responsive layout. The container uses <code>display: grid</code> with <code>grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))</code>, which automatically makes all cards in each row match the height of the tallest card in that row.
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;">
+            ${cards.map((card) => html`
+                <pie-card
+                    tag="${ifDefined(tag)}"
+                    variant="${ifDefined(variant)}"
+                    ?disabled="${disabled}"
+                    ?isDraggable="${isDraggable}"
+                    padding="${padding || nothing}"
+                    style="height: 100%;">
+                    <div style="font-size: calc(var(--dt-font-body-l-size) * 1px); font-family: var(--dt-font-interactive-l-family);">
+                        <h2 style="margin-top: 0">${card.title}</h2>
+                        ${sanitizeAndRenderHTML(card.content)}
+                    </div>
+                </pie-card>
+            `)}
+        </div>
+    `;
+};
+
+export const EqualHeightCards = EqualHeightCardsTemplate.bind({});
+EqualHeightCards.args = {
+    ...defaultArgs,
+    tag: 'button',
+    variant: 'outline',
+    padding: 'c',
+};
+EqualHeightCards.parameters = {
+    layout: 'padded',
+};
+
 export const CardWithImage = createCardStory({
     ...defaultArgs,
     slot: `<div style="font-size: calc(var(--dt-font-body-l-size) * 1px); font-family: var(--dt-font-interactive-l-family);">

--- a/apps/pie-storybook/stories/pie-card.stories.ts
+++ b/apps/pie-storybook/stories/pie-card.stories.ts
@@ -8,6 +8,7 @@ import '@justeattakeaway/pie-webc/components/card';
 import {
     type CardProps as CardPropsBase, variants, tags, paddingValues, defaultProps,
 } from '@justeattakeaway/pie-webc/components/card';
+import '@justeattakeaway/pie-webc/components/notification';
 
 import { type SlottedComponentProps } from '../types';
 import { createStory, type TemplateFunction, sanitizeAndRenderHTML } from '../utilities';
@@ -151,13 +152,7 @@ export const Default = createCardStory();
 export const Outline = createCardStory({ variant: 'outline' });
 export const Inverse = createCardStory({ variant: 'inverse' }, { bgColor: 'dark (container-dark)' });
 export const OutlineInverse = createCardStory({ variant: 'outline-inverse' }, { bgColor: 'dark (container-dark)' });
-const EqualHeightCardsTemplate: TemplateFunction<CardProps> = ({
-    variant,
-    padding,
-    tag,
-    disabled,
-    isDraggable,
-}) => {
+const EqualHeightCardsTemplate: TemplateFunction<CardProps> = () => {
     const cards = [
         {
             title: 'Short card',
@@ -186,17 +181,19 @@ const EqualHeightCardsTemplate: TemplateFunction<CardProps> = ({
     ];
 
     return html`
-        <div style="margin-bottom: 16px; padding: 12px; background-color: var(--dt-color-support-info-02); border-radius: var(--dt-radius-rounded-b); font-size: calc(var(--dt-font-body-s-size) * 1px); font-family: var(--dt-font-interactive-l-family);">
+        <pie-notification
+            variant="info"
+            isOpen
+            isCompact
+            style="margin-bottom: 16px;">
             This story demonstrates equal-height cards in a responsive layout. The container uses <code>display: grid</code> with <code>grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))</code>, which automatically makes all cards in each row match the height of the tallest card in that row.
-        </div>
+        </pie-notification>
         <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px;">
             ${cards.map((card) => html`
                 <pie-card
-                    tag="${ifDefined(tag)}"
-                    variant="${ifDefined(variant)}"
-                    ?disabled="${disabled}"
-                    ?isDraggable="${isDraggable}"
-                    padding="${padding || nothing}"
+                    tag="button"
+                    variant="outline"
+                    padding="c"
                     style="height: 100%;">
                     <div style="font-size: calc(var(--dt-font-body-l-size) * 1px); font-family: var(--dt-font-interactive-l-family);">
                         <h2 style="margin-top: 0">${card.title}</h2>
@@ -209,14 +206,11 @@ const EqualHeightCardsTemplate: TemplateFunction<CardProps> = ({
 };
 
 export const EqualHeightCards = EqualHeightCardsTemplate.bind({});
-EqualHeightCards.args = {
-    ...defaultArgs,
-    tag: 'button',
-    variant: 'outline',
-    padding: 'c',
-};
 EqualHeightCards.parameters = {
     layout: 'padded',
+    controls: {
+        disable: true,
+    },
 };
 
 export const CardWithImage = createCardStory({

--- a/packages/components/pie-card/src/card.scss
+++ b/packages/components/pie-card/src/card.scss
@@ -11,6 +11,7 @@
     --card-border-color: transparent;
 
     display: block;
+    height: 100%;
     position: relative;
     color: var(--card-color);
     background-color: var(--int-states-mixin-bg-color);


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Small tweak to ensure the inside of pie-card will fully occupy the height of the host element. Previously if the host element was stretching to fill the entire container it sits in, the inner `c-card` div in the shadow dom would still only be as tell as its content needed. This meant it was impossible for consumers to style their own grids/flexboxes with cards matching their own required heights.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
