### PR TITLE
feat(pie-webc-core): DSW-4006 add configurable internal test-id attribute

### DIFF
--- a/.changeset/configurable-test-id-attribute.md
+++ b/.changeset/configurable-test-id-attribute.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+---
+
+[Added] `setPieTestIdAttribute` / `getPieTestIdAttribute` to globally configure the attribute name PIE components use for their internal test hooks (defaults to `data-test-id`). Lets consumers align PIE internals with their Playwright `testIdAttribute` so `getByTestId` works end-to-end.

--- a/apps/pie-storybook/.storybook/main.ts
+++ b/apps/pie-storybook/.storybook/main.ts
@@ -4,6 +4,15 @@ import remarkGfm from 'remark-gfm';
 const isBrowserTesting = process.env.BROWSER_TESTING === 'true';
 
 const config: StorybookConfig = {
+    viteFinal (config) {
+        config.define = {
+            ...config.define,
+            // Ensure source-imported PieElement subclasses work in Storybook's dev
+            // server, where the per-package vite build-time replacement is absent.
+            __PACKAGE_VERSION__: JSON.stringify('storybook-dev'),
+        };
+        return config;
+    },
     stories: isBrowserTesting
         ? [
             "../stories/testing/**/*.test.stories.ts"

--- a/apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts
@@ -3,7 +3,9 @@ import '@justeattakeaway/pie-webc/components/button';
 import '@justeattakeaway/pie-webc-core/src/test/functions/dispatchCustomEvent/MockComponent';
 import '@justeattakeaway/pie-webc-core/src/test/mixins/formControlMixin/MockComponent';
 import '@justeattakeaway/pie-webc-core/src/test/mixins/delegatesFocusMixin/MockComponent';
+import '@justeattakeaway/pie-webc-core/src/test/internals/TestIdMockComponent';
 import { EXPECTED_MOCK_EVENT_MESSAGE } from '@justeattakeaway/pie-webc-core/src/test/functions/dispatchCustomEvent/constants';
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core/src/functions/testIdAttribute';
 /**
  * Mock stories for testing pie-webc-core functionality
  */
@@ -84,3 +86,13 @@ export const DelegatesFocusMixinElement = () => html`
     <button id="first-focusable">First Focusable Element</button>
     <delegates-focus-mixin-mock></delegates-focus-mixin-mock>
 `;
+
+/**
+ * Story for testing the configurable internal test-id attribute. The override is
+ * set inside the render fn so it only affects this story's page load.
+ */
+export const TestIdAttributeOverride = () => {
+    setPieTestIdAttribute('data-qa');
+    return html`<test-id-mock></test-id-mock>`;
+};
+TestIdAttributeOverride.storyName = 'Test Id Attribute Override';

--- a/apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-webc-core.test.stories.ts
@@ -4,8 +4,10 @@ import '@justeattakeaway/pie-webc-core/src/test/functions/dispatchCustomEvent/Mo
 import '@justeattakeaway/pie-webc-core/src/test/mixins/formControlMixin/MockComponent';
 import '@justeattakeaway/pie-webc-core/src/test/mixins/delegatesFocusMixin/MockComponent';
 import '@justeattakeaway/pie-webc-core/src/test/internals/TestIdMockComponent';
+
 import { EXPECTED_MOCK_EVENT_MESSAGE } from '@justeattakeaway/pie-webc-core/src/test/functions/dispatchCustomEvent/constants';
 import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core/src/functions/testIdAttribute';
+
 /**
  * Mock stories for testing pie-webc-core functionality
  */
@@ -89,7 +91,11 @@ export const DelegatesFocusMixinElement = () => html`
 
 /**
  * Story for testing the configurable internal test-id attribute. The override is
- * set inside the render fn so it only affects this story's page load.
+ * set inside the render fn so it only affects this story's page load under test.
+ *
+ * NOTE: `setPieTestIdAttribute` mutates a global. When browsing Storybook manually,
+ * navigating away from this story without a full reload leaves the override active,
+ * so other components' `data-test-id` hooks will render as `data-qa` until reload.
  */
 export const TestIdAttributeOverride = () => {
     setPieTestIdAttribute('data-qa');

--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./packages/components/pie-assistive-text/dist/index.js",
-      "maxSize": "1.3 KB"
+      "maxSize": "1.5 KB"
     },
     {
       "path": "./packages/components/pie-assistive-text/dist/react.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./packages/components/pie-chip/dist/index.js",
-      "maxSize": "3.30 KB"
+      "maxSize": "3.45 KB"
     },
     {
       "path": "./packages/components/pie-chip/dist/react.js",
@@ -58,7 +58,7 @@
     },
     {
       "path": "./packages/components/pie-divider/dist/index.js",
-      "maxSize": "1.35 KB"
+      "maxSize": "1.6 KB"
     },
     {
       "path": "./packages/components/pie-divider/dist/react.js",
@@ -66,7 +66,7 @@
     },
     {
       "path": "./packages/components/pie-form-label/dist/index.js",
-      "maxSize": "1.28 KB"
+      "maxSize": "1.45 KB"
     },
     {
       "path": "./packages/components/pie-form-label/dist/react.js",
@@ -74,7 +74,7 @@
     },
     {
       "path": "./packages/components/pie-icon-button/dist/index.js",
-      "maxSize": "2.7 KB"
+      "maxSize": "2.98 KB"
     },
     {
       "path": "./packages/components/pie-icon-button/dist/react.js",
@@ -106,7 +106,7 @@
     },
     {
       "path": "./packages/components/pie-modal/dist/index.js",
-      "maxSize": "7.87 KB"
+      "maxSize": "8.0 KB"
     },
     {
       "path": "./packages/components/pie-modal/dist/react.js",
@@ -122,7 +122,7 @@
     },
     {
       "path": "./packages/components/pie-radio/dist/index.js",
-      "maxSize": "3.08 KB"
+      "maxSize": "3.33 KB"
     },
     {
       "path": "./packages/components/pie-radio/dist/react.js",
@@ -138,7 +138,7 @@
     },
     {
       "path": "./packages/components/pie-spinner/dist/index.js",
-      "maxSize": "1.5 KB"
+      "maxSize": "1.65 KB"
     },
     {
       "path": "./packages/components/pie-spinner/dist/react.js",
@@ -194,7 +194,7 @@
     },
     {
       "path": "./packages/components/pie-select/dist/*.js",
-      "maxSize": "3 KB"
+      "maxSize": "3.25 KB"
     },
     {
       "path": "./packages/components/pie-breadcrumb/dist/*.js",

--- a/packages/components/pie-webc-core/README.md
+++ b/packages/components/pie-webc-core/README.md
@@ -78,3 +78,33 @@ Currently, for writing unit tests we simply name the file `**/*.spec.ts`. To wri
 
 ## Bundling
 When we build the package, we run a plugin for Rollup named `rollup-plugin-visualizer`. This generates a file named `stats.html` in the root of the package. This file can be viewed in the browser to visualise the bundled Javascript and better understand what contributes to the size of the final build output.
+
+## Configuring the internal test-id attribute
+
+By default, PIE components expose internal test hooks under `data-test-id`. If
+your test tooling uses a different attribute (e.g. Playwright's
+`testConfig.testIdAttribute = 'data-qa'`), you can tell PIE to use the same name
+so a single `getByTestId` strategy works end-to-end:
+
+```ts
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';
+
+// Call ONCE, before any PIE component renders (top of your app/test entry).
+setPieTestIdAttribute('data-qa');
+```
+
+After this, every PIE component renames its internal `data-test-id` attributes
+to `data-qa` (the original `data-test-id` is removed). Calling it with an invalid
+attribute name logs a warning and keeps the previous value.
+
+**Important notes:**
+
+- **Set it before first render.** The rename is applied as components render; an
+  element that rendered before the override was set and never updates again will
+  keep `data-test-id`.
+- **React / Vue wrappers:** works unchanged — the wrappers mount the same custom
+  element, whose lifecycle performs the rename.
+- **SSR:** server-rendered HTML still contains `data-test-id`; the configured
+  name is applied on the client after render/hydration. The configured name is
+  therefore present in the live (hydrated) browser — which is what Playwright
+  e2e tests observe — but not in raw, pre-JS server HTML.

--- a/packages/components/pie-webc-core/src/functions/index.ts
+++ b/packages/components/pie-webc-core/src/functions/index.ts
@@ -1,2 +1,3 @@
 export * from './wrapNativeEvent';
 export * from './dispatchCustomEvent';
+export * from './testIdAttribute';

--- a/packages/components/pie-webc-core/src/functions/testIdAttribute.ts
+++ b/packages/components/pie-webc-core/src/functions/testIdAttribute.ts
@@ -1,0 +1,42 @@
+/**
+ * The default attribute name PIE components use for their internal test hooks.
+ */
+export const DEFAULT_TEST_ID_ATTRIBUTE = 'data-test-id';
+
+/**
+ * Key for the globally-shared configured attribute name. Using `Symbol.for`
+ * means the value is shared even if `pie-webc-core` is duplicated across bundles.
+ */
+const STORE_KEY = Symbol.for('pie.testIdAttribute');
+
+/**
+ * Matches a conservative subset of valid HTML attribute names: a leading letter
+ * followed by letters, digits, hyphens or underscores (covers `data-*` names).
+ */
+const VALID_ATTRIBUTE_NAME = /^[a-z][\w-]*$/i;
+
+const store = globalThis as unknown as Record<symbol, string | undefined>;
+
+/**
+ * Returns the attribute name PIE components should expose their internal test
+ * hooks under. Defaults to `data-test-id`.
+ */
+export function getPieTestIdAttribute (): string {
+    return store[STORE_KEY] ?? DEFAULT_TEST_ID_ATTRIBUTE;
+}
+
+/**
+ * Globally overrides the attribute name PIE components use for their internal
+ * test hooks (e.g. `data-qa`). Must be called before components first render.
+ * Invalid names are ignored with a console warning.
+ *
+ * @param name - A valid HTML attribute name.
+ */
+export function setPieTestIdAttribute (name: string): void {
+    if (typeof name !== 'string' || !VALID_ATTRIBUTE_NAME.test(name)) {
+        console.warn(`[PIE] Ignoring invalid test-id attribute name: "${name}". It must match ${VALID_ATTRIBUTE_NAME.toString()}.`);
+        return;
+    }
+
+    store[STORE_KEY] = name;
+}

--- a/packages/components/pie-webc-core/src/functions/testIdAttribute.ts
+++ b/packages/components/pie-webc-core/src/functions/testIdAttribute.ts
@@ -34,7 +34,7 @@ export function getPieTestIdAttribute (): string {
  */
 export function setPieTestIdAttribute (name: string): void {
     if (typeof name !== 'string' || !VALID_ATTRIBUTE_NAME.test(name)) {
-        console.warn(`[PIE] Ignoring invalid test-id attribute name: "${name}". It must match ${VALID_ATTRIBUTE_NAME.toString()}.`);
+        console.warn(`[PIE] Ignoring invalid test-id attribute name: "${name}". Use a valid HTML attribute name (e.g. "data-qa").`);
         return;
     }
 

--- a/packages/components/pie-webc-core/src/internals/PieElement.ts
+++ b/packages/components/pie-webc-core/src/internals/PieElement.ts
@@ -1,7 +1,16 @@
 import { LitElement } from 'lit';
 
+import { TestIdController } from './TestIdController';
+
 export class PieElement extends LitElement {
     public static readonly v = __PACKAGE_VERSION__;
+
+    constructor () {
+        super();
+        // Renames internal data-test-id attributes when a consumer override is set.
+        // eslint-disable-next-line no-new
+        new TestIdController(this);
+    }
 
     protected willUpdate (): void {
         if (!this.getAttribute('v')) {

--- a/packages/components/pie-webc-core/src/internals/TestIdController.ts
+++ b/packages/components/pie-webc-core/src/internals/TestIdController.ts
@@ -1,0 +1,59 @@
+import {
+    type ReactiveController, type ReactiveControllerHost, isServer,
+} from 'lit';
+
+import {
+    DEFAULT_TEST_ID_ATTRIBUTE, getPieTestIdAttribute,
+} from '../functions/testIdAttribute';
+
+type Host = ReactiveControllerHost & Element;
+
+/**
+ * Renames a component's internal `data-test-id` attributes to a consumer-
+ * configured attribute name (e.g. `data-qa`) so a single `getByTestId` strategy
+ * works end-to-end.
+ *
+ * Runs after every host update via `hostUpdated`, so it survives re-renders and
+ * works regardless of whether a subclass overrides `updated()`. It is a no-op
+ * unless a consumer has set an override, and never runs during server rendering.
+ */
+export class TestIdController implements ReactiveController {
+    private host: Host;
+
+    constructor (host: Host) {
+        this.host = host;
+        host.addController(this);
+    }
+
+    hostUpdated (): void {
+        // The rename is a client-only DOM operation; SSR output keeps data-test-id.
+        if (isServer) {
+            return;
+        }
+
+        const attribute = getPieTestIdAttribute();
+
+        // No override configured — leave the default behaviour untouched (zero cost).
+        if (attribute === DEFAULT_TEST_ID_ATTRIBUTE) {
+            return;
+        }
+
+        const root = this.host.shadowRoot;
+        if (!root) {
+            return;
+        }
+
+        // querySelectorAll does not pierce shadow boundaries, so this only ever
+        // touches THIS component's internals — nested PIE components run their own
+        // pass, and consumer light-DOM / slotted content is never affected.
+        root.querySelectorAll(`[${DEFAULT_TEST_ID_ATTRIBUTE}]`).forEach((element) => {
+            const value = element.getAttribute(DEFAULT_TEST_ID_ATTRIBUTE);
+            if (value === null) {
+                return;
+            }
+
+            element.setAttribute(attribute, value);
+            element.removeAttribute(DEFAULT_TEST_ID_ATTRIBUTE);
+        });
+    }
+}

--- a/packages/components/pie-webc-core/src/internals/TestIdController.ts
+++ b/packages/components/pie-webc-core/src/internals/TestIdController.ts
@@ -13,12 +13,25 @@ type Host = ReactiveControllerHost & Element;
  * configured attribute name (e.g. `data-qa`) so a single `getByTestId` strategy
  * works end-to-end.
  *
- * Runs after every host update via `hostUpdated`, so it survives re-renders and
- * works regardless of whether a subclass overrides `updated()`. It is a no-op
- * unless a consumer has set an override, and never runs during server rendering.
+ * Triggered after every host update via `hostUpdated`, so it survives re-renders
+ * and works regardless of whether a subclass overrides `updated()`. It is a
+ * no-op unless a consumer has set an override, and never runs during server
+ * rendering.
+ *
+ * The DOM mutation is deferred to a microtask rather than performed synchronously
+ * in `hostUpdated`. Some internal `data-test-id` attributes are interpolated
+ * (`data-test-id="${...}"`), which makes their host elements Lit attribute parts
+ * that are tracked during SSR hydration. Mutating those attributes synchronously
+ * inside the update flush interleaves with Lit hydrating sibling/descendant parts
+ * in the same tree, desyncing its part walk and throwing "Unexpected
+ * TemplateResult rendered to part". A microtask always runs after the current
+ * synchronous hydration pass has settled, so the rename can never interleave with
+ * it.
  */
 export class TestIdController implements ReactiveController {
     private host: Host;
+
+    private renameQueued = false;
 
     constructor (host: Host) {
         this.host = host;
@@ -31,9 +44,28 @@ export class TestIdController implements ReactiveController {
             return;
         }
 
+        // No override configured — leave the default behaviour untouched (zero cost).
+        if (getPieTestIdAttribute() === DEFAULT_TEST_ID_ATTRIBUTE) {
+            return;
+        }
+
+        // Coalesce repeated updates into a single pending rename.
+        if (this.renameQueued) {
+            return;
+        }
+
+        this.renameQueued = true;
+
+        // Defer out of the synchronous update/hydration flush (see class comment).
+        queueMicrotask(() => {
+            this.renameQueued = false;
+            this.renameTestIdAttributes();
+        });
+    }
+
+    private renameTestIdAttributes (): void {
         const attribute = getPieTestIdAttribute();
 
-        // No override configured — leave the default behaviour untouched (zero cost).
         if (attribute === DEFAULT_TEST_ID_ATTRIBUTE) {
             return;
         }

--- a/packages/components/pie-webc-core/src/internals/TestIdController.ts
+++ b/packages/components/pie-webc-core/src/internals/TestIdController.ts
@@ -48,6 +48,8 @@ export class TestIdController implements ReactiveController {
         // pass, and consumer light-DOM / slotted content is never affected.
         root.querySelectorAll(`[${DEFAULT_TEST_ID_ATTRIBUTE}]`).forEach((element) => {
             const value = element.getAttribute(DEFAULT_TEST_ID_ATTRIBUTE);
+            // The selector guarantees the attribute exists; this guard only
+            // narrows getAttribute's `string | null` return for setAttribute below.
             if (value === null) {
                 return;
             }

--- a/packages/components/pie-webc-core/src/test/functions/testIdAttribute/testIdAttribute.spec.ts
+++ b/packages/components/pie-webc-core/src/test/functions/testIdAttribute/testIdAttribute.spec.ts
@@ -1,0 +1,54 @@
+import {
+    describe, it, expect, vi, afterEach,
+} from 'vitest';
+
+import {
+    DEFAULT_TEST_ID_ATTRIBUTE,
+    getPieTestIdAttribute,
+    setPieTestIdAttribute,
+} from '../../../functions/testIdAttribute';
+
+describe('testIdAttribute config', () => {
+    afterEach(() => {
+        // Reset to the default between tests (the store lives on globalThis).
+        setPieTestIdAttribute(DEFAULT_TEST_ID_ATTRIBUTE);
+        vi.restoreAllMocks();
+    });
+
+    it('defaults to "data-test-id"', () => {
+        expect(getPieTestIdAttribute()).toBe('data-test-id');
+        expect(DEFAULT_TEST_ID_ATTRIBUTE).toBe('data-test-id');
+    });
+
+    it('returns the configured value after a valid override', () => {
+        setPieTestIdAttribute('data-qa');
+        expect(getPieTestIdAttribute()).toBe('data-qa');
+    });
+
+    it('accepts names with hyphens, digits and underscores after the first letter', () => {
+        setPieTestIdAttribute('data-qa_2');
+        expect(getPieTestIdAttribute()).toBe('data-qa_2');
+    });
+
+    it.each([
+        ['', 'empty string'],
+        ['1abc', 'leading digit'],
+        ['has space', 'whitespace'],
+        ['data qa', 'whitespace'],
+        ['-leading-hyphen', 'leading hyphen'],
+    ])('rejects invalid name %j (%s): warns and keeps the previous value', (invalid) => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        setPieTestIdAttribute('data-qa'); // establish a known-good prior value
+        warn.mockClear();
+
+        setPieTestIdAttribute(invalid as string);
+
+        expect(warn).toHaveBeenCalledOnce();
+        expect(getPieTestIdAttribute()).toBe('data-qa'); // unchanged
+    });
+
+    it('shares the value across calls via globalThis (single source of truth)', () => {
+        setPieTestIdAttribute('data-e2e');
+        expect((globalThis as Record<symbol, unknown>)[Symbol.for('pie.testIdAttribute')]).toBe('data-e2e');
+    });
+});

--- a/packages/components/pie-webc-core/src/test/functions/testIdAttribute/testIdAttribute.spec.ts
+++ b/packages/components/pie-webc-core/src/test/functions/testIdAttribute/testIdAttribute.spec.ts
@@ -10,8 +10,8 @@ import {
 
 describe('testIdAttribute config', () => {
     afterEach(() => {
-        // Reset to the default between tests (the store lives on globalThis).
-        setPieTestIdAttribute(DEFAULT_TEST_ID_ATTRIBUTE);
+        // Reset directly so teardown doesn't depend on setPieTestIdAttribute working.
+        (globalThis as Record<symbol, unknown>)[Symbol.for('pie.testIdAttribute')] = undefined;
         vi.restoreAllMocks();
     });
 

--- a/packages/components/pie-webc-core/src/test/internals/TestIdMockComponent.ts
+++ b/packages/components/pie-webc-core/src/test/internals/TestIdMockComponent.ts
@@ -1,0 +1,25 @@
+import { html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import { PieElement } from '../../internals/PieElement';
+
+/**
+ * Mock element used by the test-id override browser story. Renders a nested set
+ * of internal `data-test-id` hooks so the rename pass can be observed in a real
+ * browser shadow root.
+ */
+@customElement('test-id-mock')
+export class TestIdMockComponent extends PieElement {
+    render () {
+        return html`
+            <div data-test-id="test-id-mock-root">
+                <span data-test-id="test-id-mock-label">Mock</span>
+            </div>`;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'test-id-mock': TestIdMockComponent;
+    }
+}

--- a/packages/components/pie-webc-core/src/test/internals/TestIdMockComponent.ts
+++ b/packages/components/pie-webc-core/src/test/internals/TestIdMockComponent.ts
@@ -3,12 +3,14 @@ import { customElement } from 'lit/decorators.js';
 
 import { PieElement } from '../../internals/PieElement';
 
+const componentSelector = 'test-id-mock';
+
 /**
  * Mock element used by the test-id override browser story. Renders a nested set
  * of internal `data-test-id` hooks so the rename pass can be observed in a real
  * browser shadow root.
  */
-@customElement('test-id-mock')
+@customElement(componentSelector)
 export class TestIdMockComponent extends PieElement {
     render () {
         return html`

--- a/packages/components/pie-webc-core/src/test/internals/pieElementTestId.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/pieElementTestId.client.spec.ts
@@ -32,6 +32,8 @@ describe('PieElement + TestIdController integration', () => {
         document.body.innerHTML = `<${SELECTOR}></${SELECTOR}>`;
         const el = document.body.querySelector(SELECTOR) as MockComponent;
         await el.updateComplete;
+        // The rename is deferred to a microtask; flush past it before asserting.
+        await new Promise<void>((resolve) => { setTimeout(resolve, 0); });
 
         expect(el.shadowRoot?.querySelector('[data-qa="pie-element-inner"]')).not.toBeNull();
         expect(el.shadowRoot?.querySelector('[data-test-id]')).toBeNull();

--- a/packages/components/pie-webc-core/src/test/internals/pieElementTestId.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/pieElementTestId.client.spec.ts
@@ -4,9 +4,7 @@ import {
 } from 'vitest';
 
 import { PieElement } from '../../internals/PieElement';
-import {
-    DEFAULT_TEST_ID_ATTRIBUTE, setPieTestIdAttribute,
-} from '../../functions/testIdAttribute';
+import { setPieTestIdAttribute } from '../../functions/testIdAttribute';
 
 vi.mock('lit', async () => ({
     ...((await vi.importActual('lit')) as Record<string, unknown>),

--- a/packages/components/pie-webc-core/src/test/internals/pieElementTestId.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/pieElementTestId.client.spec.ts
@@ -1,0 +1,41 @@
+import { html } from 'lit';
+import {
+    describe, it, expect, vi, afterEach,
+} from 'vitest';
+
+import { PieElement } from '../../internals/PieElement';
+import {
+    DEFAULT_TEST_ID_ATTRIBUTE, setPieTestIdAttribute,
+} from '../../functions/testIdAttribute';
+
+vi.mock('lit', async () => ({
+    ...((await vi.importActual('lit')) as Record<string, unknown>),
+    isServer: false,
+}));
+
+const SELECTOR = 'pie-element-testid-mock';
+
+class MockComponent extends PieElement {
+    render () {
+        return html`<div data-test-id="pie-element-inner"></div>`;
+    }
+}
+
+customElements.define(SELECTOR, MockComponent);
+
+describe('PieElement + TestIdController integration', () => {
+    afterEach(() => {
+        (globalThis as Record<symbol, unknown>)[Symbol.for('pie.testIdAttribute')] = undefined;
+        document.body.innerHTML = '';
+    });
+
+    it('renames internal test ids on any PieElement subclass when overridden', async () => {
+        setPieTestIdAttribute('data-qa');
+        document.body.innerHTML = `<${SELECTOR}></${SELECTOR}>`;
+        const el = document.body.querySelector(SELECTOR) as MockComponent;
+        await el.updateComplete;
+
+        expect(el.shadowRoot?.querySelector('[data-qa="pie-element-inner"]')).not.toBeNull();
+        expect(el.shadowRoot?.querySelector('[data-test-id]')).toBeNull();
+    });
+});

--- a/packages/components/pie-webc-core/src/test/internals/testIdAttribute.browser.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdAttribute.browser.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
+
+test.describe('Configurable test-id attribute', () => {
+    test('renames internal data-test-id to the configured attribute in the live browser', async ({ page }) => {
+        // Arrange
+        const mockPage = new BasePage(page, 'webc-core--test-id-attribute-override');
+        await mockPage.load();
+
+        // Assert — configured attribute is present (CSS locators pierce shadow DOM)
+        await expect(page.locator('[data-qa="test-id-mock-root"]')).toBeAttached();
+        await expect(page.locator('[data-qa="test-id-mock-label"]')).toBeAttached();
+
+        // Assert — the original data-test-id has been removed (replace semantics)
+        await expect(page.locator('[data-test-id="test-id-mock-root"]')).toHaveCount(0);
+        await expect(page.locator('[data-test-id="test-id-mock-label"]')).toHaveCount(0);
+    });
+
+    test('the rename still applies when the same element is driven through a host framework', async ({ page }) => {
+        // The story mounts the real <test-id-mock> custom element; React/Vue wrappers
+        // mount this same element via @lit/react createComponent, so observing the
+        // upgraded element here is equivalent to the wrapped case.
+        const mockPage = new BasePage(page, 'webc-core--test-id-attribute-override');
+        await mockPage.load();
+
+        await expect(page.locator('test-id-mock')).toBeAttached();
+        await expect(page.locator('[data-qa="test-id-mock-root"]')).toBeAttached();
+    });
+});

--- a/packages/components/pie-webc-core/src/test/internals/testIdAttribute.browser.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdAttribute.browser.spec.ts
@@ -16,10 +16,11 @@ test.describe('Configurable test-id attribute', () => {
         await expect(page.locator('[data-test-id="test-id-mock-label"]')).toHaveCount(0);
     });
 
-    test('the rename still applies when the same element is driven through a host framework', async ({ page }) => {
-        // The story mounts the real <test-id-mock> custom element; React/Vue wrappers
-        // mount this same element via @lit/react createComponent, so observing the
-        // upgraded element here is equivalent to the wrapped case.
+    test('exposes the configured attribute on the upgraded custom element host and internals', async ({ page }) => {
+        // This does not mount a React/Vue wrapper directly. The wrappers (via
+        // @lit/react createComponent) mount this same <test-id-mock> custom element,
+        // so verifying the upgraded element + renamed internals here is representative
+        // of the wrapped case; a true framework-integration test is tracked separately.
         const mockPage = new BasePage(page, 'webc-core--test-id-attribute-override');
         await mockPage.load();
 

--- a/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
@@ -1,0 +1,64 @@
+import {
+    LitElement, html, type ReactiveControllerHost,
+} from 'lit';
+import {
+    describe, it, expect, vi, afterEach,
+} from 'vitest';
+
+import { TestIdController } from '../../internals/TestIdController';
+import {
+    DEFAULT_TEST_ID_ATTRIBUTE, setPieTestIdAttribute,
+} from '../../functions/testIdAttribute';
+
+vi.mock('lit', async () => ({
+    ...((await vi.importActual('lit')) as Record<string, unknown>),
+    isServer: false,
+}));
+
+const SELECTOR = 'test-id-controller-client-mock';
+
+class MockComponent extends LitElement {
+    constructor () {
+        super();
+        // eslint-disable-next-line no-new
+        new TestIdController(this as ReactiveControllerHost & Element);
+    }
+
+    render () {
+        return html`
+            <div data-test-id="mock-root">
+                <button data-test-id="mock-button">Go</button>
+            </div>`;
+    }
+}
+
+customElements.define(SELECTOR, MockComponent);
+
+async function mount (): Promise<MockComponent> {
+    document.body.innerHTML = `<${SELECTOR}></${SELECTOR}>`;
+    const el = document.body.querySelector(SELECTOR) as MockComponent;
+    await el.updateComplete;
+    return el;
+}
+
+describe('TestIdController (client)', () => {
+    afterEach(() => {
+        (globalThis as Record<symbol, unknown>)[Symbol.for('pie.testIdAttribute')] = undefined;
+        document.body.innerHTML = '';
+    });
+
+    it('leaves data-test-id untouched when no override is set', async () => {
+        const el = await mount();
+        expect(el.shadowRoot?.querySelector('[data-test-id="mock-button"]')).not.toBeNull();
+        expect(el.shadowRoot?.querySelector('[data-qa]')).toBeNull();
+    });
+
+    it('renames every internal data-test-id to the configured attribute', async () => {
+        setPieTestIdAttribute('data-qa');
+        const el = await mount();
+
+        expect(el.shadowRoot?.querySelector('[data-qa="mock-root"]')).not.toBeNull();
+        expect(el.shadowRoot?.querySelector('[data-qa="mock-button"]')).not.toBeNull();
+        expect(el.shadowRoot?.querySelector('[data-test-id]')).toBeNull();
+    });
+});

--- a/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
@@ -6,9 +6,7 @@ import {
 } from 'vitest';
 
 import { TestIdController } from '../../internals/TestIdController';
-import {
-    DEFAULT_TEST_ID_ATTRIBUTE, setPieTestIdAttribute,
-} from '../../functions/testIdAttribute';
+import { setPieTestIdAttribute } from '../../functions/testIdAttribute';
 
 vi.mock('lit', async () => ({
     ...((await vi.importActual('lit')) as Record<string, unknown>),

--- a/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
@@ -32,10 +32,15 @@ class MockComponent extends LitElement {
 
 customElements.define(SELECTOR, MockComponent);
 
+// The rename is deferred to a microtask after the update, so flush past it
+// (a macrotask drains any queued microtasks) before asserting.
+const flushRename = () => new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+
 async function mount (): Promise<MockComponent> {
     document.body.innerHTML = `<${SELECTOR}></${SELECTOR}>`;
     const el = document.body.querySelector(SELECTOR) as MockComponent;
     await el.updateComplete;
+    await flushRename();
     return el;
 }
 
@@ -69,6 +74,7 @@ describe('TestIdController (client)', () => {
         setPieTestIdAttribute('data-qa');
         el.requestUpdate();
         await el.updateComplete;
+        await flushRename();
 
         expect(el.shadowRoot?.querySelector('[data-qa="mock-button"]')).not.toBeNull();
         expect(el.shadowRoot?.querySelector('[data-test-id]')).toBeNull();

--- a/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdController.client.spec.ts
@@ -61,4 +61,18 @@ describe('TestIdController (client)', () => {
         expect(el.shadowRoot?.querySelector('[data-qa="mock-button"]')).not.toBeNull();
         expect(el.shadowRoot?.querySelector('[data-test-id]')).toBeNull();
     });
+
+    it('applies the rename on a re-render that happens after the override is set', async () => {
+        // Mount with no override — data-test-id stays.
+        const el = await mount();
+        expect(el.shadowRoot?.querySelector('[data-test-id="mock-button"]')).not.toBeNull();
+
+        // Set the override AFTER first render, then force another update cycle.
+        setPieTestIdAttribute('data-qa');
+        el.requestUpdate();
+        await el.updateComplete;
+
+        expect(el.shadowRoot?.querySelector('[data-qa="mock-button"]')).not.toBeNull();
+        expect(el.shadowRoot?.querySelector('[data-test-id]')).toBeNull();
+    });
 });

--- a/packages/components/pie-webc-core/src/test/internals/testIdController.server.spec.ts
+++ b/packages/components/pie-webc-core/src/test/internals/testIdController.server.spec.ts
@@ -1,0 +1,48 @@
+import {
+    LitElement, html, type ReactiveControllerHost,
+} from 'lit';
+import {
+    describe, it, expect, vi, afterEach,
+} from 'vitest';
+
+import { TestIdController } from '../../internals/TestIdController';
+import { setPieTestIdAttribute } from '../../functions/testIdAttribute';
+
+vi.mock('lit', async () => ({
+    ...((await vi.importActual('lit')) as Record<string, unknown>),
+    isServer: true,
+}));
+
+const SELECTOR = 'test-id-controller-server-mock';
+
+class MockComponent extends LitElement {
+    constructor () {
+        super();
+        // eslint-disable-next-line no-new
+        new TestIdController(this as ReactiveControllerHost & Element);
+    }
+
+    render () {
+        return html`<div data-test-id="mock-root"></div>`;
+    }
+}
+
+customElements.define(SELECTOR, MockComponent);
+
+describe('TestIdController (server)', () => {
+    afterEach(() => {
+        (globalThis as Record<symbol, unknown>)[Symbol.for('pie.testIdAttribute')] = undefined;
+        document.body.innerHTML = '';
+    });
+
+    it('does NOT rename when running on the server, even with an override set', async () => {
+        setPieTestIdAttribute('data-qa');
+        document.body.innerHTML = `<${SELECTOR}></${SELECTOR}>`;
+        const el = document.body.querySelector(SELECTOR) as MockComponent;
+        await el.updateComplete;
+
+        // isServer guard short-circuits the rename: data-test-id is preserved.
+        expect(el.shadowRoot?.querySelector('[data-test-id="mock-root"]')).not.toBeNull();
+        expect(el.shadowRoot?.querySelector('[data-qa]')).toBeNull();
+    });
+});

--- a/packages/components/pie-webc-core/vite.config.js
+++ b/packages/components/pie-webc-core/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
+    define: {
+        __PACKAGE_VERSION__: JSON.stringify('test'),
+    },
     build: {
         lib: {
             entry: {
@@ -17,6 +20,9 @@ export default defineConfig({
         dir: '.',
         environment: 'jsdom',
         globals: true,
+        define: {
+            __PACKAGE_VERSION__: JSON.stringify('test'),
+        },
         exclude: [
             '**/test/{accessibility,component,system,visual}/*.spec.{js,ts}',
             '**/test/**/*.browser.spec.{js,ts}',

--- a/packages/components/pie-webc-core/vite.config.js
+++ b/packages/components/pie-webc-core/vite.config.js
@@ -2,9 +2,6 @@ import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
-    define: {
-        __PACKAGE_VERSION__: JSON.stringify('test'),
-    },
     build: {
         lib: {
             entry: {

--- a/packages/components/pie-webc-core/vite.config.js
+++ b/packages/components/pie-webc-core/vite.config.js
@@ -2,6 +2,13 @@ import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
+    // __PACKAGE_VERSION__ is injected by downstream consumers in real builds.
+    // Under Vitest we stub it so importing PieElement (which reads it) works in jsdom.
+    ...(process.env.VITEST ? {
+        define: {
+            __PACKAGE_VERSION__: JSON.stringify('test'),
+        },
+    } : {}),
     build: {
         lib: {
             entry: {
@@ -17,9 +24,6 @@ export default defineConfig({
         dir: '.',
         environment: 'jsdom',
         globals: true,
-        define: {
-            __PACKAGE_VERSION__: JSON.stringify('test'),
-        },
         exclude: [
             '**/test/{accessibility,component,system,visual}/*.spec.{js,ts}',
             '**/test/**/*.browser.spec.{js,ts}',

--- a/packages/components/pie-webc/docs/framework-integration-guides/nextjs-14.md
+++ b/packages/components/pie-webc/docs/framework-integration-guides/nextjs-14.md
@@ -10,6 +10,7 @@ This guide will show you how to set up the PIE Web Components in a Next.js 14 ap
 - [Dependencies](#dependencies)
 - [Next.js config](#nextjs-config)
 - [Usage](#usage)
+- [Configuring the test-id attribute](#configuring-the-test-id-attribute)
 
 
 ## Dependencies
@@ -72,3 +73,23 @@ export default function SomeComponent() {
 ```
 
 You should now be able to use any components you need in your Next.js application!
+
+## Configuring the test-id attribute
+
+PIE components expose their internal test hooks using the `data-test-id` attribute by default. If your test tooling targets a different attribute (for example, Playwright's `testConfig.testIdAttribute`), you can tell PIE to use the same attribute name so a single `getByTestId` strategy works for both your own markup and PIE internals.
+
+Because the app is server-side rendered, set this on the **client only**, as early as possible — at the module scope of your custom `_app`, so it runs before any PIE component hydrates:
+
+```jsx
+// pages/_app.tsx — module scope (runs before hydration)
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';
+
+if (typeof window !== 'undefined') {
+    setPieTestIdAttribute('data-qa');
+}
+```
+
+- Defaults to `data-test-id`. Pass any valid attribute name (e.g. `data-qa`). Invalid names are ignored with a warning.
+- The `typeof window` guard keeps it off the server; placing it at module scope (not in `useEffect`/`componentDidMount`) ensures it runs **before** PIE components hydrate, so the first client render already uses the configured attribute.
+- During SSR the server-rendered HTML still contains `data-test-id`; the configured name is applied on the client after hydration (which is what Playwright e2e tests observe).
+- `setPieTestIdAttribute` is provided by `@justeattakeaway/pie-webc-core`, which is installed automatically as a dependency of the PIE components.

--- a/packages/components/pie-webc/docs/framework-integration-guides/no-framework.md
+++ b/packages/components/pie-webc/docs/framework-integration-guides/no-framework.md
@@ -9,6 +9,7 @@ This guide will show you how to set up the PIE Web Components in a web applicati
 
 - [Dependencies](#dependencies)
 - [Usage](#usage)
+- [Configuring the test-id attribute](#configuring-the-test-id-attribute)
 
 ## Dependencies
 Please refer to the [Getting started](https://webc.pie.design/?path=/docs/introduction-getting-started--docs) guide for the dependencies required to use PIE Web Components in your application.
@@ -47,3 +48,24 @@ setupCounter(document.querySelector<HTMLElement>('#counter')!);
 ```
 
 You should now be able to use any components you need in your application!
+
+## Configuring the test-id attribute
+
+PIE components expose their internal test hooks using the `data-test-id` attribute by default. If your test tooling targets a different attribute (for example, Playwright's `testConfig.testIdAttribute`), you can tell PIE to use the same attribute name so a single `getByTestId` strategy works for both your own markup and PIE internals.
+
+Call `setPieTestIdAttribute` **once**, before any PIE component is added to the page:
+
+```ts
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';
+
+// Run before the components are rendered into the DOM.
+setPieTestIdAttribute('data-qa');
+
+document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
+    <pie-button id="counter" type="button">count is 0</pie-button>
+`;
+```
+
+- Defaults to `data-test-id`. Pass any valid attribute name (e.g. `data-qa`). Invalid names are ignored with a warning.
+- Set it **before components first render** — a component that has already rendered keeps `data-test-id` until it next updates.
+- `setPieTestIdAttribute` is provided by `@justeattakeaway/pie-webc-core`, which is installed automatically as a dependency of the PIE components.

--- a/packages/components/pie-webc/docs/framework-integration-guides/nuxt-3.md
+++ b/packages/components/pie-webc/docs/framework-integration-guides/nuxt-3.md
@@ -10,6 +10,7 @@ This guide will show you how to set up the PIE Web Components in a Nuxt 3 applic
 - [Dependencies](#dependencies)
 - [Nuxt config](#nuxt-config)
 - [Usage](#usage)
+- [Configuring the test-id attribute](#configuring-the-test-id-attribute)
 
 
 ## Dependencies
@@ -117,3 +118,23 @@ import '@justeattakeaway/pie-icons-webc/dist/IconCamera.js';
 ```
 
 You should now be able to use any components you need in your Nuxt application!
+
+## Configuring the test-id attribute
+
+PIE components expose their internal test hooks using the `data-test-id` attribute by default. If your test tooling targets a different attribute (for example, Playwright's `testConfig.testIdAttribute`), you can tell PIE to use the same attribute name so a single `getByTestId` strategy works for both your own markup and PIE internals.
+
+Because the app is server-side rendered, set this in a **client-only** plugin so it runs in the browser before PIE components hydrate:
+
+```ts
+// plugins/pie-test-id.client.ts
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';
+
+export default defineNuxtPlugin(() => {
+    setPieTestIdAttribute('data-qa');
+});
+```
+
+- The `.client.ts` suffix ensures the plugin only runs on the client, and Nuxt runs plugins before mounting the app.
+- Defaults to `data-test-id`. Pass any valid attribute name (e.g. `data-qa`). Invalid names are ignored with a warning.
+- During SSR the server-rendered HTML still contains `data-test-id`; the configured name is applied on the client after hydration (which is what Playwright e2e tests observe).
+- `setPieTestIdAttribute` is provided by `@justeattakeaway/pie-webc-core`, which is installed automatically as a dependency of the PIE components.

--- a/packages/components/pie-webc/docs/framework-integration-guides/react-19.md
+++ b/packages/components/pie-webc/docs/framework-integration-guides/react-19.md
@@ -9,6 +9,7 @@ This guide will show you how to set up the PIE Web Components in a React 19 appl
 
 - [Dependencies](#dependencies)
 - [Usage](#usage)
+- [Configuring the test-id attribute](#configuring-the-test-id-attribute)
 
 ## Dependencies
 The first step is to install the React specific dependency:
@@ -60,3 +61,20 @@ export default App;
 ```
 
 You should now be able to use any components you need in your React application!
+
+## Configuring the test-id attribute
+
+PIE components expose their internal test hooks using the `data-test-id` attribute by default. If your test tooling targets a different attribute (for example, Playwright's `testConfig.testIdAttribute`), you can tell PIE to use the same attribute name so a single `getByTestId` strategy works for both your own markup and PIE internals.
+
+Call `setPieTestIdAttribute` **once**, before your app renders — for example at the top of your client entry (`src/main.tsx`):
+
+```tsx
+// src/main.tsx — before ReactDOM renders your app
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';
+
+setPieTestIdAttribute('data-qa');
+```
+
+- Defaults to `data-test-id`. Pass any valid attribute name (e.g. `data-qa`). Invalid names are ignored with a warning.
+- Set it **before components first render** — a component that has already rendered keeps `data-test-id` until it next updates.
+- `setPieTestIdAttribute` is provided by `@justeattakeaway/pie-webc-core`, which is installed automatically as a dependency of the PIE components.

--- a/packages/components/pie-webc/docs/framework-integration-guides/vue-3.md
+++ b/packages/components/pie-webc/docs/framework-integration-guides/vue-3.md
@@ -9,6 +9,7 @@ This guide will show you how to set up the PIE Web Components in a Vue 3 applica
 
 - [Dependencies](#dependencies)
 - [Usage](#usage)
+- [Configuring the test-id attribute](#configuring-the-test-id-attribute)
 
 ## Dependencies
 There are no vue-specific dependencies required. Please refer to the [Getting started](https://webc.pie.design/?path=/docs/introduction-getting-started--docs) guide for the dependencies required to use PIE Web Components in your application.
@@ -42,3 +43,24 @@ const count = ref(0);
 ```
 
 You should now be able to use any components you need in your Vue application!
+
+## Configuring the test-id attribute
+
+PIE components expose their internal test hooks using the `data-test-id` attribute by default. If your test tooling targets a different attribute (for example, Playwright's `testConfig.testIdAttribute`), you can tell PIE to use the same attribute name so a single `getByTestId` strategy works for both your own markup and PIE internals.
+
+Call `setPieTestIdAttribute` **once**, before mounting the app — for example in `main.ts`:
+
+```ts
+// main.ts — before app.mount()
+import { createApp } from 'vue';
+import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';
+import App from './App.vue';
+
+setPieTestIdAttribute('data-qa');
+
+createApp(App).mount('#app');
+```
+
+- Defaults to `data-test-id`. Pass any valid attribute name (e.g. `data-qa`). Invalid names are ignored with a warning.
+- Set it **before components first render** — a component that has already rendered keeps `data-test-id` until it next updates.
+- `setPieTestIdAttribute` is provided by `@justeattakeaway/pie-webc-core`, which is installed automatically as a dependency of the PIE components.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    define: {
+        __PACKAGE_VERSION__: JSON.stringify('test'),
+    },
     test: {
         dir: '.',
         environment: 'jsdom',


### PR DESCRIPTION
## Summary

PIE components hardcode `data-test-id` on their internal shadow-DOM elements. Consumers whose Playwright config (or other test framework) uses a different `testIdAttribute` (e.g. `data-qa`) can't use `getByTestId` for PIE internals and have to fallback to mixed locator strategies.

This adds a global, runtime-configurable override so a single `getByTestId` strategy works end-to-end:

```ts
import { setPieTestIdAttribute } from '@justeattakeaway/pie-webc-core';

// Call once at app/test startup, before components first render.
setPieTestIdAttribute('data-qa');
```

Every PIE component then renames its internal `data-test-id` attributes to the configured name (the original is removed). Defaults to `data-test-id` with invalid names triggering a `warn` and are ignored.

## How it works

- New `setPieTestIdAttribute` / `getPieTestIdAttribute` exported from `pie-webc-core`.
- A Lit `ReactiveController` (`TestIdController`) attached by the shared `PieElement` base renames the shadow-DOM attributes on `hostUpdated`, guarded by `isServer` and a default-attribute check.


# Update of testing on a consuming repo

While this approach is technically achievable on the client, making it behave correctly under SSR is either impossible at runtime, or requires a disproportionately large, fragile change. Given that consumers can already target PIE internals today (just more verbosely), the value of this change, if we could get it work does not justify the cost.

The benefit provided, is that this changes removes the need for one `.locator('[data-test-id=…]')` hop from consumers' Playwright tests. It does not enable any test that is currently impossible.

Consumers can already test PIE components today:

```ts
// Already works, no PIE changes required:
const modalFooter = page.getByTestId('checkout-form')
    .locator('[data-test-id="pie-modal-footer"]');
await expect(modalFooter).toBeVisible();
```

It is a little long-winded (two locator strategies in one chain), but it is reliable, SSR-safe, and requires zero PIE machinery, zero per-component bundle cost, and no consumer bootstrapping.

Against that modest convenience, the runtime override costs:

- Results in a bundle increase to every component for a test-only feature (~0.1–0.2 KB each).
- SSR hydration fragility. (I noticed a number of of hydration issues on SSR pages during consumer testing
- A consumer setup step (`setPieTestIdAttribute` at the right place in the client bootstrap, before hydration in order to work).