### PR TITLE
ci(pie-monorepo): DSW-4032 update deprecated actions

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -39,7 +39,7 @@ runs:
       # Cache node_modules across runs so the Yarn link step can be skipped on hit
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             **/node_modules

--- a/.github/workflows/amplify-deploy.yml
+++ b/.github/workflows/amplify-deploy.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       # Checkout the repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Configure AWS credentials using OIDC
       - name: Configure AWS credentials

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     # Checkout the Repo
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/changeset-snapshot.yml
+++ b/.github/workflows/changeset-snapshot.yml
@@ -104,7 +104,7 @@ jobs:
         id: comment-branch
 
       - name: Checkout pull request branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.comment-branch.outputs.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       # Setup Repo
@@ -133,7 +133,7 @@ jobs:
     steps:
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # Setup Repo
       - name: Setup Repo
         uses: ./.github/actions/setup-repo
@@ -151,7 +151,7 @@ jobs:
     steps:
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # Setup Repo
       - name: Setup Repo
         uses: ./.github/actions/setup-repo
@@ -173,7 +173,7 @@ jobs:
     if: (github.event.repository.fork == false || github.event_name == 'pull_request')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Lint workflows
         shell: bash
         env:
@@ -204,7 +204,7 @@ jobs:
     steps:
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # Setup Repo
       - name: Setup Repo
         uses: ./.github/actions/setup-repo
@@ -272,7 +272,7 @@ jobs:
         package: ${{ fromJson(needs.check-change-type.outputs.changed-component-packages) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: Setup Repo
@@ -341,7 +341,7 @@ jobs:
     steps:
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       # Setup Repo

--- a/.github/workflows/closed.yml
+++ b/.github/workflows/closed.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check repo environments
         id: list-environments

--- a/.github/workflows/dangerjs-checks.yml
+++ b/.github/workflows/dangerjs-checks.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Generate GitHub App token

--- a/.github/workflows/install-build.yml
+++ b/.github/workflows/install-build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Repo
         uses: ./.github/actions/setup-repo
         with:

--- a/.github/workflows/labeler-get-labels.yml
+++ b/.github/workflows/labeler-get-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Fetch branches # This is necessary for comparing the current branch changes against main
       env:

--- a/.github/workflows/labeler-set-labels.yml
+++ b/.github/workflows/labeler-set-labels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Generate GitHub App token
         id: get-token

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Generate GitHub App token
       id: get-token

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-aperture.yml
+++ b/.github/workflows/test-aperture.yml
@@ -106,7 +106,7 @@ jobs:
           repo_token: ${{ steps.get-token.outputs.token }}
 
       - name: Checkout pull request branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.comment-branch.outputs.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/update-eslint-snacks-plugin.yml
+++ b/.github/workflows/update-eslint-snacks-plugin.yml
@@ -27,7 +27,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.get-token.outputs.token }}
 

--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Checkout the Repo
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.get-token.outputs.token }}
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "resolutions": {
     "axios": "0.32.0",
-    "basic-ftp": "5.2.2",
+    "basic-ftp": "5.3.0",
     "lit": "3.2.0",
     "lodash": "4.18.0",
     "tar": "7.5.16",

--- a/packages/tools/pie-css/package.json
+++ b/packages/tools/pie-css/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/postcss-import": "14.0.3",
     "include-media": "2.0.0",
-    "postcss": "8.4.32",
+    "postcss": "8.5.15",
     "postcss-import": "15.1.0",
     "w3c-css-validator": "1.4.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,7 +3201,7 @@ __metadata:
     "@justeat/pie-design-tokens": "npm:7.11.1"
     "@types/postcss-import": "npm:14.0.3"
     include-media: "npm:2.0.0"
-    postcss: "npm:8.4.32"
+    postcss: "npm:8.5.15"
     postcss-import: "npm:15.1.0"
     w3c-css-validator: "npm:1.4.1"
   languageName: unknown
@@ -7999,10 +7999,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:5.2.2":
-  version: 5.2.2
-  resolution: "basic-ftp@npm:5.2.2"
-  checksum: 10/2bb208276bafbc3549992734b67247d78bfe6546e2eb1e9513c2761364c47e88b94171666359200279a738b36b152d2bbba0953d4f83f4677f1fd5b68aea3e29
+"basic-ftp@npm:5.3.0":
+  version: 5.3.0
+  resolution: "basic-ftp@npm:5.3.0"
+  checksum: 10/08eef717642f32d92936e02f516ab6426ecc61084e4a75b542cd202dd84dddff2520dda321db1be34b7e49860cf1b2aed67ab275dc3e53b185949df311241396
   languageName: node
   linkType: hard
 
@@ -14911,7 +14911,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
   bin:
@@ -16499,17 +16499,6 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10/e4e4486f33b3163a606a6ed94f9c196ab49a37a7a7163abfcd469e5f113210120d70b8dd5e33d64636f41ad52316a3725655421eb9a1094f1bcab1db2f555c62
-  languageName: node
-  linkType: hard
-
-"postcss@npm:8.4.32":
-  version: 8.4.32
-  resolution: "postcss@npm:8.4.32"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10/28084864122f29148e1f632261c408444f5ead0e0b9ea9bd9729d0468818ebe73fe5dc0075acd50c1365dbe639b46a79cba27d355ec857723a24bc9af0f18525
   languageName: node
   linkType: hard
 
@@ -18205,7 +18194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Updates some old dependency versions
- Updates `actions/checkout` action to v6 to ensure these run on Node 24, and not Node 20. This _should_ remove the following warnings in CI.

<img width="3264" height="773" alt="Screenshot 2026-06-09 at 10 51 49" src="https://github.com/user-attachments/assets/9a8aeb0f-4341-4cca-9ea5-75721ba94f06" />

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- N/A I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- N/A If changes will affect consumers of the package, I have created a changeset entry.
- N/A If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---
