### PR TITLE
fix(generator-pie-component): DSW-123 fix broken markdown import

### DIFF
--- a/.changeset/polite-areas-yell.md
+++ b/.changeset/polite-areas-yell.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/generator-pie-component": minor
+---
+
+[Fixed] - Storybook markdown import

--- a/packages/tools/generator-pie-component/src/app/templates/pie-placeholder.mdx
+++ b/packages/tools/generator-pie-component/src/app/templates/pie-placeholder.mdx
@@ -1,5 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Meta, Markdown } from '@storybook/addon-docs';
 import readme from '@justeattakeaway/pie-<%= fileName %>/README.md?raw';
 
 <Meta title="Components/<%= displayName %>" name="Overview" />

--- a/packages/tools/generator-pie-component/src/app/templates/pie-placeholder.mdx
+++ b/packages/tools/generator-pie-component/src/app/templates/pie-placeholder.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/blocks';
+import { Markdown } from '@storybook/addon-docs/blocks';
 import readme from '@justeattakeaway/pie-<%= fileName %>/README.md?raw';
 
 <Meta title="Components/<%= displayName %>" name="Overview" />


### PR DESCRIPTION
- I think due to recent storybook upgrades, the previously working Markdown import in the placeholder component docs mdx file was now broken for new components. Updated the import to fix.