### PR TITLE
chore(pie-docs): DSW-123 ensure pie-docs build errors trigger exit code 1

### DIFF
--- a/apps/pie-docs/.eleventy.js
+++ b/apps/pie-docs/.eleventy.js
@@ -5,6 +5,21 @@ const {
     plugins
 } = require('./src/_11ty');
 
+// Force-exit watchdog. Eleventy signals fatal errors by setting
+// `process.exitCode = 1` but never calls `process.exit()`. The
+// @lit-labs/eleventy-plugin-lit worker thread keeps the event loop alive
+// (Worker.unref() doesn't fully unref the underlying MessagePort/pipes),
+// so the process hangs and CI/turbo never see the non-zero exit. This
+// unref'd interval polls the exit code and forces termination if it
+// becomes non-zero. Unref'd timers don't keep the loop alive on their
+// own, so successful builds still exit naturally with code 0.
+const exitWatchdog = setInterval(() => {
+    if (process.exitCode && process.exitCode !== 0) {
+        process.exit(process.exitCode);
+    }
+}, 100);
+exitWatchdog.unref();
+
 module.exports = eleventyConfig => {
     // Copy over img directory to dist directory.
     eleventyConfig.addPassthroughCopy({ 'src/assets/img': 'assets/img' });


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
PIE Docs currently has an issue in that if there are template issues during build (like seen below) the build process / turbo / CI never exit with code `1` (error)

Claude is under the impression this is due to the `@lit-labs/eleventy-plugin-lit` plugin, and is prevents the exit code from surfacing.

This PR adds a watcher, so that if an exit code 1 is present, we kill the process.
```
@justeattakeaway/pie-docs:build: [11ty] Problem writing Eleventy templates:
@justeattakeaway/pie-docs:build: [11ty] 1. Having trouble rendering njk template ./src/foundations/gradients/overview/overview.md (via TemplateContentRenderError)
@justeattakeaway/pie-docs:build: [11ty] 2. (./src/foundations/gradients/overview/overview.md) [Line 21, Column 12]
@justeattakeaway/pie-docs:build: [11ty]   parseAggregate: expected comma after expression (via Template render error)
@justeattakeaway/pie-docs:build: [11ty] 
@justeattakeaway/pie-docs:build: [11ty] Original error stack trace: Error: parseAggregate: expected comma after expression
@justeattakeaway/pie-docs:build: [11ty]     at new TemplateError (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/lib.js:74:17)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.error (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:63:12)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.fail (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:66:16)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseAggregate (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:881:16)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parsePrimary (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:808:19)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseUnary (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:768:19)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parsePow (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:753:21)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseMod (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:745:21)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseFloorDiv (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:737:21)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseDiv (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:729:21)
@justeattakeaway/pie-docs:build: [11ty] Copied 27 Wrote 0 files in 1.78 seconds (v3.1.5)
@justeattakeaway/pie-docs:build: [11ty] Eleventy Fatal Error (CLI):
@justeattakeaway/pie-docs:build: [11ty] 1. Having trouble rendering njk template ./src/foundations/gradients/overview/overview.md (via TemplateContentRenderError)
@justeattakeaway/pie-docs:build: [11ty] 2. (./src/foundations/gradients/overview/overview.md) [Line 21, Column 12]
@justeattakeaway/pie-docs:build: [11ty]   parseAggregate: expected comma after expression (via Template render error)
@justeattakeaway/pie-docs:build: [11ty] 
@justeattakeaway/pie-docs:build: [11ty] Original error stack trace: Error: parseAggregate: expected comma after expression
@justeattakeaway/pie-docs:build: [11ty]     at new TemplateError (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/lib.js:74:17)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.error (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:63:12)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.fail (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:66:16)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseAggregate (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:881:16)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parsePrimary (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:808:19)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseUnary (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:768:19)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parsePow (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:753:21)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseMod (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:745:21)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseFloorDiv (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:737:21)
@justeattakeaway/pie-docs:build: [11ty]     at Parser.parseDiv (/Users/ben.siggery/Code/pie/apps/pie-docs/node_modules/nunjucks/src/parser.js:729:21)
```

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [ ] I have added thorough tests where applicable (unit / component / visual).
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.
