### PR TITLE
docs(pie-radio-group): DSW-123 document custom radio markup

### DIFF
--- a/.changeset/short-beers-jog.md
+++ b/.changeset/short-beers-jog.md
@@ -1,0 +1,6 @@
+---
+"@justeattakeaway/pie-radio-group": patch
+"@justeattakeaway/pie-storybook": patch
+---
+
+[Added] - Documentation and code example of wrapping pie-radio components in custom markup inside the radio-group

--- a/apps/pie-storybook/stories/pie-radio-group.stories.ts
+++ b/apps/pie-storybook/stories/pie-radio-group.stories.ts
@@ -135,3 +135,118 @@ const Template = ({
 };
 
 export const Default = createStory<RadioGroupProps>(Template, defaultArgs)();
+
+const tileOptions = [
+    { value: 'sunmi', label: 'Sunmi', image: './static/images/burger-4by3.png' },
+    { value: 'citaq', label: 'Citaq', image: './static/images/modal-image-4by3.jpg' },
+    { value: 'tablet', label: 'Tablet', image: './static/images/modal-image-illustration.png' },
+];
+
+const ImageTileTemplate = ({
+    name,
+    value,
+    isInline,
+    disabled,
+    assistiveText,
+    status,
+}: RadioGroupProps) => {
+    function onChange (event: CustomEvent) {
+        const selectedRadioElement = event.target as HTMLInputElement;
+        action('change')(selectedRadioElement.value);
+    }
+
+    // The tile is consumer markup, so it forwards its own clicks to the radio it wraps. Clicks that
+    // came from the radio are ignored, otherwise it would be activated twice.
+    function onTileClick (event: MouseEvent) {
+        if ((event.target as HTMLElement).closest('pie-radio')) {
+            return;
+        }
+
+        (event.currentTarget as HTMLElement).querySelector('pie-radio')?.click();
+    }
+
+    return html`
+        <style>
+            pie-radio-group {
+                max-width: 600px;
+            }
+
+            .c-radioTile {
+                flex: 1 1 180px;
+                display: flex;
+                flex-direction: column;
+                gap: var(--dt-spacing-b);
+                padding: var(--dt-spacing-b);
+                border: 1px solid var(--dt-color-border-strong);
+                border-radius: var(--dt-radius-rounded-c);
+                background-color: var(--dt-color-container-default);
+                cursor: pointer;
+            }
+
+            /* The group only spaces slotted \`pie-radio\`s in its column layout, so the tiles space themselves */
+            pie-radio-group:not([isinline]) .c-radioTile:not(:first-of-type) {
+                margin-block-start: var(--dt-spacing-c);
+            }
+
+            /* The hover token is an overlay colour plus an opacity, mixed over the container colour */
+            .c-radioTile:hover {
+                background-color: color-mix(in srgb, var(--dt-color-hover-01-bg) var(--dt-color-hover-01), var(--dt-color-container-default));
+            }
+
+            /* pie-radio reflects its \`checked\` property, so the selected tile needs no JS */
+            .c-radioTile:has(pie-radio[checked]) {
+                border-color: var(--dt-color-interactive-brand);
+                box-shadow: inset 0 0 0 1px var(--dt-color-interactive-brand);
+            }
+
+            .c-radioTile:has(pie-radio:focus-visible) {
+                box-shadow: 0 0 0 2px var(--dt-color-focus-inner), 0 0 0 4px var(--dt-color-focus-outer);
+            }
+
+            /* The group reflects \`disabled\`, so the tiles can follow the group's state */
+            pie-radio-group[disabled] .c-radioTile {
+                cursor: not-allowed;
+                background-color: var(--dt-color-container-default);
+            }
+
+            .c-radioTile-image {
+                display: block;
+                inline-size: 100%;
+                aspect-ratio: 4 / 3;
+                object-fit: cover;
+                border-radius: var(--dt-radius-rounded-b);
+            }
+        </style>
+        <p>Please note, the tiles here are an example of custom markup wrapping each pie-radio. See the
+        <pie-link href="/?path=/docs/components-radio-group--overview">radio group overview</pie-link>
+        for what the group handles and what you are responsible for.</p>
+        <pie-radio-group
+            name="${ifDefined(name)}"
+            .value=${ifDefined(value)}
+            ?isInline=${isInline}
+            ?disabled=${disabled}
+            assistiveText="${ifDefined(assistiveText)}"
+            status=${ifDefined(status)}
+            @change=${onChange}>
+                <pie-form-label slot="label">What device do you use to manage orders?</pie-form-label>
+                ${tileOptions.map((option) => html`
+                    <div class="c-radioTile" @click=${onTileClick}>
+                        <img class="c-radioTile-image" src=${option.image} alt="">
+                        <pie-radio value=${option.value}>${option.label}</pie-radio>
+                    </div>
+                `)}
+        </pie-radio-group>
+    `;
+};
+
+/**
+ * Demonstrates that a radio group also drives radios wrapped in arbitrary consumer markup, not
+ * just direct `pie-radio` children or `pie-list-item`s. The group still owns selection, keyboard
+ * navigation and the disabled state, while the tile is responsible for forwarding its own clicks
+ * to the radio it wraps.
+ */
+export const ImageTiles = createStory<RadioGroupProps>(ImageTileTemplate, defaultArgs)({
+    name: 'device',
+    value: 'sunmi',
+    isInline: true,
+});

--- a/packages/components/pie-radio-group/README.md
+++ b/packages/components/pie-radio-group/README.md
@@ -165,6 +165,8 @@ The selected state can be styled from the radio's reflected `checked` attribute.
 
 The group handles the radios, but the wrapper is yours. You are responsible for wiring up its ARIA, testing the result with screen readers, and handling its clicks and interactive styles.
 
+We recommend keeping the wrapper free of other interactive elements or components. The group manages focus and keyboard navigation across its radios, so nested controls interfere with both that and how each option is announced.
+
 ## Questions and Support
 
 If you work at Just Eat Takeaway.com, please contact us on **#help-designsystem**. Otherwise, please raise an issue on [Github](https://github.com/justeattakeaway/pie/issues).

--- a/packages/components/pie-radio-group/README.md
+++ b/packages/components/pie-radio-group/README.md
@@ -19,6 +19,7 @@
   - [Events](#events)
 - [Forms Usage](#forms-usage)
 - [Usage Examples](#usage-examples)
+  - [Wrapping radio buttons in custom markup](#wrapping-radio-buttons-in-custom-markup)
 - [Questions and Support](#questions-and-support)
 - [Contributing](#contributing)
 
@@ -43,7 +44,7 @@ Ideally, you should install the component using the **`@justeattakeaway/pie-webc
 ### Slots
 | Slot      | Description                                                                                      |
 |-----------|--------------------------------------------------------------------------------------------------|
-| `default` | Either [`pie-radio`](https://webc.pie.design/?path=/docs/components-radio--overview) components, or [`pie-list-item`](https://webc.pie.design/?path=/docs/components-list--overview) components that each slot a `pie-radio` for a list-style layout (see [List items in a radio group](#list-items-in-a-radio-group)). Do not add other HTML. |
+| `default` | Either [`pie-radio`](https://webc.pie.design/?path=/docs/components-radio--overview) components, or [`pie-list-item`](https://webc.pie.design/?path=/docs/components-list--overview) components that each slot a `pie-radio` for a list-style layout (see [List items in a radio group](#list-items-in-a-radio-group)), or your own markup wrapping each `pie-radio` (see [Wrapping radio buttons in custom markup](#wrapping-radio-buttons-in-custom-markup)). |
 | `label`   | To provide a custom label for the radio group. Please use [`pie-form-label`](https://webc.pie.design/?path=/docs/components-form-label--overview). |
 
 ### CSS Variables
@@ -125,6 +126,44 @@ For full usage details and code examples, see the [`pie-list` documentation](htt
 #### SSR and group-disabled
 
 Group-disabled propagation occurs at runtime via Lit context. If you need disabled styles on page load in an SSR environment, set `disabled` directly on each item rather than relying on the group container.
+
+### Wrapping radio buttons in custom markup
+
+The group finds its radios anywhere in its subtree, so each `pie-radio` can be wrapped in your own markup. This lets you build layouts such as image tiles while the group keeps ownership of selection, keyboard navigation and the disabled state.
+
+The selected state can be styled from the radio's reflected `checked` attribute.
+
+```html
+<pie-radio-group name="device" isInline>
+    <pie-form-label slot="label">What device do you use to manage orders?</pie-form-label>
+    <div class="c-deviceTile">
+        <img src="/images/sunmi.jpg" alt="">
+        <pie-radio value="sunmi">Sunmi</pie-radio>
+    </div>
+    <div class="c-deviceTile">
+        <img src="/images/citaq.jpg" alt="">
+        <pie-radio value="citaq">Citaq</pie-radio>
+    </div>
+</pie-radio-group>
+```
+
+```css
+.c-deviceTile {
+    display: flex;
+    flex-direction: column;
+    gap: var(--dt-spacing-b);
+    padding: var(--dt-spacing-b);
+    border: 1px solid var(--dt-color-border-strong);
+    border-radius: var(--dt-radius-rounded-c);
+    cursor: pointer;
+}
+
+.c-deviceTile:has(pie-radio[checked]) {
+    border-color: var(--dt-color-interactive-brand);
+}
+```
+
+The group handles the radios, but the wrapper is yours. You are responsible for wiring up its ARIA, testing the result with screen readers, and handling its clicks and interactive styles.
 
 ## Questions and Support
 


### PR DESCRIPTION
Tiny addition to the radio-group docs to help people understand how to wrap radios in custom markup whilst preserving radio group behaviours.