### PR TITLE
fix(pie-notification): DSW-4291 fix content width limit for dismissible notifications

### DIFF
--- a/.changeset/happy-cat-flops.md
+++ b/.changeset/happy-cat-flops.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-notification": patch
+---
+
+[Fixed] - Corrected content width limit for dismissible notifications

--- a/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
+++ b/apps/pie-storybook/stories/testing/pie-notification.test.stories.ts
@@ -675,3 +675,5 @@ export const SlottedBothActionsStackedCompact = createStory<NotificationProps>(S
     leadingAction: undefined,
     supportingAction: undefined,
 })();
+
+export const DismissibleLongCopy = createNotificationStory({ variant: 'info', isDismissible: true, slot: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet tincidunt est, vitae vulputate turpis.' });

--- a/packages/components/pie-notification/src/notification.scss
+++ b/packages/components/pie-notification/src/notification.scss
@@ -101,7 +101,7 @@
         gap: var(--dt-spacing-c);
 
         &.is-dismissible {
-            max-width: calc(100% - var(--notification-close-btn-offset) - 40px); // 40px is the size of the medium icon button
+            margin-inline-end: calc(var(--notification-close-btn-offset) + 40px); // 40px is the size of the medium icon button
         }
     }
 

--- a/packages/components/pie-notification/test/visual/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/visual/pie-notification.spec.ts
@@ -438,6 +438,7 @@ test('should render dismissible notification with long copy', async ({ page }) =
     const basePage = new BasePage(page, 'notification--dismissible-long-copy');
 
     await basePage.load();
+    await page.setViewportSize({ width: 1275, height: 900 });
 
     await percySnapshot(page, 'PieNotification - Dismissible with long copy', screenWidths);
 });

--- a/packages/components/pie-notification/test/visual/pie-notification.spec.ts
+++ b/packages/components/pie-notification/test/visual/pie-notification.spec.ts
@@ -433,3 +433,11 @@ test.describe('Slotted Action Buttons', () => {
         await percySnapshot(page, 'PieNotification - Slotted Both Actions Stacked Compact - Should Not Stack', screenWidths);
     });
 });
+
+test('should render dismissible notification with long copy', async ({ page }) => {
+    const basePage = new BasePage(page, 'notification--dismissible-long-copy');
+
+    await basePage.load();
+
+    await percySnapshot(page, 'PieNotification - Dismissible with long copy', screenWidths);
+});


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- @justeattakeaway/pie-notification - Fixed content width limit for dismissible notifications on wide screens

Before:
<img width="3120" height="1774" alt="image" src="https://github.com/user-attachments/assets/1f1407d2-5975-43b9-95f2-e3fea9522635" />

After:
<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/b1df8da4-52c4-4900-adcf-0f304296cf63" />

## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [x] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [x] I have added thorough tests where applicable (unit / component / visual).

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have verified that all acceptance criteria for this ticket have been completed.
- [x] If there are visual test updates, I have reviewed them.