### PR TITLE
test(pie-list): DSW-4246 height assertions

### DIFF
--- a/apps/pie-storybook/stories/testing/pie-list.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-list.test.stories.ts
@@ -602,3 +602,48 @@ const MetaTextWithTrailingTemplate = () => withLayout(html`
 `);
 
 export const MetaTextWithTrailing = createStory<ListProps>(MetaTextWithTrailingTemplate, defaultArgs)();
+
+/**
+ * Test-only: compact items with primary text only.
+ * Verifies the compact row height (48px min-height).
+ */
+const ItemHeightCompactTemplate = () => withLayout(html`
+    <pie-list>
+        <pie-list-item isCompact primaryText="Primary text" data-test-id="item-1"></pie-list-item>
+        <pie-list-item isCompact primaryText="Primary text" data-test-id="item-2"></pie-list-item>
+        <pie-list-item isCompact primaryText="Primary text" data-test-id="item-3"></pie-list-item>
+        <pie-list-item isCompact primaryText="Primary text" data-test-id="item-4"></pie-list-item>
+    </pie-list>
+`);
+
+export const ItemHeightCompact = createStory<ListProps>(ItemHeightCompactTemplate, defaultArgs)();
+
+/**
+ * Test-only: default (non-compact) items with primary and secondary text.
+ * Verifies the two-line row height (76px min-height).
+ */
+const ItemHeightPrimaryAndSecondaryTemplate = () => withLayout(html`
+    <pie-list>
+        <pie-list-item primaryText="Primary text" secondaryText="Secondary text" data-test-id="item-1"></pie-list-item>
+        <pie-list-item primaryText="Primary text" secondaryText="Secondary text" data-test-id="item-2"></pie-list-item>
+        <pie-list-item primaryText="Primary text" secondaryText="Secondary text" data-test-id="item-3"></pie-list-item>
+        <pie-list-item primaryText="Primary text" secondaryText="Secondary text" data-test-id="item-4"></pie-list-item>
+    </pie-list>
+`);
+
+export const ItemHeightPrimaryAndSecondary = createStory<ListProps>(ItemHeightPrimaryAndSecondaryTemplate, defaultArgs)();
+
+/**
+ * Test-only: default (non-compact) items with primary text only.
+ * Verifies the single-line row height (56px min-height).
+ */
+const ItemHeightPrimaryOnlyTemplate = () => withLayout(html`
+    <pie-list>
+        <pie-list-item primaryText="Primary text" data-test-id="item-1"></pie-list-item>
+        <pie-list-item primaryText="Primary text" data-test-id="item-2"></pie-list-item>
+        <pie-list-item primaryText="Primary text" data-test-id="item-3"></pie-list-item>
+        <pie-list-item primaryText="Primary text" data-test-id="item-4"></pie-list-item>
+    </pie-list>
+`);
+
+export const ItemHeightPrimaryOnly = createStory<ListProps>(ItemHeightPrimaryOnlyTemplate, defaultArgs)();

--- a/packages/components/pie-list/test/component/pie-list.spec.ts
+++ b/packages/components/pie-list/test/component/pie-list.spec.ts
@@ -510,4 +510,38 @@ test.describe('PieList - Component tests', () => {
             await expect(thumbnail).toBeVisible();
         });
     });
+
+    test.describe('item height', () => {
+        // Returns the rendered offsetHeight (integer px) of the shadow-root container for
+        // every `pie-list-item` on the page. offsetHeight is used rather than
+        // getBoundingClientRect so sub-pixel values are always rounded to whole pixels.
+        const getItemHeights = (page: Page) => page.evaluate(() => Array.from(document.querySelectorAll('pie-list-item')).map((item) => (item.shadowRoot?.querySelector('.c-listItem-container') as HTMLElement | null)?.offsetHeight ?? 0));
+
+        test('should render compact items (primary text only) at 48px', async ({ page }) => {
+            await new BasePage(page, 'list--item-height-compact').load();
+
+            const heights = await getItemHeights(page);
+
+            expect(heights.length).toBeGreaterThan(0);
+            heights.forEach((height, i) => expect(height, `item ${i + 1}`).toBe(48));
+        });
+
+        test('should render default items with primary and secondary text at 76px', async ({ page }) => {
+            await new BasePage(page, 'list--item-height-primary-and-secondary').load();
+
+            const heights = await getItemHeights(page);
+
+            expect(heights.length).toBeGreaterThan(0);
+            heights.forEach((height, i) => expect(height, `item ${i + 1}`).toBe(76));
+        });
+
+        test('should render default items (primary text only) at 56px', async ({ page }) => {
+            await new BasePage(page, 'list--item-height-primary-only').load();
+
+            const heights = await getItemHeights(page);
+
+            expect(heights.length).toBeGreaterThan(0);
+            heights.forEach((height, i) => expect(height, `item ${i + 1}`).toBe(56));
+        });
+    });
 });

--- a/packages/components/pie-list/test/visual/pie-list.spec.ts
+++ b/packages/components/pie-list/test/visual/pie-list.spec.ts
@@ -25,6 +25,9 @@ const visualStories: { storyId: string, snapshotName: string }[] = [
     { storyId: 'list--link-list', snapshotName: 'PieList - Link list' },
     { storyId: 'list--button-list', snapshotName: 'PieList - Button list' },
     { storyId: 'list--button-list-disabled', snapshotName: 'PieList - Button list (disabled)' },
+    { storyId: 'list--item-height-compact', snapshotName: 'PieList - Item height (compact, primary text only)' },
+    { storyId: 'list--item-height-primary-and-secondary', snapshotName: 'PieList - Item height (primary and secondary text)' },
+    { storyId: 'list--item-height-primary-only', snapshotName: 'PieList - Item height (primary text only)' },
 ];
 
 test.describe('PieList - Visual tests', () => {


### PR DESCRIPTION
- Adds some small browser + visual tests to check the list-item heights are correct. This is ahead of work to make the divider optional to establish a baseline and avoid regression