### PR TITLE
feat(pie-cookie-banner): WEBEX-582 added aria labels

### DIFF
--- a/.changeset/nine-waves-work.md
+++ b/.changeset/nine-waves-work.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-cookie-banner": minor
+---
+
+[Added] - ARIA labels to switches in Manage preferences

--- a/packages/components/pie-cookie-banner/src/index.ts
+++ b/packages/components/pie-cookie-banner/src/index.ts
@@ -266,6 +266,7 @@ export class PieCookieBanner extends PieElement implements CookieBannerProps {
                  </div>
                 <pie-switch
                     id="${id}"
+                    .aria="${{ label: title }}"
                     ?checked="${this.defaultPreferences?.[id] || shouldToggleAll || checked}"
                     ?disabled="${disabled}"
                     @change="${this._handleSwitchStates}">

--- a/packages/components/pie-cookie-banner/test/component/pie-cookie-banner.spec.ts
+++ b/packages/components/pie-cookie-banner/test/component/pie-cookie-banner.spec.ts
@@ -131,6 +131,16 @@ test.describe('PieCookieBanner - Component tests', () => {
         expect(isNecessaryPreferenceToggleDisabled).toBe(true);
     });
 
+    test('should have an aria-label matching the preference title on each switch', async () => {
+        // Arrange
+        await pieCookieBannerComponent.load();
+        await pieCookieBannerComponent.clickManagePreferencesAction();
+
+        // Assert
+        expect(await pieCookieBannerComponent.getPreferenceSwitchAriaLabel('all')).toBe('Turn all on');
+        expect(await pieCookieBannerComponent.getPreferenceSwitchAriaLabel('functional')).toBe('Functional');
+    });
+
     test('should toggle all preferences if the `all` preference node is set to true', async () => {
         // Arrange
         await pieCookieBannerComponent.load({ defaultPreferences: null });

--- a/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
+++ b/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
@@ -311,6 +311,19 @@ export class CookieBannerComponent extends BasePage {
         return this.getModalCookieTechnologiesLinkAttribute('target');
     }
 
+
+    /**
+     * Retrieves the aria-label attribute from the preference switch associated with the specified preference ID.
+     *
+     * @param {PreferenceIds} preferenceIds The preference ID used to locate the preference switch.
+     * @returns {Promise<string | null>} A Promise that resolves to the value of the aria-label attribute
+     *                                   on the preference switch, or `null` if the attribute does not exist.
+     */
+    async getPreferenceSwitchAriaLabel (preferenceIds: PreferenceIds) : Promise<string | null> {
+        const switchComponent = this.page.locator(getPreferenceItemSelector(preferenceIds));
+        return switchComponent.getAttribute('aria-label');
+    }
+
     /**
      * Checks whether the preference toggle associated with the specified preference IDs is checked.
      *

--- a/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
+++ b/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
@@ -311,7 +311,6 @@ export class CookieBannerComponent extends BasePage {
         return this.getModalCookieTechnologiesLinkAttribute('target');
     }
 
-
     /**
      * Retrieves the aria-label attribute from the preference switch associated with the specified preference ID.
      *

--- a/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
+++ b/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
@@ -314,11 +314,11 @@ export class CookieBannerComponent extends BasePage {
     /**
      * Retrieves the aria-label attribute from the preference switch associated with the specified preference ID.
      *
-     * @param {PreferenceIds} preferenceIds The preference ID used to locate the preference switch.
+     * @param {PreferenceIds} preferenceId The preference ID used to locate the preference switch.
      * @returns {Promise<string | null>} A Promise that resolves to the value of the aria-label attribute
      *                                   on the preference switch, or `null` if the attribute does not exist.
      */
-    async getPreferenceSwitchAriaLabel (preferenceId: PreferenceIds): Promise<string | null> {
+    async getPreferenceSwitchAriaLabel (preferenceId: PreferenceIds) : Promise<string | null> {
         const switchInput = this.page.locator(`#${preferenceId} [data-test-id="switch-input"]`);
         return switchInput.getAttribute('aria-label');
     }

--- a/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
+++ b/packages/components/pie-cookie-banner/test/helpers/page-object/pie-cookie-banner.page.ts
@@ -318,9 +318,9 @@ export class CookieBannerComponent extends BasePage {
      * @returns {Promise<string | null>} A Promise that resolves to the value of the aria-label attribute
      *                                   on the preference switch, or `null` if the attribute does not exist.
      */
-    async getPreferenceSwitchAriaLabel (preferenceIds: PreferenceIds) : Promise<string | null> {
-        const switchComponent = this.page.locator(getPreferenceItemSelector(preferenceIds));
-        return switchComponent.getAttribute('aria-label');
+    async getPreferenceSwitchAriaLabel (preferenceId: PreferenceIds): Promise<string | null> {
+        const switchInput = this.page.locator(`#${preferenceId} [data-test-id="switch-input"]`);
+        return switchInput.getAttribute('aria-label');
     }
 
     /**


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

a11y fix - adds a label so preference is read out when the user toggles the switch 

Before (sound on):

https://github.com/user-attachments/assets/831c70a2-dd4f-46ea-8f8c-a65c22985f31

After:

https://github.com/user-attachments/assets/78e7fb4d-4b03-49ee-993a-d57cbf3a5f69

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

- [-] N/A I have added thorough tests where applicable (unit / component / visual).
- [-] N/A I have reviewed visual test updates properly before approving.
---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
