### PR TITLE
chore(pie-monorepo): DSW-4042 fix flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,25 +293,27 @@ jobs:
           PKG: ${{ matrix.package }}
         run: echo "safe=${PKG//\//__}" >> "$GITHUB_OUTPUT"
       - name: Run System / Component / a11y Tests
+        id: browser-tests
         uses: ./.github/actions/run-script
         with:
           script-name: "test:browsers:ci --filter=${{ matrix.package }}"
           concurrency: 1
       - name: Upload Browsers Report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always()
+        if: steps.browser-tests.outcome == 'failure'
         with:
           name: lit-browsers-report-${{ steps.pkg.outputs.safe }}
           path: lit-browsers-report/
           retention-days: 7
       - name: Run Visual Tests
+        id: visual-tests
         uses: ./.github/actions/run-script
         with:
           script-name: "test:visual:ci --filter=${{ matrix.package }}"
           concurrency: 1
       - name: Upload Visual Report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always()
+        if: steps.visual-tests.outcome == 'failure'
         with:
           name: lit-visual-report-${{ steps.pkg.outputs.safe }}
           path: lit-visual-report/

--- a/apps/pie-storybook/.storybook/main.ts
+++ b/apps/pie-storybook/.storybook/main.ts
@@ -14,7 +14,7 @@ const config: StorybookConfig = {
             "../stories/!(testing)/**/*.stories.@(js|ts|tsx)",
         ],
     addons: [
-        "@storybook/addon-a11y",
+        ...(isBrowserTesting ? [] : ["@storybook/addon-a11y"]),
         "@storybook/addon-designs",
         "@storybook/addon-links",
         "storybook-dark-mode",

--- a/packages/components/pie-assistive-text/test/visual/pie-assistive-text.spec.ts
+++ b/packages/components/pie-assistive-text/test/visual/pie-assistive-text.spec.ts
@@ -9,7 +9,6 @@ const directions = ['ltr', 'rtl'];
 directions.forEach((dir) => {
     test(`should render all prop variations with ${dir} direction`, async ({ page }) => {
         const assistiveTextVariantsPage = new BasePage(page, 'assistive-text--variants');
-        assistiveTextVariantsPage.waitUntilStrategy = 'networkidle';
         await assistiveTextVariantsPage.load({}, { writingDirection: dir });
 
         await expect.soft(page.getByTestId(assistiveText.selectors.container.dataTestId).first()).toBeVisible();

--- a/packages/components/pie-avatar/test/visual/pie-avatar.spec.ts
+++ b/packages/components/pie-avatar/test/visual/pie-avatar.spec.ts
@@ -6,7 +6,6 @@ import { avatar } from '../helpers/selectors';
 test.describe('PieAvatar - Visual tests`', () => {
     test('should display the PieAvatar default variant successfully', async ({ page }) => {
         const avatarPage = new BasePage(page, 'avatar--default');
-        avatarPage.waitUntilStrategy = 'networkidle';
         const avatarComponent = page.locator(avatar.selectors.container.dataTestId);
         await avatarPage.load();
 
@@ -16,7 +15,6 @@ test.describe('PieAvatar - Visual tests`', () => {
 
     test('should display the PieAvatar component when label is provided', async ({ page }) => {
         const avatarPage = new BasePage(page, 'avatar--default');
-        avatarPage.waitUntilStrategy = 'networkidle';
         avatarPage.args = 'label:Alice Johnson';
         const avatarComponent = page.locator(avatar.selectors.container.dataTestId);
         await avatarPage.load();
@@ -27,7 +25,6 @@ test.describe('PieAvatar - Visual tests`', () => {
 
     test('should display the PieAvatar component when src is provided', async ({ page }) => {
         const avatarPage = new BasePage(page, 'avatar--with-image');
-        avatarPage.waitUntilStrategy = 'networkidle';
         const avatarComponent = page.locator(avatar.selectors.container.dataTestId);
         const avatarImg = page.getByTestId(avatar.selectors.image.dataTestId);
         await avatarPage.load();

--- a/packages/components/pie-breadcrumb/test/visual/pie-breadcrumb.spec.ts
+++ b/packages/components/pie-breadcrumb/test/visual/pie-breadcrumb.spec.ts
@@ -10,7 +10,6 @@ test.describe('PieBreadcrumb - Visual tests`', () => {
     test('should truncate the breadcrumb text when the label is too long (bigger than 250px)', async ({ page }) => {
         // Arrange
         const basePage = new BasePage(page, 'breadcrumb--with-long-text');
-        basePage.waitUntilStrategy = 'networkidle';
         await basePage.load();
 
         // Assert
@@ -21,7 +20,6 @@ test.describe('PieBreadcrumb - Visual tests`', () => {
         test(`should render items in writing direction: ${direction}`, async ({ page }) => {
             // Arrange
             const basePage = new BasePage(page, 'breadcrumb--default');
-            basePage.waitUntilStrategy = 'networkidle';
             await basePage.load({}, { writingDirection: direction });
 
             // Assert
@@ -33,7 +31,6 @@ test.describe('PieBreadcrumb - Visual tests`', () => {
         test(`should render PieBreadcrumb with variant: ${variant}`, async ({ page }) => {
             // Arrange
             const selectVariationsPage = new BasePage(page, `breadcrumb--${variant}-prop-variation`);
-            selectVariationsPage.waitUntilStrategy = 'networkidle';
             await selectVariationsPage.load();
 
             // Assert
@@ -44,7 +41,6 @@ test.describe('PieBreadcrumb - Visual tests`', () => {
     test('should render a single item breadcrumb', async ({ page }) => {
         // Arrange
         const basePage = new BasePage(page, 'breadcrumb--single-item');
-        basePage.waitUntilStrategy = 'networkidle';
         await basePage.load();
 
         // Assert
@@ -54,7 +50,6 @@ test.describe('PieBreadcrumb - Visual tests`', () => {
     test('should render a single item breadcrumb in compact mode', async ({ page }) => {
         // Arrange
         const basePage = new BasePage(page, 'breadcrumb--single-item-compact');
-        basePage.waitUntilStrategy = 'networkidle';
         await basePage.load();
 
         // Assert

--- a/packages/components/pie-button/test/visual/pie-button-anchor.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button-anchor.spec.ts
@@ -9,7 +9,6 @@ variants.forEach((variant) => {
     test(`should render all size and variant variations for anchor tag for variant: ${variant}`, async ({ page }) => {
         // Arrange
         const buttonPage = new BasePage(page, `button--${variant}-anchor-variations`);
-        buttonPage.waitUntilStrategy = 'networkidle';
         const buttonComponent = new ButtonComponent(page);
         await buttonPage.load();
 

--- a/packages/components/pie-button/test/visual/pie-button-size.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button-size.spec.ts
@@ -7,7 +7,6 @@ import { ButtonComponent } from '../helpers/page-object/pie-button.component.ts'
 test('should render all size variations', async ({ page }) => {
     // Arrange
     const buttonPage = new BasePage(page, 'button--responsive-button-variations');
-    buttonPage.waitUntilStrategy = 'networkidle';
     const buttonComponent = new ButtonComponent(page);
     await buttonPage.load();
 
@@ -19,7 +18,6 @@ test('should render all size variations', async ({ page }) => {
 test('should render all size variations, with larger button text string', async ({ page }) => {
     // Arrange
     const buttonPage = new BasePage(page, 'button--double-line-text-button-variations');
-    buttonPage.waitUntilStrategy = 'networkidle';
     const buttonComponent = new ButtonComponent(page);
     await buttonPage.load();
 

--- a/packages/components/pie-button/test/visual/pie-button.spec.ts
+++ b/packages/components/pie-button/test/visual/pie-button.spec.ts
@@ -8,7 +8,6 @@ variants.forEach((variant) => {
     test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
         // Arrange
         const buttonPage = new BasePage(page, `button--${variant}-variations`);
-        buttonPage.waitUntilStrategy = 'networkidle';
         const buttonComponent = new ButtonComponent(page);
         await buttonPage.load();
 
@@ -21,7 +20,6 @@ variants.forEach((variant) => {
 test('should render isFullWidth correctly in different layout contexts', async ({ page }) => {
     // Arrange
     const buttonPage = new BasePage(page, 'button--is-full-width-layout-variations');
-    buttonPage.waitUntilStrategy = 'networkidle';
     const buttonComponent = new ButtonComponent(page);
     await buttonPage.load();
 

--- a/packages/components/pie-card/test/visual/pie-card.spec.ts
+++ b/packages/components/pie-card/test/visual/pie-card.spec.ts
@@ -8,7 +8,6 @@ import { variants, type CardProps } from '../../src/defs.ts';
 test.describe('PieCard - Visual tests`', () => {
     variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
         const variantPage = new BasePage(page, `card--${variant}-variants`);
-        variantPage.waitUntilStrategy = 'networkidle';
         await variantPage.load();
 
         await percySnapshot(page, `PIE Card - Variant: ${variant}`, percyWidths);
@@ -19,7 +18,6 @@ test.describe('PieCard - `padding` prop', async () => {
     const paddingTokens = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
     paddingTokens.forEach((paddingToken) => test(`should render the padding variants for padding token value: ${paddingToken}`, async ({ page }) => {
         const paddingVariantPage = new BasePage(page, `card--padding-${paddingToken}-variants`);
-        paddingVariantPage.waitUntilStrategy = 'networkidle';
 
         await paddingVariantPage.load();
         await percySnapshot(page, `PIE Card - Padding values: ${paddingToken}`, percyWidths);
@@ -33,7 +31,6 @@ test.describe('PieCard - Disabled Prop Visual Tests', () => {
         };
 
         const cardWithImagePage = new CardWithImagePage(page);
-        cardWithImagePage.waitUntilStrategy = 'networkidle';
         await cardWithImagePage.load({ ...props });
 
         await expect.soft(cardWithImagePage.cardComponent.componentLocator.locator('img')).toHaveCSS('opacity', '0.5');
@@ -46,7 +43,6 @@ test.describe('PieCard - Disabled Prop Visual Tests', () => {
         };
 
         const cardWithImagePage = new CardWithImagePage(page);
-        cardWithImagePage.waitUntilStrategy = 'networkidle';
         await cardWithImagePage.load({ ...props });
 
         await expect.soft(cardWithImagePage.cardComponent.componentLocator.locator('img')).not.toHaveCSS('opacity', '0.5');

--- a/packages/components/pie-checkbox-group/test/visual/pie-checkbox-group.spec.ts
+++ b/packages/components/pie-checkbox-group/test/visual/pie-checkbox-group.spec.ts
@@ -9,7 +9,6 @@ const readingDirections = ['ltr', 'rtl'];
 readingDirections.forEach((direction) => test(`should render all prop variations for the checkbox group component with dir: ${direction}`, async ({ page }) => {
     // Arrange
     const checkboxGroupVariations = new BasePage(page, 'checkbox-group--variations');
-    checkboxGroupVariations.waitUntilStrategy = 'networkidle';
     await checkboxGroupVariations.load({}, { writingDirection: direction });
 
     // Assert

--- a/packages/components/pie-checkbox/test/visual/pie-checkbox.spec.ts
+++ b/packages/components/pie-checkbox/test/visual/pie-checkbox.spec.ts
@@ -7,7 +7,6 @@ const checkedStates = [true, false];
 checkedStates.forEach((state) => test(`should render all prop variations for the checked state: ${state}`, async ({ page }) => {
     // Arrange
     const checkboxVariationsPage = new BasePage(page, `checkbox--checked-${state}-variations`);
-    checkboxVariationsPage.waitUntilStrategy = 'networkidle';
     await checkboxVariationsPage.load();
 
     // Assert
@@ -17,7 +16,6 @@ checkedStates.forEach((state) => test(`should render all prop variations for the
 test('should render all label position and fit variations', async ({ page }) => {
     // Arrange
     const labelPositionPage = new BasePage(page, 'checkbox--label-position-variations');
-    labelPositionPage.waitUntilStrategy = 'networkidle';
     await labelPositionPage.load();
 
     // Assert
@@ -27,7 +25,6 @@ test('should render all label position and fit variations', async ({ page }) => 
 test('should render all rich label variations', async ({ page }) => {
     // Arrange
     const richLabelPage = new BasePage(page, 'checkbox--rich-label-variations');
-    richLabelPage.waitUntilStrategy = 'networkidle';
     await richLabelPage.load();
 
     // Assert

--- a/packages/components/pie-chip/test/visual/pie-chip.spec.ts
+++ b/packages/components/pie-chip/test/visual/pie-chip.spec.ts
@@ -6,8 +6,6 @@ import { variants } from '../../src/defs.ts';
 
 variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
     const basePage = new BasePage(page, `chip--${variant}-prop-variations`);
-    basePage.waitUntilStrategy = 'networkidle';
-
     await basePage.load();
 
     await percySnapshot(page, `PIE Chip - Variant: ${variant}`, percyWidths);
@@ -15,8 +13,6 @@ variants.forEach((variant) => test(`should render all prop variations for Varian
 
 variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant} when type='checkbox'`, async ({ page }) => {
     const basePage = new BasePage(page, `chip--${variant}-checkbox-prop-variations`);
-    basePage.waitUntilStrategy = 'networkidle';
-
     await basePage.load();
 
     await percySnapshot(page, `PIE Chip - Checkbox - Variant: ${variant}`, percyWidths);

--- a/packages/components/pie-cookie-banner/test/visual/pie-cookie-banner.spec.ts
+++ b/packages/components/pie-cookie-banner/test/visual/pie-cookie-banner.spec.ts
@@ -7,7 +7,6 @@ let pieCookieBannerComponent: CookieBannerComponent;
 test.describe('PieCookieBanner - Visual tests`', () => {
     test.beforeEach(async ({ page }) => {
         pieCookieBannerComponent = new CookieBannerComponent(page);
-        pieCookieBannerComponent.waitUntilStrategy = 'networkidle';
     });
 
     test('should display the PieCookieBanner component successfully', async ({ page }) => {

--- a/packages/components/pie-data-table/test/accessibility/pie-data-table.spec.ts
+++ b/packages/components/pie-data-table/test/accessibility/pie-data-table.spec.ts
@@ -10,8 +10,6 @@ test.describe('PieDataTable - Accessibility tests', () => {
         test(`should test a11y for Story: ${friendlyStoryName}`, async ({ page, makeAxeBuilder }) => {
             // Arrange
             const basePage = new BasePage(page, `data-table--${storyUrl}`);
-            basePage.waitUntilStrategy = 'networkidle';
-
             await basePage.load();
 
             // Act

--- a/packages/components/pie-data-table/test/visual/pie-data-table.spec.ts
+++ b/packages/components/pie-data-table/test/visual/pie-data-table.spec.ts
@@ -13,7 +13,6 @@ test.describe('PieDataTable - Visual tests`', () => {
 
             test(`should display the PieDataTable component successfully - ${friendlyStoryName} - ${dir}`, async ({ page }) => {
                 const basePage = new BasePage(page, `data-table--${storyUrl}`);
-                basePage.waitUntilStrategy = 'networkidle';
 
                 await basePage.load({}, { writingDirection: dir });
 

--- a/packages/components/pie-divider/test/visual/pie-divider.spec.ts
+++ b/packages/components/pie-divider/test/visual/pie-divider.spec.ts
@@ -6,7 +6,6 @@ import { variants } from '../../src/defs.ts';
 
 variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
     const basePage = new BasePage(page, `divider--${variant}-prop-variations`);
-    basePage.waitUntilStrategy = 'networkidle';
 
     await basePage.load();
 

--- a/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
+++ b/packages/components/pie-form-label/test/visual/pie-form-label.spec.ts
@@ -6,7 +6,6 @@ import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-obj
 test.describe('Pie Form Label - Visual tests`', () => {
     test('should display the Pie Form Label component successfully', async ({ page }) => {
         const formLabelPage = new BasePage(page, 'form-label--variants');
-        formLabelPage.waitUntilStrategy = 'networkidle';
         await formLabelPage.load();
 
         await percySnapshot(page, 'Pie Form Label - Visual Test', percyWidths);

--- a/packages/components/pie-icon-button/test/accessibility/pie-icon-button.spec.ts
+++ b/packages/components/pie-icon-button/test/accessibility/pie-icon-button.spec.ts
@@ -5,7 +5,6 @@ import { variants } from '../../src/defs.ts';
 variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ makeAxeBuilder, page }) => {
     // Arrange
     const iconButtonPage = new BasePage(page, `icon-button--${variant}-variations`);
-    iconButtonPage.waitUntilStrategy = 'networkidle';
     await iconButtonPage.load();
 
     // Act

--- a/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
+++ b/packages/components/pie-icon-button/test/visual/pie-icon-button.spec.ts
@@ -9,7 +9,6 @@ variants.forEach((variant) => {
     test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
     // Arrange
         const iconButtonPage = new BasePage(page, `icon-button--${variant}-variations`);
-        iconButtonPage.waitUntilStrategy = 'networkidle';
         await iconButtonPage.load();
 
         const iconButtonComponent = await page.locator(iconButton.selectors.container.dataTestId).first();

--- a/packages/components/pie-link/test/visual/pie-link.spec.ts
+++ b/packages/components/pie-link/test/visual/pie-link.spec.ts
@@ -11,8 +11,6 @@ variants.forEach((variant) => {
     sizes.forEach((size) => {
         test(`should render all prop variations for Variant: ${variant} and Size: ${size}`, async ({ page }) => {
             const linkVariationsPage = new BasePage(page, `link--${variant}-${size}-variations`);
-            linkVariationsPage.waitUntilStrategy = 'networkidle';
-
             await linkVariationsPage.load();
 
             await percySnapshot(page, `PIE Link - Variant: ${variant} - Size: ${size}`, percyWidths);

--- a/packages/components/pie-list/test/visual/pie-list.spec.ts
+++ b/packages/components/pie-list/test/visual/pie-list.spec.ts
@@ -5,8 +5,6 @@ import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-obj
 test.describe('PieList - Visual tests`', () => {
     test('should display the PieList component successfully', async ({ page }) => {
         const basePage = new BasePage(page, 'list--default');
-        basePage.waitUntilStrategy = 'networkidle';
-
         await basePage.load();
 
         await percySnapshot(page, 'PieList - Visual Test');

--- a/packages/components/pie-lottie-player/test/visual/pie-lottie-player.spec.ts
+++ b/packages/components/pie-lottie-player/test/visual/pie-lottie-player.spec.ts
@@ -11,7 +11,6 @@ test.describe('PieLottiePlayer - Visual tests', () => {
         };
 
         const lottiePlayerPage = new LottiePlayerDefaultPage(page);
-        lottiePlayerPage.waitUntilStrategy = 'networkidle';
         await lottiePlayerPage.load({ ...props });
 
         // Assert

--- a/packages/components/pie-modal/test/visual/pie-modal.spec.ts
+++ b/packages/components/pie-modal/test/visual/pie-modal.spec.ts
@@ -17,7 +17,6 @@ const sharedProps: ModalProps = {
 sizes.forEach((size) => {
     test(`should render correctly with size = ${size}`, async ({ page }) => {
         const modalDefaultPage = new ModalDefaultPage(page);
-        modalDefaultPage.waitUntilStrategy = 'networkidle';
         const props: ModalProps = {
             ...sharedProps,
             hasStackedActions: false,
@@ -39,7 +38,6 @@ test.describe('Prop: `isFullWidthBelowMid`', () => {
     test.describe('when true', () => {
         test('should be full width for a modal with size = medium', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isFullWidthBelowMid: true,
@@ -60,7 +58,6 @@ test.describe('Prop: `isFullWidthBelowMid`', () => {
 
         test('should not be full width when size = small', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isFullWidthBelowMid: true,
@@ -84,7 +81,6 @@ test.describe('Prop: `isFullWidthBelowMid`', () => {
       .forEach((size) => {
           test(`should not be full width for a modal with size = ${size}`, async ({ page }) => {
               const modalDefaultPage = new ModalDefaultPage(page);
-              modalDefaultPage.waitUntilStrategy = 'networkidle';
               const props: ModalProps = {
                   ...sharedProps,
                   isFullWidthBelowMid: false,
@@ -110,7 +106,6 @@ test.describe('Prop: `isDismissible`', () => {
     test.describe('when true', () => {
         test('should display a close button within the modal', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isDismissible: true,
@@ -132,7 +127,6 @@ test.describe('Prop: `isDismissible`', () => {
     test.describe('when false', () => {
         test('should not display a close button', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isDismissible: false,
@@ -156,7 +150,6 @@ test.describe('Prop: `isHeadingEmphasised`', () => {
     test.describe('when true', () => {
         test('should display the emphasised style for the heading', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isHeadingEmphasised: true,
@@ -178,7 +171,6 @@ test.describe('Prop: `isHeadingEmphasised`', () => {
     test.describe('when false', () => {
         test('should not display the emphasised style for the heading', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isHeadingEmphasised: false,
@@ -205,7 +197,6 @@ test.describe('Prop: `hasBackButton`', () => {
         test.describe('when true', () => {
             test(`should display a back button within the modal and dir is ${dir}`, async ({ page }) => {
                 const modalDefaultPage = new ModalDefaultPage(page);
-                modalDefaultPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     hasBackButton: true,
@@ -227,7 +218,6 @@ test.describe('Prop: `hasBackButton`', () => {
         test.describe('when false', () => {
             test(`should not display a back button and dir is ${dir}`, async ({ page }) => {
                 const modalDefaultPage = new ModalDefaultPage(page);
-                modalDefaultPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     hasBackButton: false,
@@ -251,7 +241,6 @@ test.describe('Prop: `hasBackButton`', () => {
 test.describe('Prop: `heading`', () => {
     test('should display & render long headings correctly', async ({ page }) => {
         const modalDefaultPage = new ModalDefaultPage(page);
-        modalDefaultPage.waitUntilStrategy = 'networkidle';
         const props: ModalProps = {
             heading: 'This is a modal heading but super long and should span multiple lines - hopefully this should never happen on production',
             hasBackButton: true,
@@ -274,7 +263,6 @@ test.describe('Prop: `heading`', () => {
 test.describe('Prop: `isLoading`', () => {
     test('should display loading spinner when `isLoading` is true', async ({ page }) => {
         const modalDefaultPage = new ModalDefaultPage(page);
-        modalDefaultPage.waitUntilStrategy = 'networkidle';
         const props: ModalProps = {
             ...sharedProps,
             hasBackButton: true,
@@ -299,7 +287,6 @@ test.describe('Prop: `backgroundColor`', () => {
     test.describe('when the backgroundColor is not set', () => {
         test('should render with default background color', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
             };
@@ -318,7 +305,6 @@ test.describe('Prop: `backgroundColor`', () => {
         backgroundColors.forEach((backgroundColor) => {
             test(`should render with backgroundColor = ${backgroundColor}`, async ({ page }) => {
                 const modalDefaultPage = new ModalDefaultPage(page);
-                modalDefaultPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     backgroundColor,
@@ -342,7 +328,6 @@ test.describe('Prop: `leadingAction`', () => {
     test.describe('when prop is passed into component', () => {
         test('should display leading action button', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 leadingAction: {
@@ -363,7 +348,6 @@ test.describe('Prop: `leadingAction`', () => {
     test.describe('when `leadingAction.variant` is set to "destructive"', () => {
         test('should show a "destructive" button', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 leadingAction: {
@@ -385,7 +369,6 @@ test.describe('Prop: `leadingAction`', () => {
     test.describe('when prop is provided empty', () => {
         test('should not render leading action markup', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 leadingAction: {
@@ -406,7 +389,6 @@ test.describe('Prop: `leadingAction`', () => {
     test.describe('when prop is not passed into component', () => {
         test('should not display leading action or footer', async ({ page }) => {
             const modalDefaultPage = new ModalDefaultPage(page);
-            modalDefaultPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 isOpen: true,
@@ -430,7 +412,6 @@ test.describe('Prop: `supportingAction`', () => {
         test.describe('and `supportingAction.text` is provided but `supportingAction.variant` is not', () => {
             test('should fall back to default variant', async ({ page }) => {
                 const modalDefaultPage = new ModalDefaultPage(page);
-                modalDefaultPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     leadingAction: {
@@ -454,7 +435,6 @@ test.describe('Prop: `supportingAction`', () => {
         test.describe('and `supportingAction.text` is provided but empty', () => {
             test('should not render supporting action markup', async ({ page }) => {
                 const modalDefaultPage = new ModalDefaultPage(page);
-                modalDefaultPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     leadingAction: {
@@ -478,7 +458,6 @@ test.describe('Prop: `supportingAction`', () => {
         test.describe('and `supportingAction.text` is not provided', () => {
             test('should not render supporting action markup', async ({ page }) => {
                 const modalDefaultPage = new ModalDefaultPage(page);
-                modalDefaultPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     leadingAction: {
@@ -501,7 +480,6 @@ test.describe('Prop: `supportingAction`', () => {
 test.describe('when `supportingAction.text` is supplied but `leadingAction.text` is not', () => {
     test('should not render supporting action markup', async ({ page }) => {
         const modalDefaultPage = new ModalDefaultPage(page);
-        modalDefaultPage.waitUntilStrategy = 'networkidle';
         const props: ModalProps = {
             ...sharedProps,
             supportingAction: {
@@ -527,7 +505,6 @@ test.describe('Prop: `position`', () => {
                     [true, false].forEach((isFullWidthBelowMid) => {
                         test(`and isFullWidthBelowMid is ${isFullWidthBelowMid}`, async ({ page }) => {
                             const modalDefaultPage = new ModalDefaultPage(page);
-                            modalDefaultPage.waitUntilStrategy = 'networkidle';
                             const props: ModalProps = {
                                 ...sharedProps,
                                 isFullWidthBelowMid,
@@ -557,7 +534,6 @@ test.describe('Prop: `isFooterPinned`', () => {
     [true, false].forEach((isFooterPinned) => {
         test(`when isFooterPinned is: ${isFooterPinned}`, async ({ page }) => {
             const modalLargeTextContentPage = new ModalLargeTextContentPage(page);
-            modalLargeTextContentPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = {
                 ...sharedProps,
                 leadingAction: {
@@ -587,7 +563,6 @@ test.describe('Prop: `isFooterPinned`', () => {
         (['medium', 'large'] as Array<ModalProps['size']>).forEach((size) => {
             test(`when modal is fullscreen with size: ${size} and isFooterPinned: ${isFooterPinned}`, async ({ page }) => {
                 const modalLargeTextContentPage = new ModalLargeTextContentPage(page);
-                modalLargeTextContentPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     leadingAction: {
@@ -623,7 +598,6 @@ test.describe('Prop: `hasStackedActions`', () => {
       .forEach((size) => {
           test(`should display actions full width (at narrow viewports – with leading action on top) for a modal with size = ${size}`, async ({ page }) => {
               const modalDefaultPage = new ModalDefaultPage(page);
-              modalDefaultPage.waitUntilStrategy = 'networkidle';
               const props: ModalProps = {
                   ...sharedProps,
                   hasStackedActions: true,
@@ -652,7 +626,6 @@ test.describe('Slot: `footer`', () => {
     test.describe('is assigned', () => {
         test('should display the "footer" slot content in the modal footer', async ({ page }) => {
             const modalCustomFooterPage = new ModalCustomFooterPage(page);
-            modalCustomFooterPage.waitUntilStrategy = 'networkidle';
             const props:ModalProps = { ...sharedProps };
             await modalCustomFooterPage.load(props);
 
@@ -669,7 +642,6 @@ test.describe('Slot: `headerContent`', () => {
     test.describe('is assigned', () => {
         test('should display the "headerContent" slot content in the modal header', async ({ page }) => {
             const modalCustomHeaderContentPage = new ModalCustomHeaderContentPage(page);
-            modalCustomHeaderContentPage.waitUntilStrategy = 'networkidle';
             const props: ModalProps = { ...sharedProps };
             await modalCustomHeaderContentPage.load(props);
 
@@ -688,7 +660,6 @@ test.describe('Slot: `image`', () => {
                     test.describe(`when isDismissible = ${isDismissible}`, () => {
                         test('should render correctly ', async ({ page }) => {
                             const modalCustomImageSlotContentPage = new ModalCustomImageSlotContentPage(page);
-                            modalCustomImageSlotContentPage.waitUntilStrategy = 'networkidle';
                             const props: ModalProps = {
                                 ...sharedProps,
                                 imageSlotMode,
@@ -712,7 +683,6 @@ test.describe('Slot: `image`', () => {
                         test.describe(`when isDismissible = ${isDismissible}`, () => {
                             test('should render correctly', async ({ page }) => {
                                 const modalCustomImageSlotContentPage = new ModalCustomImageSlotContentPage(page);
-                                modalCustomImageSlotContentPage.waitUntilStrategy = 'networkidle';
                                 const props: ModalProps = {
                                     ...sharedProps,
                                     imageSlotMode: 'illustration',
@@ -736,7 +706,6 @@ test.describe('Slot: `image`', () => {
         [...imageSlotAspectRatios, undefined].forEach((imageSlotAspectRatio) => {
             test(`should render correctly with imageSlotAspectRatio = ${imageSlotAspectRatio}`, async ({ page }) => {
                 const modalCustomImageSlotContentPage = new ModalCustomImageSlotContentPage(page);
-                modalCustomImageSlotContentPage.waitUntilStrategy = 'networkidle';
                 const props: ModalProps = {
                     ...sharedProps,
                     imageSlotMode: 'image',
@@ -755,7 +724,6 @@ test.describe('Slot: `image`', () => {
 test.describe('CSS parts', () => {
     test('should apply styles to the `heading` part', async ({ page }) => {
         const modalCustomHeadingStylePage = new ModalCustomHeadingStylePage(page);
-        modalCustomHeadingStylePage.waitUntilStrategy = 'networkidle';
         const props: ModalProps = { ...sharedProps };
         await modalCustomHeadingStylePage.load(props);
 

--- a/packages/components/pie-notification/test/visual/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/visual/pie-notification.spec.ts
@@ -15,7 +15,6 @@ export const screenWidths = {
 
 variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
     const basePage = new BasePage(page, `notification--${variant}-prop-variations`);
-    basePage.waitUntilStrategy = 'networkidle';
 
     await basePage.load();
 
@@ -43,7 +42,6 @@ test.describe('Props', () => {
             test(`should render correctly the ${headingLevel} headingLevel`, async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                 };
@@ -61,7 +59,6 @@ test.describe('Props', () => {
             test('should render leadingAction when leadingAction is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                 };
@@ -75,7 +72,6 @@ test.describe('Props', () => {
             test('should not render leadingAction when leadingAction not is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     leadingAction: undefined,
@@ -92,7 +88,6 @@ test.describe('Props', () => {
             test('should not render supportingAction when leadingAction not is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     leadingAction: undefined,
@@ -108,7 +103,6 @@ test.describe('Props', () => {
             test('should render supportingAction when leadingAction and supportingAction is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     supportingAction: secondaryAction,
@@ -126,7 +120,6 @@ test.describe('Props', () => {
                 test(`should render action buttons with ${size} size`, async ({ page }) => {
                     // Arrange
                     const basePage = new BasePage(page, 'notification');
-                    basePage.waitUntilStrategy = 'networkidle';
                     const props: NotificationProps = {
                         ...initialValues,
                         leadingAction: {
@@ -151,7 +144,6 @@ test.describe('Props', () => {
             test('should render actions as links when href is provided', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification--notification-with-link-actions');
-                basePage.waitUntilStrategy = 'networkidle';
 
                 await basePage.load();
 
@@ -164,7 +156,6 @@ test.describe('Props', () => {
             test('should stack buttons on small screens', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     supportingAction: secondaryAction,
@@ -181,7 +172,6 @@ test.describe('Props', () => {
             test('should not stack buttons on small screens', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     supportingAction: secondaryAction,
@@ -198,7 +188,6 @@ test.describe('Props', () => {
             test('should not stack buttons on large screens when hasStackedActions is true', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     supportingAction: secondaryAction,
@@ -215,7 +204,6 @@ test.describe('Props', () => {
             test('should not stack buttons on large screens when hasStackedActions is false', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     supportingAction: secondaryAction,
@@ -232,7 +220,6 @@ test.describe('Props', () => {
             test('should not stack buttons when hasStackedActions is true and isCompact is true regardless the screen size', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     supportingAction: secondaryAction,
@@ -251,7 +238,6 @@ test.describe('Props', () => {
             test('should align actions to the edge of the container', async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification--is-compact');
-                basePage.waitUntilStrategy = 'networkidle';
                 await basePage.load();
 
                 // Assert
@@ -265,7 +251,6 @@ test.describe('Props', () => {
             test(`should render correctly the ${positionValue} position`, async ({ page }) => {
                 // Arrange
                 const basePage = new BasePage(page, 'notification');
-                basePage.waitUntilStrategy = 'networkidle';
                 const props: NotificationProps = {
                     ...initialValues,
                     position: positionValue,
@@ -284,7 +269,6 @@ test.describe('Reading direction - RTL - Right to Left', () => {
     test('should slots icons and buttons when the reading direction is RTL', async ({ page }) => {
         // Arrange
         const basePage = new BasePage(page, 'notification--notification-rtl');
-        basePage.waitUntilStrategy = 'networkidle';
         const props: NotificationProps = {
             isOpen: true,
             isDismissible: true,
@@ -300,7 +284,6 @@ test.describe('Reading direction - RTL - Right to Left', () => {
 test.describe('Slotted Action Buttons', () => {
     test('should render slotted leading action with icon', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-leading-action');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
 
@@ -309,7 +292,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should render slotted supporting action (disabled)', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-supporting-action');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
 
@@ -318,7 +300,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should render both slotted actions (leading loading, supporting ghost)', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
 
@@ -327,7 +308,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should render slotted actions in compact mode', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions-compact');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
 
@@ -336,7 +316,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should stack slotted action buttons on small screens', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions-stacked');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
         await page.setViewportSize({ width: 375, height: 667 });
@@ -346,7 +325,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should not stack slotted action buttons on large screens', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions-stacked');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
         await page.setViewportSize({ width: 1275, height: 900 });
@@ -356,7 +334,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should not stack slotted action buttons on small screens when hasStackedActions is false', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions-not-stacked');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
         await page.setViewportSize({ width: 375, height: 667 });
@@ -366,7 +343,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should not stack slotted action buttons on large screens when hasStackedActions is false', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions-not-stacked');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
         await page.setViewportSize({ width: 1275, height: 900 });
@@ -376,7 +352,6 @@ test.describe('Slotted Action Buttons', () => {
 
     test('should not stack slotted action buttons when hasStackedActions is true and isCompact is true', async ({ page }) => {
         const basePage = new BasePage(page, 'notification--slotted-both-actions-stacked-compact');
-        basePage.waitUntilStrategy = 'networkidle';
 
         await basePage.load();
 

--- a/packages/components/pie-radio-group/test/visual/pie-radio-group.spec.ts
+++ b/packages/components/pie-radio-group/test/visual/pie-radio-group.spec.ts
@@ -7,7 +7,6 @@ const directions = ['ltr', 'rtl'];
 
 directions.forEach((direction) => test(`should render all prop variations for direction: ${direction}`, async ({ page }) => {
     const radioGroupVariationsPage = new BasePage(page, 'radio-group--variations');
-    radioGroupVariationsPage.waitUntilStrategy = 'networkidle';
     await radioGroupVariationsPage.load({}, { writingDirection: direction });
     await page.waitForSelector('pie-radio-group');
 

--- a/packages/components/pie-radio/test/visual/pie-radio.spec.ts
+++ b/packages/components/pie-radio/test/visual/pie-radio.spec.ts
@@ -9,7 +9,6 @@ readingDirections.forEach((dir) => {
     test(`should render all prop variations for the direction: ${dir}`, async ({ page }) => {
     // Arrange
         const radioVariations = new BasePage(page, 'radio--variations');
-        radioVariations.waitUntilStrategy = 'networkidle';
         await radioVariations.load({}, { writingDirection: dir });
         await page.waitForSelector(radio.selectors.container.dataTestId);
 

--- a/packages/components/pie-select/test/visual/pie-select.spec.ts
+++ b/packages/components/pie-select/test/visual/pie-select.spec.ts
@@ -9,7 +9,6 @@ test.describe('PieSelect - Visual tests`', () => {
         test(`should render prop variations in writing direction: ${direction}`, async ({ page }) => {
             // Arrange
             const selectVariationsPage = new BasePage(page, 'select--variations');
-            selectVariationsPage.waitUntilStrategy = 'networkidle';
             await selectVariationsPage.load({}, { writingDirection: direction });
 
             // Assert
@@ -21,7 +20,6 @@ test.describe('PieSelect - Visual tests`', () => {
         test(`should render assistive text and status prop variations in writing direction: ${direction}`, async ({ page }) => {
             // Arrange
             const selectVariationsPage = new BasePage(page, 'select--status-variations');
-            selectVariationsPage.waitUntilStrategy = 'networkidle';
             await selectVariationsPage.load({}, { writingDirection: direction });
 
             // Assert

--- a/packages/components/pie-spinner/test/accessibility/pie-spinner.spec.ts
+++ b/packages/components/pie-spinner/test/accessibility/pie-spinner.spec.ts
@@ -7,7 +7,6 @@ test.describe('PieSpinner - Accessibility tests', () => {
         test(`a11y - should test the PieSpinner component WCAG compliance - ${variant}`, async ({ makeAxeBuilder, page }) => {
             // Arrange
             const spinnerPage = new BasePage(page, `spinner--${variant}`);
-            spinnerPage.waitUntilStrategy = 'networkidle';
             await spinnerPage.load();
 
             // Act

--- a/packages/components/pie-spinner/test/visual/pie-spinner.spec.ts
+++ b/packages/components/pie-spinner/test/visual/pie-spinner.spec.ts
@@ -9,7 +9,6 @@ test.describe('PieSpinner - Visual tests`', () => {
     variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
     // Arrange
         const spinnerVariantsPage = new BasePage(page, `spinner--${variant}-variations`);
-        spinnerVariantsPage.waitUntilStrategy = 'networkidle';
         await spinnerVariantsPage.load();
 
         // Assert

--- a/packages/components/pie-switch/test/visual/pie-switch.spec.ts
+++ b/packages/components/pie-switch/test/visual/pie-switch.spec.ts
@@ -12,7 +12,6 @@ writingDirections.forEach((direction) => {
     test(`should render all prop variations in writing direction: ${direction}`, async ({ page }) => {
         // Arrange
         const switchVariationsPage = new BasePage(page, 'switch--variations');
-        switchVariationsPage.waitUntilStrategy = 'networkidle';
         await switchVariationsPage.load({}, { writingDirection: direction });
 
         // Assert

--- a/packages/components/pie-tabs/test/visual/pie-tabs.spec.ts
+++ b/packages/components/pie-tabs/test/visual/pie-tabs.spec.ts
@@ -5,8 +5,6 @@ import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-obj
 test.describe('PieTabs - Visual tests`', () => {
     test('should display the PieTabs component successfully', async ({ page }) => {
         const basePage = new BasePage(page, 'tabs--default');
-        basePage.waitUntilStrategy = 'networkidle';
-
         await basePage.load();
 
         await percySnapshot(page, 'PieTabs - Visual Test');

--- a/packages/components/pie-tag/test/visual/pie-tag.spec.ts
+++ b/packages/components/pie-tag/test/visual/pie-tag.spec.ts
@@ -7,8 +7,6 @@ import { variants } from '../../src/defs.ts';
 variants.forEach((variant) => {
     test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
         const tagVariationsPage = new BasePage(page, `tag--${variant}-variations`);
-        tagVariationsPage.waitUntilStrategy = 'networkidle';
-
         await tagVariationsPage.load();
 
         await percySnapshot(page, `PIE Tag - Variant: ${variant}`, percyWidths);
@@ -17,8 +15,6 @@ variants.forEach((variant) => {
 
 test('should allow for custom styling using CSS parts', async ({ page }) => {
     const tagVariationsPage = new BasePage(page, 'tag--custom-styled-tags');
-    tagVariationsPage.waitUntilStrategy = 'networkidle';
-
     await tagVariationsPage.load();
 
     await percySnapshot(page, 'PIE Tag - CSS parts styles', percyWidths);
@@ -26,8 +22,6 @@ test('should allow for custom styling using CSS parts', async ({ page }) => {
 
 test('should render slotted raw SVG icons correctly in all sizes', async ({ page }) => {
     const rawSVGPage = new BasePage(page, 'tag--raw-svg-slot');
-    rawSVGPage.waitUntilStrategy = 'networkidle';
-
     await rawSVGPage.load();
 
     await percySnapshot(page, 'PIE Tag - Raw SVG Slot', percyWidths);
@@ -35,8 +29,6 @@ test('should render slotted raw SVG icons correctly in all sizes', async ({ page
 
 test('should render text truncation correctly for different tag sizes and variants', async ({ page }) => {
     const textTruncationPage = new BasePage(page, 'tag--text-truncation');
-    textTruncationPage.waitUntilStrategy = 'networkidle';
-
     await textTruncationPage.load();
 
     await percySnapshot(page, 'PIE Tag - Text Truncation', percyWidths);
@@ -44,8 +36,6 @@ test('should render text truncation correctly for different tag sizes and varian
 
 test('should render translucent tags over images correctly', async ({ page }) => {
     const translucentOverImagePage = new BasePage(page, 'tag--translucent-over-image');
-    translucentOverImagePage.waitUntilStrategy = 'networkidle';
-
     await translucentOverImagePage.load();
 
     await percySnapshot(page, 'PIE Tag - Translucent Over Image', percyWidths);
@@ -53,8 +43,6 @@ test('should render translucent tags over images correctly', async ({ page }) =>
 
 test('should render icon-only tags as the large size for both small and large sizes', async ({ page }) => {
     const iconOnlyPage = new BasePage(page, 'tag--icon-only-variations');
-    iconOnlyPage.waitUntilStrategy = 'networkidle';
-
     await iconOnlyPage.load();
 
     await percySnapshot(page, 'PIE Tag - Icon Only Variations', percyWidths);

--- a/packages/components/pie-text-input/test/visual/pie-text-input.spec.ts
+++ b/packages/components/pie-text-input/test/visual/pie-text-input.spec.ts
@@ -9,7 +9,6 @@ readingDirections.forEach(async (dir) => {
     statusTypes.forEach(async (status) => {
         test(`Status - ${status} - ${dir}`, async ({ page }) => {
             const textInputVariations = new BasePage(page, `text-input--${status}-variations`);
-            textInputVariations.waitUntilStrategy = 'networkidle';
             await textInputVariations.load({}, { writingDirection: dir });
             await page.waitForSelector('pie-text-input');
 
@@ -20,7 +19,6 @@ readingDirections.forEach(async (dir) => {
     test(`Content and slots - ${dir}`, async ({ page }) => {
     // Arrange
         const textInputVariations = new BasePage(page, 'text-input--slot-variations');
-        textInputVariations.waitUntilStrategy = 'networkidle';
         await textInputVariations.load({}, { writingDirection: dir });
         await page.waitForSelector('pie-text-input');
 

--- a/packages/components/pie-textarea/test/visual/pie-textarea.spec.ts
+++ b/packages/components/pie-textarea/test/visual/pie-textarea.spec.ts
@@ -15,7 +15,6 @@ readingDirections.forEach((direction) => {
     test(`should render prop variations in writing direction: ${direction}`, async ({ page }) => {
         // Arrange
         const textareaVariationsPage = new BasePage(page, 'textarea--variations');
-        textareaVariationsPage.waitUntilStrategy = 'networkidle';
         await textareaVariationsPage.load({}, { writingDirection: direction });
 
         // Assert
@@ -26,7 +25,6 @@ readingDirections.forEach((direction) => {
 test('should render text related prop variations', async ({ page }) => {
     // Arrange
     const textareaVariationsPage = new BasePage(page, 'textarea--extended-text-variations');
-    textareaVariationsPage.waitUntilStrategy = 'networkidle';
     await textareaVariationsPage.load();
 
     // Assert
@@ -37,7 +35,6 @@ readingDirections.forEach((direction) => {
     test(`should render assistive text and status prop variations in writing direction: ${direction}`, async ({ page }) => {
         // Arrange
         const textareaVariationsPage = new BasePage(page, 'textarea--status-variations');
-        textareaVariationsPage.waitUntilStrategy = 'networkidle';
         await textareaVariationsPage.load({}, { writingDirection: direction });
 
         // Assert
@@ -48,7 +45,6 @@ readingDirections.forEach((direction) => {
 resizeModes.forEach((size) => {
     test(`should render tall textarea with ${size}`, async ({ page }) => {
         const textareaPage = new BasePage(page, 'textarea');
-        textareaPage.waitUntilStrategy = 'networkidle';
         const props: Partial<TextareaProps> = {
             resize: size,
         };

--- a/packages/components/pie-thumbnail/test/visual/pie-thumbnail.spec.ts
+++ b/packages/components/pie-thumbnail/test/visual/pie-thumbnail.spec.ts
@@ -6,7 +6,6 @@ import { thumbnail } from '../helpers/selectors.ts';
 
 variants.forEach((variant) => test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
     const basePage = new BasePage(page, `thumbnail--${variant}-prop-variations`);
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load();
 
     const thumbnailComponent = page.getByTestId(thumbnail.selectors.container.dataTestId).first();
@@ -17,7 +16,6 @@ variants.forEach((variant) => test(`should render all prop variations for Varian
 
 test('should render all prop variants for background variants', async ({ page }) => {
     const basePage = new BasePage(page, 'thumbnail--background-prop-variations');
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load();
 
     const thumbnailComponent = page.getByTestId(thumbnail.selectors.container.dataTestId).first();
@@ -28,7 +26,6 @@ test('should render all prop variants for background variants', async ({ page })
 
 test('should render all prop variations for the 4by3 aspect ratio', async ({ page }) => {
     const basePage = new BasePage(page, 'thumbnail--aspect-ratio-4-by-3-prop-variations');
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load();
 
     const thumbnailComponent = page.getByTestId(thumbnail.selectors.container.dataTestId).first();
@@ -39,7 +36,6 @@ test('should render all prop variations for the 4by3 aspect ratio', async ({ pag
 
 test('should render all prop variations for the 16by9 aspect ratio', async ({ page }) => {
     const basePage = new BasePage(page, 'thumbnail--aspect-ratio-16-by-9-prop-variations');
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load();
 
     const thumbnailComponent = page.getByTestId(thumbnail.selectors.container.dataTestId).first();
@@ -50,7 +46,6 @@ test('should render all prop variations for the 16by9 aspect ratio', async ({ pa
 
 test('should render the component default placeholder on image load failure', async ({ page }) => {
     const basePage = new BasePage(page, 'thumbnail--invalid-src-and-default-placeholder');
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load();
 
     const thumbnailComponent = page.getByTestId(thumbnail.selectors.container.dataTestId).first();
@@ -61,7 +56,6 @@ test('should render the component default placeholder on image load failure', as
 
 test('should not render the component default placeholder if the `hideDefaultPlaceholder` is set to true', async ({ page }) => {
     const basePage = new BasePage(page, 'thumbnail--default');
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load({
         src: 'invalid-url',
         hideDefaultPlaceholder: true,
@@ -75,7 +69,6 @@ test('should not render the component default placeholder if the `hideDefaultPla
 
 test('should render a custom placeholder on image load failure if the `placeholder` prop is set', async ({ page }) => {
     const basePage = new BasePage(page, 'thumbnail--invalid-src-and-custom-placeholder');
-    basePage.waitUntilStrategy = 'networkidle';
     await basePage.load();
 
     const thumbnailComponent = page.getByTestId(thumbnail.selectors.container.dataTestId).first();

--- a/packages/components/pie-toast-provider/test/visual/pie-toast-provider.spec.ts
+++ b/packages/components/pie-toast-provider/test/visual/pie-toast-provider.spec.ts
@@ -8,8 +8,6 @@ const directions = ['ltr', 'rtl'];
 test.describe('PieToastProvider - Visual tests`', () => {
     test('should display the PieToastProvider component successfully', async ({ page }) => {
         const basePage = new BasePage(page, 'toast-provider--custom-z-index');
-        basePage.waitUntilStrategy = 'networkidle';
-
         await basePage.load();
 
         const toastElement = page.locator('pie-toast');
@@ -22,8 +20,6 @@ test.describe('PieToastProvider - Visual tests`', () => {
         directions.forEach((direction) => {
             test(`should render position: ${position} correctly with direction: ${direction}`, async ({ page }) => {
                 const basePage = new BasePage(page, `toast-provider--position-${position}`);
-                basePage.waitUntilStrategy = 'networkidle';
-
                 await basePage.load({}, { writingDirection: direction });
 
                 const toastElement = page.locator('pie-toast');

--- a/packages/components/pie-toast/test/component/pie-toast.spec.ts
+++ b/packages/components/pie-toast/test/component/pie-toast.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-object/base-page.ts';
 import { toast } from 'test/helpers/page-object/selectors.ts';
 import { type ToastProps, variants } from '../../src/defs.ts';
+import type { PieToast } from '../../src/index.ts';
 
 test.describe('PieToast - Component tests', () => {
     const mainAction = {
@@ -41,10 +42,17 @@ test.describe('PieToast - Component tests', () => {
             test('should not render the toast when isOpen is false', async ({ page }) => {
                 // Arrange
                 const toastPage = new BasePage(page, 'toast');
-                const props: Partial<ToastProps> = {
-                    isOpen: false,
-                };
-                await toastPage.load({ ...props });
+                await toastPage.load();
+
+                await page.evaluate(() => {
+                    const toast = document.querySelector('pie-toast') as PieToast;
+
+                    if(!toast) {
+                        throw new Error('Toast component not found');
+                    }
+
+                    toast.isOpen = false;
+                });
 
                 // Act
                 const toastComponent = page.getByTestId(toast.selectors.container.dataTestId);

--- a/packages/components/pie-toast/test/component/pie-toast.spec.ts
+++ b/packages/components/pie-toast/test/component/pie-toast.spec.ts
@@ -47,7 +47,7 @@ test.describe('PieToast - Component tests', () => {
                 await page.evaluate(() => {
                     const toast = document.querySelector('pie-toast') as PieToast;
 
-                    if(!toast) {
+                    if (!toast) {
                         throw new Error('Toast component not found');
                     }
 

--- a/packages/components/pie-toast/test/component/pie-toast.spec.ts
+++ b/packages/components/pie-toast/test/component/pie-toast.spec.ts
@@ -44,14 +44,17 @@ test.describe('PieToast - Component tests', () => {
                 const toastPage = new BasePage(page, 'toast');
                 await toastPage.load();
 
-                await page.evaluate(() => {
-                    const toast = document.querySelector('pie-toast') as PieToast;
+                await page.locator('pie-toast').waitFor({ state: 'attached' });
+
+                await page.evaluate(async () => {
+                    const toast = document.querySelector('pie-toast') as PieToast | null;
 
                     if (!toast) {
                         throw new Error('Toast component not found');
                     }
 
                     toast.isOpen = false;
+                    await toast.updateComplete;
                 });
 
                 // Act

--- a/packages/components/pie-toast/test/visual/pie-toast.spec.ts
+++ b/packages/components/pie-toast/test/visual/pie-toast.spec.ts
@@ -11,7 +11,6 @@ const percyWidths = {
 variants.forEach((variant) => {
     test(`should render all prop variations for Variant: ${variant}`, async ({ page }) => {
         const toastVariationsPage = new BasePage(page, `toast--${variant}-variations`);
-        toastVariationsPage.waitUntilStrategy = 'networkidle';
 
         await toastVariationsPage.load();
         await expect.soft(page.getByTestId(toast.selectors.container.dataTestId).first()).toBeVisible();

--- a/packages/components/pie-webc-testing/src/helpers/page-object/base-page.ts
+++ b/packages/components/pie-webc-testing/src/helpers/page-object/base-page.ts
@@ -12,7 +12,7 @@ export class BasePage {
     path: string;
     args: string;
     globals: string;
-    waitUntilStrategy: 'load' | 'networkidle' = 'load';
+    waitUntilStrategy: 'load' | 'networkidle' = 'networkidle';
 
     constructor (page: Page, componentName: string, componentTag = 'data-test-id') {
         this.page = page;

--- a/packages/tools/generator-pie-component/src/app/templates/test/visual/pie-placeholder.__spec__.ts
+++ b/packages/tools/generator-pie-component/src/app/templates/test/visual/pie-placeholder.__spec__.ts
@@ -5,8 +5,6 @@ import { BasePage } from '@justeattakeaway/pie-webc-testing/src/helpers/page-obj
 test.describe('Pie<%= componentName %> - Visual tests`', () => {
     test('should display the Pie<%= componentName %> component successfully', async ({ page }) => {
         const basePage = new BasePage(page, '<%= fileName %>--default');
-        basePage.waitUntilStrategy = 'networkidle';
-
         await basePage.load();
 
         await percySnapshot(page, 'Pie<%= componentName %> - Visual Test');


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
- Removes all test waiting to BasePage to reduce duplication and switched to 'networkidle'
- Turns off the Storybook a11y plugin on Storybook test deployments to prevent conflicts with Playwright's on Axe runner
- Fixes a flaky pie-toast test

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [ ] I have added thorough tests where applicable (unit / component / visual).
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
---
