### PR TITLE
fix(pie-monorepo-utils): DSW-1234 extend ticket prefix length validation

### DIFF
--- a/.changeset/gentle-sheep-know.md
+++ b/.changeset/gentle-sheep-know.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-monorepo-utils": patch
+---
+
+[Changed] - Extend ticket prefix max length from 4 to 6 chars, so it allows longer prefixes such as WEBEX

--- a/.cz-config.js
+++ b/.cz-config.js
@@ -25,7 +25,7 @@ const getCurrentTicketNumberFromBranch = () => {
         const branchName = require('child_process').execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
         const { getTicketIdFromBranchName } = require('./packages/tools/pie-monorepo-utils/git-hooks/git-hooks-utils.js');
         const ticketId = getTicketIdFromBranchName(branchName);
-        
+
         return ticketId;
     } catch (error) {
         console.warn('Warning: Could not determine current branch name:', error.message);
@@ -68,5 +68,5 @@ module.exports = {
   allowTicketNumber: true,
   fallbackTicketNumber: getCurrentTicketNumberFromBranch(),
   isTicketNumberRequired: true,
-  ticketNumberRegExp: '[A-Z]{2,4}-(?!0+$)\\d{1,7}',
+  ticketNumberRegExp: '[A-Z]{2,6}-(?!0+$)\\d{1,7}',
 };

--- a/packages/tools/pie-monorepo-utils/git-hooks/git-hooks-utils.js
+++ b/packages/tools/pie-monorepo-utils/git-hooks/git-hooks-utils.js
@@ -1,10 +1,10 @@
 const TICKET_PATTERNS = {
     // Case insensitive branch name pattern: supports multiple ticket formats like dsw-123, abc-789
-    BRANCH: /(^[a-z]{2,4}-(\d{1,7}))-\w.*/i,
+    BRANCH: /(^[a-z]{2,6}-(\d{1,7}))-\w.*/i,
     // Case insensitive commit message pattern: type(scope): TICKET-123 title (supports multiple ticket formats)
-    COMMIT: /^(\w+)\((\w.*)\): ([A-Z]{2,4}-(?!0+)\d{1,7}) (\w.*)$/i,
+    COMMIT: /^(\w+)\((\w.*)\): ([A-Z]{2,6}-(?!0+)\d{1,7}) (\w.*)$/i,
     // PR title pattern: type(scope): TICKET-123 title (supports multiple ticket formats)
-    PR_TITLE: /^(\w+)\((\w.*)\): ([A-Z]{2,4}-(?!0+)\d{1,7}) (\w.*)$|^Version Packages.*/,
+    PR_TITLE: /^(\w+)\((\w.*)\): ([A-Z]{2,6}-(?!0+)\d{1,7}) (\w.*)$|^Version Packages.*/,
 };
 
 /**


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Extend ticket prefix max length from 4 to 6 chars, so it allows longer prefixes such as WEBEX
