### PR TITLE
fix(pie-button): DSW-4330 fix text color for isReponsive buttons

### DIFF
--- a/.changeset/fifty-places-look.md
+++ b/.changeset/fifty-places-look.md
@@ -1,0 +1,5 @@
+---
+"@justeattakeaway/pie-css": patch
+---
+
+[Fixed] - isResponsive doesn't set the correct text color for small to medium buttons

--- a/packages/tools/pie-css/scss/mixins/components/_button.scss
+++ b/packages/tools/pie-css/scss/mixins/components/_button.scss
@@ -282,6 +282,7 @@
         &.#{$prefix}--small-productive {
             @include responsive-wide($prefix) {
                 --int-states-mixin-bg-color: var(--dt-color-interactive-brand);
+                --btn-text-color: var(--dt-color-content-interactive-light-solid);
 
                 @include interactive-states('--dt-color-interactive-brand');
             }

--- a/packages/tools/pie-css/test/css/__snapshots__/css.spec.ts.snap
+++ b/packages/tools/pie-css/test/css/__snapshots__/css.spec.ts.snap
@@ -307,6 +307,7 @@ exports[`components/button.css > should render the expected CSS content 1`] = `
 @media (min-width: 769px) {
   .c-button--primary.c-button--xsmall.c-button--expressive.c-button--responsive, .c-button--primary.c-button--small-productive.c-button--responsive {
     --int-states-mixin-bg-color: var(--dt-color-interactive-brand);
+    --btn-text-color: var(--dt-color-content-interactive-light-solid);
   }
 }
 @media (min-width: 769px) and (hover: hover) {

--- a/packages/tools/pie-css/test/scss/unit/mixins/components/button.spec.ts
+++ b/packages/tools/pie-css/test/scss/unit/mixins/components/button.spec.ts
@@ -402,6 +402,7 @@ describe('mixins.button', () => {
             expect(css).toContain('.c-button--primary.c-button--xsmall,.c-button--primary.c-button--small-productive');
             expect(css).toContain('--int-states-mixin-bg-color:var(--dt-color-interactive-primary)');
             expect(css).toContain('--btn-text-color:var(--dt-color-content-interactive-primary-solid)');
+            expect(css).toContain('@media(min-width:769px){.c-button--primary.c-button--xsmall.c-button--expressive.c-button--responsive,.c-button--primary.c-button--small-productive.c-button--responsive{--int-states-mixin-bg-color:var(--dt-color-interactive-brand);--btn-text-color:var(--dt-color-content-interactive-light-solid);}}');
         });
 
         it('should output primary-alternative variant', () => {


### PR DESCRIPTION
## Describe your changes (can list changeset entries if preferable)

- Fixes an incorrect text color for pie buttons when the `isResponsive `prop is enabled.
- When a pie button is `size="small-productive"` and `isResponsive`, the button switches to the next size up on desktop (it becomes medium). However, the text color is still based on the small-productive size, resulting in the incorrect text color shown below:
<img width="179" height="75" alt="Screenshot 2026-09-11 at 16 43 37" src="https://github.com/user-attachments/assets/0e126845-75d7-4d29-be1a-cc760da2f0aa" />

The button should instead use the same white text color as a regular [medium-sized ](https://webc.pie.design/?path=/story/components-button--primary)button in dark mode:

<img width="179" height="75" alt="Screenshot 2026-09-11 at 16 41 47" src="https://github.com/user-attachments/assets/5cf5f087-9fbe-429b-aab8-e3d77eae9945" />



## Author Checklist (complete before requesting a review, do not delete any)
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests where applicable (unit / component / visual).
- [x] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [x] I have reviewed visual test updates properly before approving.
- [x] If changes will affect consumers of the package, I have created a changeset entry.
- [-] If a changeset file has been created, I have tested these changes in [PIE Aperture](https://github.com/justeattakeaway/pie-aperture/) using the `/test-aperture` command.
- [-] If a component was added or its props were updated, I provided the necessary updates for the Figma Code Connect file

## Not-applicable Checklist items
Please move any Author checklist items that do not apply to this pull request here.

---

## Reviewer checklists (complete before approving)
Mark items as `[-] N/A` if not applicable.

### Reviewer 1
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.

### Reviewer 2
- [-] I have reviewed the `PIE Storybook`/`PIE Docs` PR preview.
- [-] I have verified that all acceptance criteria for this ticket have been completed.
- [-] I have reviewed the Aperture changes (if added)
- [-] If there are visual test updates, I have reviewed them.
