### PR TITLE
fix(generator-pie-component): DSW-123 set version to workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@custom-elements-manifest/analyzer": "0.11.0",
     "@justeat/pie-design-tokens": "7.11.1",
     "@justeattakeaway/browserslist-config-pie": "0.2.1",
-    "@justeattakeaway/generator-pie-component": "0.33.0",
+    "@justeattakeaway/generator-pie-component": "workspace:*",
     "@justeattakeaway/pie-icons": "5.25.0",
     "@justeattakeaway/pie-webc-testing": "0.13.5",
     "@justeattakeaway/pie-wrapper-react": "0.14.4",

--- a/packages/tools/generator-pie-component/src/app/index.ts
+++ b/packages/tools/generator-pie-component/src/app/index.ts
@@ -42,7 +42,7 @@ export default class extends Generator {
             this.props,
             undefined,
             {
-                globOptions: { dot: true, ignore: ['**/pie-placeholder.__stories__.ts', '**/pie-placeholder.mdx'] },
+                globOptions: { dot: true, ignore: ['**/pie-placeholder.__stories__.ts', '**/pie-placeholder.mdx', '**/pie-placeholder.__test__.__stories__.ts'] },
                 processDestinationPath,
             },
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3776,18 +3776,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@justeattakeaway/generator-pie-component@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@justeattakeaway/generator-pie-component@npm:0.33.0"
-  dependencies:
-    chalk: "npm:5.6.2"
-    yaml: "npm:2.8.3"
-    yeoman-generator: "npm:5.10.0"
-  checksum: 10/7e140cd4dba3b139171ca1101bc75a6a8d5ce32b7a4c2e6c252d22523be6d5dd49cea04e467dba78e98f1bda5ebed4d85d7bd73f615e3881ea6ed58ffd545fbd
-  languageName: node
-  linkType: hard
-
-"@justeattakeaway/generator-pie-component@workspace:packages/tools/generator-pie-component":
+"@justeattakeaway/generator-pie-component@workspace:*, @justeattakeaway/generator-pie-component@workspace:packages/tools/generator-pie-component":
   version: 0.0.0-use.local
   resolution: "@justeattakeaway/generator-pie-component@workspace:packages/tools/generator-pie-component"
   dependencies:
@@ -21120,7 +21109,7 @@ __metadata:
     "@custom-elements-manifest/analyzer": "npm:0.11.0"
     "@justeat/pie-design-tokens": "npm:7.11.1"
     "@justeattakeaway/browserslist-config-pie": "npm:0.2.1"
-    "@justeattakeaway/generator-pie-component": "npm:0.33.0"
+    "@justeattakeaway/generator-pie-component": "workspace:*"
     "@justeattakeaway/pie-icons": "npm:5.25.0"
     "@justeattakeaway/pie-webc-testing": "npm:0.13.5"
     "@justeattakeaway/pie-wrapper-react": "npm:0.14.4"


### PR DESCRIPTION
- This should fix the generator not being found when running the `yo` command.
- Stop test story file being copied to component package (should only be added to storybook app)