### PR TITLE
fix(pie-toast): DSW-4010 ensure component opens and hides correctly

### DIFF
--- a/.changeset/many-hats-report.md
+++ b/.changeset/many-hats-report.md
@@ -1,0 +1,7 @@
+---
+"@justeattakeaway/pie-toast-provider": minor
+"@justeattakeaway/pie-toast": minor
+---
+
+[Fixed] - the `isOpen` prop for pie-toast doesn't work as expected 
+[Added] - support a new css property for pie-toast-provider to override the position

--- a/packages/components/pie-toast-provider/README.md
+++ b/packages/components/pie-toast-provider/README.md
@@ -46,6 +46,7 @@ This component does not have any slots. All content is controlled through proper
 | Name                     | Description                                 | Default                     |
 |--------------------------|---------------------------------------------|-----------------------------|
 | `--toast-provider-z-index` | Controls the stacking order of the toasts. | `--dt-z-index-toast` (6000) |
+| `--toast-provider-position` | Controls the CSS positioning of the provider. Set to `absolute` to position relative to the nearest positioned ancestor instead of the viewport. | `fixed` |
 | `--toast-provider-offset` | Controls the gap between toasts and the boundary of the viewport. | `--dt-spacing-c  (Desktop)` / `--dt-spacing-d (Mobile)` |
 
 ### Events

--- a/packages/components/pie-toast-provider/src/toast-provider.scss
+++ b/packages/components/pie-toast-provider/src/toast-provider.scss
@@ -4,6 +4,7 @@
 
 :host {
     --toast-provider-z-index: var(--dt-z-index-toast);
+    --toast-provider-position: fixed;
     --toast-provider-offset: var(--dt-spacing-d);
 
     @include media('>md') {
@@ -12,7 +13,7 @@
 }
 
 .c-toast-provider {
-    position: fixed;
+    position: var(--toast-provider-position);
     z-index: var(--toast-provider-z-index);
 
     &.c-toast-provider--default {

--- a/packages/components/pie-toast/src/index.ts
+++ b/packages/components/pie-toast/src/index.ts
@@ -312,6 +312,10 @@ export class PieToast extends PieElement implements ToastProps {
     }
 
     render () {
+        if (!this.isOpen) {
+            return nothing;
+        }
+
         const {
             variant,
             message,

--- a/packages/components/pie-toast/test/component/pie-toast.spec.ts
+++ b/packages/components/pie-toast/test/component/pie-toast.spec.ts
@@ -22,6 +22,38 @@ test.describe('PieToast - Component tests', () => {
     });
 
     test.describe('Props', () => {
+        test.describe('isOpen', () => {
+            test('should render the toast when isOpen is true', async ({ page }) => {
+                // Arrange
+                const toastPage = new BasePage(page, 'toast');
+                const props: Partial<ToastProps> = {
+                    isOpen: true,
+                };
+                await toastPage.load({ ...props });
+
+                // Act
+                const toastComponent = page.getByTestId(toast.selectors.container.dataTestId);
+
+                // Assert
+                await expect(toastComponent).toBeVisible();
+            });
+
+            test('should not render the toast when isOpen is false', async ({ page }) => {
+                // Arrange
+                const toastPage = new BasePage(page, 'toast');
+                const props: Partial<ToastProps> = {
+                    isOpen: false,
+                };
+                await toastPage.load({ ...props });
+
+                // Act
+                const toastComponent = page.getByTestId(toast.selectors.container.dataTestId);
+
+                // Assert
+                await expect(toastComponent).toHaveCount(0);
+            });
+        });
+
         test.describe('message', () => {
             test('should render the message', async ({ page }) => {
                 // Arrange


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

[Fixed] - the `isOpen` prop for pie-toast doesn't work as expected 
[Added] - support a new css property for pie-toast-provider to override the position when needed. This is useful for cases where we want the toast to be relative to a parent container using absolute position instead of being fixed to the viewport (current behavior)

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [-] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
