### PR TITLE
ci(pie-monorepo): DSW-123 don't deploy / browser test on pie-design-system-app[bot] PR's (Version Packages / pie-icon updates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
 
   deploy-storybook:
     needs: [ unit-tests, check-change-type ]
-    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true'
+    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && github.head_ref != 'changeset-release/main'
     permissions:
       contents: read
       deployments: write
@@ -250,7 +250,7 @@ jobs:
   # Workflow task that deploys an instance of storybook used for test suites to run against
   deploy-storybook-testing:
     needs: [ unit-tests, check-change-type ]
-    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true'
+    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && github.head_ref != 'changeset-release/main'
     permissions:
       contents: read
       deployments: write
@@ -274,7 +274,7 @@ jobs:
     name: component-tests (${{ matrix.package }})
     needs: [ build-ubuntu-node-24, deploy-storybook-testing, check-change-type ]
     if: >-
-      needs.check-change-type.outputs.web-components-change == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      needs.check-change-type.outputs.web-components-change == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
@@ -330,7 +330,7 @@ jobs:
 
   deploy-docs:
     needs: [ unit-tests, check-change-type ]
-    if: (needs.check-change-type.outputs.pie-docs-change == 'true' || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true'
+    if: (needs.check-change-type.outputs.pie-docs-change == 'true' || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && github.head_ref != 'changeset-release/main'
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
 
   deploy-storybook:
     needs: [ unit-tests, check-change-type ]
-if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
+    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pie-design-system-app[bot]')
     permissions:
       contents: read
       deployments: write
@@ -250,7 +250,7 @@ if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.c
   # Workflow task that deploys an instance of storybook used for test suites to run against
   deploy-storybook-testing:
     needs: [ unit-tests, check-change-type ]
-if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
+    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pie-design-system-app[bot]')
     permissions:
       contents: read
       deployments: write
@@ -274,7 +274,7 @@ if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.c
     name: component-tests (${{ matrix.package }})
     needs: [ build-ubuntu-node-24, deploy-storybook-testing, check-change-type ]
     if: >-
-      needs.check-change-type.outputs.web-components-change == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
+      needs.check-change-type.outputs.web-components-change == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pie-design-system-app[bot]')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
@@ -330,7 +330,7 @@ if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.c
 
   deploy-docs:
     needs: [ unit-tests, check-change-type ]
-if: (needs.check-change-type.outputs.pie-docs-change == 'true' || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
+    if: (needs.check-change-type.outputs.pie-docs-change == 'true' || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pie-design-system-app[bot]')
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
 
   deploy-storybook:
     needs: [ unit-tests, check-change-type ]
-    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && github.head_ref != 'changeset-release/main'
+if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
     permissions:
       contents: read
       deployments: write
@@ -250,7 +250,7 @@ jobs:
   # Workflow task that deploys an instance of storybook used for test suites to run against
   deploy-storybook-testing:
     needs: [ unit-tests, check-change-type ]
-    if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && github.head_ref != 'changeset-release/main'
+if: ((needs.check-change-type.outputs.web-components-change == 'true' || needs.check-change-type.outputs.storybook-change == 'true') || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
     permissions:
       contents: read
       deployments: write
@@ -274,7 +274,7 @@ jobs:
     name: component-tests (${{ matrix.package }})
     needs: [ build-ubuntu-node-24, deploy-storybook-testing, check-change-type ]
     if: >-
-      needs.check-change-type.outputs.web-components-change == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'changeset-release/main'
+      needs.check-change-type.outputs.web-components-change == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
@@ -330,7 +330,7 @@ jobs:
 
   deploy-docs:
     needs: [ unit-tests, check-change-type ]
-    if: (needs.check-change-type.outputs.pie-docs-change == 'true' || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && github.head_ref != 'changeset-release/main'
+if: (needs.check-change-type.outputs.pie-docs-change == 'true' || github.ref == 'refs/heads/main') && needs.check-change-type.outputs.is-internal == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.head_ref, 'changeset-release/'))
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
Updates CI to no longer deploy / run tests on `pie-design-system-app[bot]` PR's. This includes:

- Version Packages - https://github.com/justeattakeaway/pie/pull/3043
- PIE Icon updates - https://github.com/justeattakeaway/pie/pull/2926 (since these PR's are autogenerated and don't include updates to components to consume newly added icons)