### PR TITLE
[Security test] stale labeler branch-name validation piebr-4fb7db313a

### DIFF
--- a/bug-bounty-poc-piebr-4fb7db313a.txt
+++ b/bug-bounty-poc-piebr-4fb7db313a.txt
@@ -1,0 +1,3 @@
+Authorized security research by sealldeveloper.
+This benign file exists only to create a fork pull request targeting the stale branch.
+OOB marker: piebr-4fb7db313a


### PR DESCRIPTION
Authorized Just Eat Takeaway.com bug-bounty validation by `sealldeveloper`. The commit is benign and only creates a marker file. The unusual fork branch name is intentionally testing the stale base branch's `pull_request_target` shell interpolation. No secret is requested or exfiltrated; the payload makes one callback containing only a random marker. The PR will be closed after the workflow signal is captured.