### PR TITLE
fix(pie-wrapper-react): SON-4389 generate controlled-input-aware React wrapper

### DIFF
--- a/.changeset/son-4389-controlled-react-input-wrapper.md
+++ b/.changeset/son-4389-controlled-react-input-wrapper.md
@@ -1,0 +1,9 @@
+---
+"@justeattakeaway/pie-wrapper-react": minor
+---
+
+[Added] - Controlled-input-aware React wrapper generation for input-like components.
+
+`@lit/react`'s `createComponent` pushes the `value` prop onto the custom element whenever it changes between renders, but it does not replicate the controlled-input value tracking that ReactDOM applies to native form controls. During fast typing with debounced parent state, a stale `value` could be written back to the element and overwrite the user's latest keystroke.
+
+Components that expose a `value` field and dispatch an `input` event now receive a generated wrapper that replicates React's controlled-input contract: `value` is only written to the element when the controlled value genuinely changes since it was last applied, so in-flight user input is never clobbered. Components that are not input-like are unaffected and continue to use the existing `createComponent` export.

--- a/.changeset/son-4389-pie-text-input-controlled.md
+++ b/.changeset/son-4389-pie-text-input-controlled.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-text-input": patch
+---
+
+[Fixed] - The React wrapper no longer drops keystrokes when the `value` prop lags behind user input (for example with debounced parent state). The generated wrapper now follows React's controlled-input contract and only writes `value` to the element when it genuinely changes.

--- a/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
+++ b/packages/tools/pie-wrapper-react/__tests__/__snapshots__/wrapper.test.js.snap
@@ -50,6 +50,87 @@ export const ButtonComponent = ButtonComponentReact as React.ForwardRefExoticCom
 "
 `;
 
+exports[`React Wrapper > should generate a controlled-input wrapper for components with a value field and an input event 1`] = `
+"import * as React from 'react';
+import { createComponent, type EventName } from '@lit/react';
+import { PieTextInput as PieTextInputLit } from './index';
+import { type TextInputProps } from './defs';
+
+export * from './defs';
+
+const PieTextInputReact = createComponent({
+    displayName: 'PieTextInput',
+    elementClass: PieTextInputLit,
+    react: React,
+    tagName: 'pie-text-input',
+    events: {
+        onInput: 'input' as EventName<InputEvent>,
+        onChange: 'change' as EventName<CustomEvent>,
+    },
+});
+
+type PieTextInputEvents = {
+    onInput?: (event: InputEvent) => void;
+    onChange?: (event: CustomEvent) => void;
+};
+
+type PieTextInputWrapperProps = React.PropsWithChildren<Omit<React.PropsWithoutRef<TextInputProps>, 'children'>>
+    & React.RefAttributes<PieTextInputLit> & PieTextInputEvents;
+
+// Use a layout effect on the client (so value writes happen before paint) and a
+// regular effect on the server to avoid React's "useLayoutEffect does nothing on
+// the server" warning during SSR.
+const useIsomorphicPieTextInputLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
+const PieTextInputControlled = React.forwardRef<PieTextInputLit, PieTextInputWrapperProps>((props, forwardedRef) => {
+    const { value, children, ...restProps } = props as PieTextInputWrapperProps & { value?: string | number | null };
+    const elementRef = React.useRef<PieTextInputLit | null>(null);
+    const lastAppliedValueRef = React.useRef<string | number | null | undefined>(undefined);
+
+    const setElementRef = React.useCallback((node: PieTextInputLit | null) => {
+        elementRef.current = node;
+
+        if (typeof forwardedRef === 'function') {
+            forwardedRef(node);
+        } else if (forwardedRef) {
+            (forwardedRef as React.MutableRefObject<PieTextInputLit | null>).current = node;
+        }
+    }, [forwardedRef]);
+
+    useIsomorphicPieTextInputLayoutEffect(() => {
+        const element = elementRef.current;
+
+        if (!element) {
+            return;
+        }
+
+        // Only write when the controlled value has actually changed since we last
+        // applied it. This prevents a re-render carrying an already-applied value
+        // from overwriting characters the user has typed in the meantime.
+        if (value !== lastAppliedValueRef.current) {
+            lastAppliedValueRef.current = value;
+
+            const nextValue = value == null ? '' : String(value);
+
+            if (element.value !== nextValue) {
+                element.value = nextValue;
+            }
+        }
+    });
+
+    return React.createElement(
+        PieTextInputReact,
+        { ...restProps, ref: setElementRef } as unknown as React.ComponentProps<typeof PieTextInputReact>,
+        children,
+    );
+});
+
+PieTextInputControlled.displayName = 'PieTextInput';
+
+export const PieTextInput = PieTextInputControlled as React.ForwardRefExoticComponent<PieTextInputWrapperProps>;
+"
+`;
+
 exports[`React Wrapper > should leave the events object empty if the component contains no custom events 1`] = `
 "import * as React from 'react';
 import { createComponent } from '@lit/react';

--- a/packages/tools/pie-wrapper-react/__tests__/wrapper.test.js
+++ b/packages/tools/pie-wrapper-react/__tests__/wrapper.test.js
@@ -50,4 +50,79 @@ describe('React Wrapper', () => {
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.includes(result)).toBe(true);
     });
+
+    it('should generate a controlled-input wrapper for components with a value field and an input event', () => {
+        const inputManifest = {
+            schemaVersion: '1.0.0',
+            readme: '',
+            modules: [
+                {
+                    kind: 'javascript-module',
+                    path: 'pie-wrapper-react',
+                    declarations: [
+                        {
+                            kind: 'class',
+                            description: '',
+                            name: 'PieTextInput',
+                            members: [
+                                { kind: 'field', name: 'value' },
+                            ],
+                            events: [
+                                { name: 'input', type: { text: 'InputEvent' } },
+                                { name: 'change', type: { text: 'CustomEvent' } },
+                            ],
+                            superclass: { name: 'LitElement', package: 'lit' },
+                            tagName: 'pie-text-input',
+                            customElement: true,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const wrapper = addReactWrapper(inputManifest);
+
+        // The controlled wrapper replaces the direct createComponent export.
+        expect(wrapper).toContain('React.forwardRef<PieTextInputLit, PieTextInputWrapperProps>');
+        expect(wrapper).toContain('lastAppliedValueRef');
+        expect(wrapper).toContain("PieTextInputControlled.displayName = 'PieTextInput'");
+        expect(wrapper).toContain('export const PieTextInput = PieTextInputControlled');
+        // The value prop must not be forwarded to the underlying createComponent element.
+        expect(wrapper).not.toContain('export const PieTextInput = PieTextInputReact');
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should not generate a controlled-input wrapper for components without an input event', () => {
+        const noInputManifest = {
+            schemaVersion: '1.0.0',
+            readme: '',
+            modules: [
+                {
+                    kind: 'javascript-module',
+                    path: 'pie-wrapper-react',
+                    declarations: [
+                        {
+                            kind: 'class',
+                            description: '',
+                            name: 'PieSelect',
+                            members: [
+                                { kind: 'field', name: 'value' },
+                            ],
+                            events: [
+                                { name: 'change', type: { text: 'CustomEvent' } },
+                            ],
+                            superclass: { name: 'LitElement', package: 'lit' },
+                            tagName: 'pie-select',
+                            customElement: true,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const wrapper = addReactWrapper(noInputManifest);
+
+        expect(wrapper).toContain('export const PieSelect = PieSelectReact');
+        expect(wrapper).not.toContain('lastAppliedValueRef');
+    });
 });

--- a/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
+++ b/packages/tools/pie-wrapper-react/scripts/add-react-wrapper.js
@@ -92,6 +92,100 @@ function formatEventName (eventName) {
 }
 
 /**
+ * Determines whether a component behaves like a controlled text input.
+ *
+ * A component is treated as a controlled input when it exposes a `value` field
+ * and dispatches an `input` event. These are the components for which `@lit/react`'s
+ * generic wrapper is insufficient, because it does not replicate the controlled-input
+ * value tracking that ReactDOM applies to native form controls.
+ *
+ * @param {object} componentClass - the component declaration from the custom elements manifest
+ * @return {boolean} - true if the component should receive the controlled-input wrapper
+ */
+function isControlledInputComponent (componentClass) {
+    const hasValueField = (componentClass.members || [])
+        .some((member) => member.kind === 'field' && member.name === 'value');
+    const hasInputEvent = (componentClass.events || [])
+        .some((event) => event.name === 'input');
+
+    return hasValueField && hasInputEvent;
+}
+
+/**
+ * Generates a controlled-input-aware React wrapper for input-like components.
+ *
+ * `@lit/react`'s `createComponent` writes the `value` prop onto the custom element
+ * whenever it changes between renders, but it does not implement the value tracking
+ * that ReactDOM applies to native form controls. As a result a stale `value` (for
+ * example while a user is typing and parent state updates are debounced) can overwrite
+ * the user's latest keystroke.
+ *
+ * The generated wrapper replicates React's controlled-input contract: `value` is only
+ * written to the element when the controlled value genuinely changes since it was last
+ * applied, so in-flight user input is never clobbered. The `value` prop is therefore not
+ * forwarded to the underlying `createComponent` element and is managed here instead.
+ *
+ * @param {string} componentName - the component class name (e.g. `PieTextInput`)
+ * @param {string} propsTypeDefinition - the composed React props type for the component
+ * @return {string} - the source code for the controlled wrapper and its export
+ */
+function generateControlledWrapper (componentName, propsTypeDefinition) {
+    return `type ${componentName}WrapperProps = ${propsTypeDefinition};
+
+// Use a layout effect on the client (so value writes happen before paint) and a
+// regular effect on the server to avoid React's "useLayoutEffect does nothing on
+// the server" warning during SSR.
+const useIsomorphic${componentName}LayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
+const ${componentName}Controlled = React.forwardRef<${componentName}Lit, ${componentName}WrapperProps>((props, forwardedRef) => {
+    const { value, children, ...restProps } = props as ${componentName}WrapperProps & { value?: string | number | null };
+    const elementRef = React.useRef<${componentName}Lit | null>(null);
+    const lastAppliedValueRef = React.useRef<string | number | null | undefined>(undefined);
+
+    const setElementRef = React.useCallback((node: ${componentName}Lit | null) => {
+        elementRef.current = node;
+
+        if (typeof forwardedRef === 'function') {
+            forwardedRef(node);
+        } else if (forwardedRef) {
+            (forwardedRef as React.MutableRefObject<${componentName}Lit | null>).current = node;
+        }
+    }, [forwardedRef]);
+
+    useIsomorphic${componentName}LayoutEffect(() => {
+        const element = elementRef.current;
+
+        if (!element) {
+            return;
+        }
+
+        // Only write when the controlled value has actually changed since we last
+        // applied it. This prevents a re-render carrying an already-applied value
+        // from overwriting characters the user has typed in the meantime.
+        if (value !== lastAppliedValueRef.current) {
+            lastAppliedValueRef.current = value;
+
+            const nextValue = value == null ? '' : String(value);
+
+            if (element.value !== nextValue) {
+                element.value = nextValue;
+            }
+        }
+    });
+
+    return React.createElement(
+        ${componentName}React,
+        { ...restProps, ref: setElementRef } as unknown as React.ComponentProps<typeof ${componentName}React>,
+        children,
+    );
+});
+
+${componentName}Controlled.displayName = '${componentName}';
+
+export const ${componentName} = ${componentName}Controlled as React.ForwardRefExoticComponent<${componentName}WrapperProps>;`;
+}
+
+/**
  * This function generates a react wrapper to enable custom lit components to be used in react apps.
  *
  * @param {JSON} - A JSON file of custom components and their attributes, generated from the @custom-elements-manifest/analyzer package
@@ -186,8 +280,12 @@ export function addReactWrapper (customElementsObject) {
 
             const componentPropsExportName = `${component.class.name.replace(/^Pie/, '')}Props`;
 
-            // Create the main source code
-            componentSrc = `import * as React from 'react';
+            // The composed React props type, shared by the standard and controlled exports.
+            const propsTypeDefinition = `React.PropsWithChildren<Omit<React.PropsWithoutRef<${componentPropsExportName}>, 'children'>>
+    & React.RefAttributes<${component.class.name}Lit>${eventsTypeDefinition ? ` & ${eventsTypeName}` : ''}${component.reactBaseType ? ' & ReactBaseType' : ''}`;
+
+            // Shared header: imports, the createComponent element, and optional types.
+            const header = `import * as React from 'react';
 import { createComponent${component.class.events?.length > 0 ? ', type EventName' : ''} } from '@lit/react';
 import { ${component.class.name} as ${component.class.name}Lit } from './index';
 import { type ${componentPropsExportName} } from './defs';
@@ -208,11 +306,21 @@ ${component.reactBaseType}` : ''
     eventsTypeDefinition ? `
 
 ${eventsTypeDefinition}` : ''
-}
+}`;
 
-export const ${component.class.name} = ${component.class.name}React as React.ForwardRefExoticComponent<React.PropsWithChildren<Omit<React.PropsWithoutRef<${componentPropsExportName}>, 'children'>>
-    & React.RefAttributes<${component.class.name}Lit>${eventsTypeDefinition ? ` & ${eventsTypeName}` : ''}${component.reactBaseType ? ' & ReactBaseType' : ''}>;
+            // Input-like components need a controlled-input-aware wrapper; everything else
+            // can be exported directly from the generic createComponent element.
+            if (isControlledInputComponent(component.class)) {
+                componentSrc = `${header}
+
+${generateControlledWrapper(component.class.name, propsTypeDefinition)}
 `;
+            } else {
+                componentSrc = `${header}
+
+export const ${component.class.name} = ${component.class.name}React as React.ForwardRefExoticComponent<${propsTypeDefinition}>;
+`;
+            }
             let reactFile;
 
             if (component.path !== 'pie-wrapper-react') {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

### Problem

`@lit/react`'s `createComponent` pushes the `value` prop onto a custom element whenever it changes between renders, but it does **not** replicate the controlled-input value tracking that ReactDOM applies to native form controls. For input-like components (e.g. `pie-text-input`, whose inner field renders with Lit's `live(value)` directive), a stale `value` — for example while a user is typing and parent state updates are debounced — gets written back to the element and overwrites the user's latest keystroke. Consumers see dropped/“reset” keystrokes when wrapping these components in React.

This was surfaced by a catalog search box dropping characters while typing. A native `<input>` did not exhibit the issue; the differentiator was the generated PIE React wrapper path.

### Fix

`pie-wrapper-react` now detects input-like components (those exposing a `value` field **and** dispatching an `input` event) and generates a controlled-input-aware wrapper for them. The wrapper replicates React's controlled-input contract:

- `value` is no longer forwarded to the underlying `createComponent` element; it is managed in the wrapper.
- `value` is only written to the element when the controlled value **genuinely changes** since it was last applied, so in-flight user input is never clobbered.
- A client-only layout effect performs the write (before paint); a regular effect is used on the server to avoid the SSR `useLayoutEffect` warning.

Non-input components are unchanged and continue to use the existing `createComponent` export (verified: existing wrapper snapshots are byte-identical).

Only `pie-text-input` currently matches the detection criteria; any future input-like component will pick up the corrected wrapper automatically.

### Changeset entries

- `[Added]` `@justeattakeaway/pie-wrapper-react` (minor) — controlled-input-aware wrapper generation.
- `[Fixed]` `@justeattakeaway/pie-text-input` (patch) — React wrapper no longer drops keystrokes when `value` lags behind user input.

### Testing

- Added generator unit/snapshot tests in `pie-wrapper-react` covering: controlled wrapper emitted for value+input components, no controlled wrapper for components without an `input` event, and unchanged output for non-input components.
- Rebuilt `pie-text-input` end-to-end (`create:manifest` → `build:react-wrapper` → `build`); the generated `src/react.ts` and the TypeScript declaration build both succeed.
- Validated in a real React app: keystrokes are no longer dropped.

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] If changes will affect consumers of the package, I have created a changeset entry.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.
- [-] N/A I have reviewed the `PIE Storybook`/`PIE Docs` PR preview. — no Storybook/Docs changes in this PR (build-tool + generated wrapper only).
- [-] N/A I have reviewed visual test updates properly before approving. — no visual changes.
- [-] N/A If a changeset file has been created, I have tested these changes in PIE Aperture using the `/test-aperture` command. — Aperture is a destructive, once-per-PR maintainer action; **this still needs to be run by a maintainer before merge** to validate the regenerated wrappers in a real consumer.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.
