### PR TITLE
fix(pie-webc-core): DSW-123 move mutation observer registration to connectedCallback

### DIFF
--- a/.changeset/eight-stamps-wave.md
+++ b/.changeset/eight-stamps-wave.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-webc-core": minor
+"@justeattakeaway/pie-switch": minor
+---
+
+[Fixed] - move mutation observer registration to connectedCallback

--- a/packages/components/pie-switch/src/index.ts
+++ b/packages/components/pie-switch/src/index.ts
@@ -1,5 +1,5 @@
 import {
-    html, unsafeCSS, nothing, type PropertyValues,
+    html, unsafeCSS, nothing,
 } from 'lit';
 import { html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { PieElement } from '@justeattakeaway/pie-webc-core/src/internals/PieElement';
@@ -76,8 +76,7 @@ export class PieSwitch extends AssociatedLabelMixin(FormControlMixin(DelegatesFo
     @state()
     private _isAnimationAllowed = false;
 
-    protected firstUpdated (changedProperties: PropertyValues): void {
-        super.firstUpdated(changedProperties);
+    protected firstUpdated (): void {
         const { signal } = this._abortController;
         this.handleFormAssociation();
         // This ensures that invalid events triggered by checkValidity() are propagated to the custom element

--- a/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
+++ b/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
@@ -87,6 +87,7 @@ export const AssociatedLabelMixin =
             private observeAssociatedLabels () : void {
                 const { labels } = this._internals;
 
+                console.log({ labels, isSafari: isSafari() });
                 if (!isSafari() || !labels.length) {
                     return;
                 }
@@ -94,8 +95,9 @@ export const AssociatedLabelMixin =
                 this.updateAssociatedLabelText();
 
                 this._labelMutationObserver = new MutationObserver(() => this.updateAssociatedLabelText());
-
+                console.log('MutationObserver', this._labelMutationObserver);
                 labels.forEach((label) => {
+                    console.log('Observing label for mutations', label);
                     this._labelMutationObserver?.observe(label, { childList: true, characterData: true, subtree: true });
                 });
             }

--- a/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
+++ b/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
@@ -1,6 +1,6 @@
 import { type LitElement } from 'lit';
 import type { GenericConstructor } from '../types/GenericConstructor';
-// import { isSafari } from '../../functions/isSafari';
+import { isSafari } from '../../functions/isSafari';
 
 /**
  * Joins and normalises the text content of a set of `<label>` elements into a single string.
@@ -88,9 +88,9 @@ export const AssociatedLabelMixin =
             private observeAssociatedLabels () : void {
                 const { labels } = this._internals;
 
-                // if (!isSafari() || !labels.length) {
-                //     return;
-                // }
+                if (!isSafari() || !labels.length) {
+                    return;
+                }
 
                 this.updateAssociatedLabelText();
 

--- a/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
+++ b/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
@@ -1,6 +1,6 @@
-import { type LitElement, type PropertyValues } from 'lit';
+import { type LitElement } from 'lit';
 import type { GenericConstructor } from '../types/GenericConstructor';
-import { isSafari } from '../../functions/isSafari';
+// import { isSafari } from '../../functions/isSafari';
 
 /**
  * Joins and normalises the text content of a set of `<label>` elements into a single string.
@@ -70,8 +70,8 @@ export const AssociatedLabelMixin =
 
             private _labelMutationObserver?: MutationObserver;
 
-            protected firstUpdated (changedProperties: PropertyValues) {
-                super.firstUpdated(changedProperties);
+            connectedCallback () {
+                super.connectedCallback();
                 this.observeAssociatedLabels();
             }
 
@@ -88,9 +88,9 @@ export const AssociatedLabelMixin =
             private observeAssociatedLabels () : void {
                 const { labels } = this._internals;
 
-                if (!isSafari() || !labels.length) {
-                    return;
-                }
+                // if (!isSafari() || !labels.length) {
+                //     return;
+                // }
 
                 this.updateAssociatedLabelText();
 

--- a/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
+++ b/packages/components/pie-webc-core/src/mixins/associatedLabel/associatedLabelMixin.ts
@@ -36,8 +36,7 @@ export interface AssociatedLabelInterface {
  *
  *
  * The class this mixin is applied to must already provide `_internals: ElementInternals`
- * (for example via `FormControlMixin`), and must call `super.firstUpdated()` if it overrides
- * `firstUpdated`.
+ * (for example via `FormControlMixin`).
  *
  * @param superClass - The LitElement class (with `_internals`) to extend.
  * @returns A new class extending both the provided LitElement and AssociatedLabelInterface.


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- When building the `AssociatedLabelMixin`, I moved the mutation observer registration logic from `connectedCallback` to `firstRender` ([commit](https://github.com/justeattakeaway/pie/pull/2985/changes/358459a15cfef3fd4a80edff39ef52af5db3dedf)) because the “MutationObserver is not defined” when the component is SSRed 👀. This PR documents the issue so we are aware of it in the future. 

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [ ] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [ ] I have verified that all acceptance criteria for this ticket have been completed.
- [ ] I have reviewed the Aperture changes (if added)
- [ ] If there are visual test updates, I have reviewed them.
