### PR TITLE
fix(pie-icon-button): DSW-123 fix readme formatting

### DIFF
--- a/.changeset/wise-mice-invent.md
+++ b/.changeset/wise-mice-invent.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-icon-button": patch
+---
+
+[Fixed] - Rogue back tick broke readme formatting in storybook

--- a/packages/components/pie-icon-button/README.md
+++ b/packages/components/pie-icon-button/README.md
@@ -1,4 +1,4 @@
-`# @justeattakeaway/pie-icon-button
+# @justeattakeaway/pie-icon-button
 
 [Source Code](https://github.com/justeattakeaway/pie/tree/main/packages/components/pie-icon-button) | [Design Documentation](https://pie.design/components/icon-button) | [NPM](https://www.npmjs.com/package/@justeattakeaway/pie-icon-button)
 


### PR DESCRIPTION
silly back tick broke the formatting of the heading in storybook